### PR TITLE
Fix runbook loading

### DIFF
--- a/pkg/runbook/github_test.go
+++ b/pkg/runbook/github_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -237,10 +238,11 @@ type testTransport struct {
 }
 
 func (t *testTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	// Redirect api.github.com requests to test server
-	if req.URL.Host == "api.github.com" {
-		req.URL.Scheme = "http"
-		req.URL.Host = t.server.URL[7:] // Strip "http://"
+	// Redirect GitHub API and raw content requests to test server
+	if req.URL.Host == "api.github.com" || req.URL.Host == "raw.githubusercontent.com" {
+		parsed, _ := url.Parse(t.server.URL)
+		req.URL.Scheme = parsed.Scheme
+		req.URL.Host = parsed.Host
 	}
 	return t.delegate.RoundTrip(req)
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved GitHub URL handling to allow users to reference GitHub blob URLs (such as runbook files) when only github.com is included in the allowed domains configuration, without requiring raw.githubusercontent.com to be separately whitelisted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->