### PR TITLE
Tests for streaming bug fix

### DIFF
--- a/pkg/agent/controller/streaming_test.go
+++ b/pkg/agent/controller/streaming_test.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
+	"github.com/codeready-toolchain/tarsy/ent/timelineevent"
 	"github.com/codeready-toolchain/tarsy/pkg/agent"
+	"github.com/codeready-toolchain/tarsy/pkg/events"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -441,4 +444,131 @@ func TestCollectStreamWithCallback_AllChunkTypes(t *testing.T) {
 	// Callback should fire for thinking (1) + text (2) = 3 times
 	// (Tool calls, code executions, groundings, usage don't trigger callback)
 	assert.Equal(t, []string{ChunkTypeThinking, ChunkTypeText, ChunkTypeText}, callbacks)
+}
+
+// ============================================================================
+// noopEventPublisher — satisfies agent.EventPublisher for streaming-path tests
+// ============================================================================
+
+type noopEventPublisher struct{}
+
+func (noopEventPublisher) PublishTimelineCreated(context.Context, string, events.TimelineCreatedPayload) error {
+	return nil
+}
+func (noopEventPublisher) PublishTimelineCompleted(context.Context, string, events.TimelineCompletedPayload) error {
+	return nil
+}
+func (noopEventPublisher) PublishStreamChunk(context.Context, string, events.StreamChunkPayload) error {
+	return nil
+}
+func (noopEventPublisher) PublishSessionStatus(context.Context, string, events.SessionStatusPayload) error {
+	return nil
+}
+func (noopEventPublisher) PublishStageStatus(context.Context, string, events.StageStatusPayload) error {
+	return nil
+}
+func (noopEventPublisher) PublishChatCreated(context.Context, string, events.ChatCreatedPayload) error {
+	return nil
+}
+func (noopEventPublisher) PublishInteractionCreated(context.Context, string, events.InteractionCreatedPayload) error {
+	return nil
+}
+func (noopEventPublisher) PublishSessionProgress(context.Context, events.SessionProgressPayload) error {
+	return nil
+}
+func (noopEventPublisher) PublishExecutionProgress(context.Context, string, events.ExecutionProgressPayload) error {
+	return nil
+}
+func (noopEventPublisher) PublishExecutionStatus(context.Context, string, events.ExecutionStatusPayload) error {
+	return nil
+}
+
+// delayedErrorLLMClient sends initial chunks immediately, waits for a
+// configurable delay, then sends an error chunk. This lets tests simulate
+// a stream that outlives its parent context deadline.
+type delayedErrorLLMClient struct {
+	initialChunks    []agent.Chunk
+	delayBeforeError time.Duration
+	errorMessage     string
+}
+
+func (m *delayedErrorLLMClient) Generate(_ context.Context, _ *agent.GenerateInput) (<-chan agent.Chunk, error) {
+	ch := make(chan agent.Chunk, len(m.initialChunks)+1)
+
+	// Send initial chunks immediately (buffered — no blocking).
+	for _, c := range m.initialChunks {
+		ch <- c
+	}
+
+	// Send error chunk after delay in a goroutine so the channel stays open
+	// until the delay elapses, letting the caller's context expire first.
+	go func() {
+		time.Sleep(m.delayBeforeError)
+		ch <- &agent.ErrorChunk{Message: m.errorMessage, Code: "timeout", Retryable: false}
+		close(ch)
+	}()
+
+	return ch, nil
+}
+
+func (m *delayedErrorLLMClient) Close() error { return nil }
+
+// ============================================================================
+// callLLMWithStreaming — expired-context cleanup test
+// ============================================================================
+
+// TestCallLLMWithStreaming_ExpiredContextCleanup verifies the context-detachment
+// fix: when the parent context expires and the LLM stream returns an error,
+// streaming timeline events must be marked as failed (not stuck at "streaming").
+//
+// Reproduces the bug fixed in streaming.go where markStreamingEventsFailed
+// used the caller's (expired) context for DB cleanup, causing silent failures.
+func TestCallLLMWithStreaming_ExpiredContextCleanup(t *testing.T) {
+	execCtx := newTestExecCtx(t, nil, nil)
+	execCtx.EventPublisher = noopEventPublisher{}
+
+	// Context expires in 50ms — long enough for the callback to create
+	// timeline events from the buffered chunks, but short enough to be
+	// expired by the time the delayed error chunk arrives.
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	llm := &delayedErrorLLMClient{
+		initialChunks: []agent.Chunk{
+			&agent.ThinkingChunk{Content: "analyzing the problem..."},
+			&agent.TextChunk{Content: "here is my analysis"},
+		},
+		delayBeforeError: 150 * time.Millisecond,
+		errorMessage:     "stream deadline exceeded",
+	}
+
+	eventSeq := 0
+	resp, err := callLLMWithStreaming(ctx, execCtx, llm, &agent.GenerateInput{}, &eventSeq)
+
+	// Stream must return an error.
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "stream deadline exceeded")
+
+	// Parent context must be expired by now (sanity check).
+	require.Error(t, ctx.Err(), "parent context should be expired")
+
+	// Query DB with a fresh context — events must NOT be stuck at "streaming".
+	dbEvents, dbErr := execCtx.Services.Timeline.GetAgentTimeline(
+		context.Background(), execCtx.ExecutionID,
+	)
+	require.NoError(t, dbErr)
+
+	// The callback should have created at least one streaming event
+	// (thinking or text) before the error arrived.
+	require.NotEmpty(t, dbEvents, "expected at least one timeline event to be created")
+
+	for _, evt := range dbEvents {
+		assert.NotEqual(t, timelineevent.StatusStreaming, evt.Status,
+			"event %s (type=%s) should not be stuck at streaming status", evt.ID, evt.EventType)
+		assert.Equal(t, timelineevent.StatusFailed, evt.Status,
+			"event %s (type=%s) should be marked as failed", evt.ID, evt.EventType)
+		assert.Contains(t, evt.Content, "Streaming failed",
+			"event %s content should indicate streaming failure", evt.ID)
+	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for streaming with parent-context expiration to ensure streams that outlive callers are handled.
  * Added a deterministic test that verifies streaming errors lead to a failed event state (not stuck in streaming) and confirms cleanup via fresh validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->