### PR TITLE
Introduce the ScoringAgent and introduce it to the AgentFactory.

### DIFF
--- a/pkg/agent/factory.go
+++ b/pkg/agent/factory.go
@@ -32,5 +32,8 @@ func (f *AgentFactory) CreateAgent(execCtx *ExecutionContext) (Agent, error) {
 		return nil, fmt.Errorf("failed to create controller for strategy %q: %w",
 			execCtx.Config.IterationStrategy, err)
 	}
+	if execCtx.Config.IterationStrategy.IsValidForScoring() {
+		return NewScoringAgent(controller), nil
+	}
 	return NewBaseAgent(controller), nil
 }

--- a/pkg/agent/factory_test.go
+++ b/pkg/agent/factory_test.go
@@ -73,4 +73,43 @@ func TestAgentFactory_CreateAgent(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "execution context and config must not be nil")
 	})
+
+	t.Run("scoring strategy produces ScoringAgent", func(t *testing.T) {
+		factory := NewAgentFactory(&mockControllerFactory{})
+		execCtx := &ExecutionContext{
+			Config: &ResolvedAgentConfig{
+				IterationStrategy: config.IterationStrategyScoring,
+			},
+		}
+
+		agent, err := factory.CreateAgent(execCtx)
+		require.NoError(t, err)
+		assert.IsType(t, &ScoringAgent{}, agent)
+	})
+
+	t.Run("scoring native-thinking strategy produces ScoringAgent", func(t *testing.T) {
+		factory := NewAgentFactory(&mockControllerFactory{})
+		execCtx := &ExecutionContext{
+			Config: &ResolvedAgentConfig{
+				IterationStrategy: config.IterationStrategyScoringNativeThinking,
+			},
+		}
+
+		agent, err := factory.CreateAgent(execCtx)
+		require.NoError(t, err)
+		assert.IsType(t, &ScoringAgent{}, agent)
+	})
+
+	t.Run("non-scoring strategy produces BaseAgent", func(t *testing.T) {
+		factory := NewAgentFactory(&mockControllerFactory{})
+		execCtx := &ExecutionContext{
+			Config: &ResolvedAgentConfig{
+				IterationStrategy: config.IterationStrategyLangChain,
+			},
+		}
+
+		agent, err := factory.CreateAgent(execCtx)
+		require.NoError(t, err)
+		assert.IsType(t, &BaseAgent{}, agent)
+	})
 }

--- a/pkg/agent/scoring_agent.go
+++ b/pkg/agent/scoring_agent.go
@@ -1,0 +1,52 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+// ScoringAgent evaluates session quality by delegating to a Controller.
+// Unlike BaseAgent, it does not call UpdateAgentExecutionStatus because
+// the scoring lifecycle is managed externally by ScoringService via the
+// session_scores table.
+type ScoringAgent struct {
+	controller Controller
+}
+
+// NewScoringAgent creates a scoring agent with the given iteration controller.
+// Panics if controller is nil (programming error in the factory).
+func NewScoringAgent(controller Controller) *ScoringAgent {
+	if controller == nil {
+		panic("NewScoringAgent: controller must not be nil")
+	}
+	return &ScoringAgent{controller: controller}
+}
+
+// Execute runs the scoring evaluation by delegating to the controller.
+//
+// Error handling follows the same contract as BaseAgent.Execute:
+//   - Infrastructure failures return (nil, error)
+//   - Controller failures return (*ExecutionResult, nil) with result.Error set
+func (a *ScoringAgent) Execute(ctx context.Context, execCtx *ExecutionContext, prevStageContext string) (*ExecutionResult, error) {
+	result, err := a.controller.Run(ctx, execCtx, prevStageContext)
+
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			return &ExecutionResult{Status: ExecutionStatusTimedOut, Error: err}, nil
+		}
+		if errors.Is(err, context.Canceled) {
+			return &ExecutionResult{Status: ExecutionStatusCancelled, Error: err}, nil
+		}
+		return &ExecutionResult{Status: ExecutionStatusFailed, Error: err}, nil
+	}
+
+	if result == nil {
+		return &ExecutionResult{
+			Status: ExecutionStatusFailed,
+			Error:  fmt.Errorf("controller returned nil result"),
+		}, nil
+	}
+
+	return result, nil
+}

--- a/pkg/agent/scoring_agent.go
+++ b/pkg/agent/scoring_agent.go
@@ -25,9 +25,8 @@ func NewScoringAgent(controller Controller) *ScoringAgent {
 
 // Execute runs the scoring evaluation by delegating to the controller.
 //
-// Error handling follows the same contract as BaseAgent.Execute:
-//   - Infrastructure failures return (nil, error)
-//   - Controller failures return (*ExecutionResult, nil) with result.Error set
+// All outcomes are returned as (*ExecutionResult, nil); no path returns (nil, error).
+// Errors from the controller are mapped to ExecutionResult.Status values directly.
 func (a *ScoringAgent) Execute(ctx context.Context, execCtx *ExecutionContext, prevStageContext string) (*ExecutionResult, error) {
 	result, err := a.controller.Run(ctx, execCtx, prevStageContext)
 

--- a/pkg/agent/scoring_agent_test.go
+++ b/pkg/agent/scoring_agent_test.go
@@ -1,0 +1,100 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockedController lets tests control the result and error returned by Run.
+type mockedController struct {
+	result *ExecutionResult
+	err    error
+}
+
+func (c *mockedController) Run(_ context.Context, _ *ExecutionContext, _ string) (*ExecutionResult, error) {
+	return c.result, c.err
+}
+
+func TestScoringAgent_Execute(t *testing.T) {
+	t.Run("timeout mapping", func(t *testing.T) {
+		agent := NewScoringAgent(&mockedController{
+			err: context.DeadlineExceeded,
+		})
+
+		result, err := agent.Execute(context.Background(), &ExecutionContext{}, "")
+		require.NoError(t, err)
+		assert.Equal(t, ExecutionStatusTimedOut, result.Status)
+		assert.ErrorIs(t, result.Error, context.DeadlineExceeded)
+	})
+
+	t.Run("cancellation mapping", func(t *testing.T) {
+		agent := NewScoringAgent(&mockedController{
+			err: context.Canceled,
+		})
+
+		result, err := agent.Execute(context.Background(), &ExecutionContext{}, "")
+		require.NoError(t, err)
+		assert.Equal(t, ExecutionStatusCancelled, result.Status)
+		assert.ErrorIs(t, result.Error, context.Canceled)
+	})
+
+	t.Run("generic error mapping", func(t *testing.T) {
+		agent := NewScoringAgent(&mockedController{
+			err: errors.New("llm call failed"),
+		})
+
+		result, err := agent.Execute(context.Background(), &ExecutionContext{}, "")
+		require.NoError(t, err)
+		assert.Equal(t, ExecutionStatusFailed, result.Status)
+		assert.Contains(t, result.Error.Error(), "llm call failed")
+	})
+
+	t.Run("nil result from controller", func(t *testing.T) {
+		agent := NewScoringAgent(&mockedController{
+			result: nil,
+			err:    nil,
+		})
+
+		result, err := agent.Execute(context.Background(), &ExecutionContext{}, "")
+		require.NoError(t, err)
+		assert.Equal(t, ExecutionStatusFailed, result.Status)
+		assert.Contains(t, result.Error.Error(), "controller returned nil result")
+	})
+
+	t.Run("successful execution", func(t *testing.T) {
+		expected := &ExecutionResult{
+			Status:        ExecutionStatusCompleted,
+			FinalAnalysis: "score: 85/100",
+		}
+		agent := NewScoringAgent(&mockedController{
+			result: expected,
+		})
+
+		result, err := agent.Execute(context.Background(), &ExecutionContext{}, "")
+		require.NoError(t, err)
+		assert.Equal(t, expected, result)
+	})
+
+	t.Run("does not access stage service", func(t *testing.T) {
+		// ExecutionContext with nil Services proves ScoringAgent never calls
+		// UpdateAgentExecutionStatus — a nil-pointer dereference would panic.
+		agent := NewScoringAgent(&mockedController{
+			result: &ExecutionResult{Status: ExecutionStatusCompleted},
+		})
+
+		execCtx := &ExecutionContext{Services: nil}
+		result, err := agent.Execute(context.Background(), execCtx, "")
+		require.NoError(t, err)
+		assert.Equal(t, ExecutionStatusCompleted, result.Status)
+	})
+}
+
+func TestNewScoringAgent_NilControllerPanics(t *testing.T) {
+	assert.PanicsWithValue(t, "NewScoringAgent: controller must not be nil", func() {
+		NewScoringAgent(nil)
+	})
+}


### PR DESCRIPTION
The scoring controller is not yet implemented so this effectively doesn't work yet. The agent is just hooked into the agent factory based on the chosen iteration strategy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic selection of a scoring-capable agent when an iteration strategy supports scoring.
  * Scoring-based execution now maps timeouts, cancellations, and failures to clearer execution outcomes.

* **Tests**
  * Expanded test coverage for agent selection and scoring execution across strategies and error scenarios, including nil-result and constructor validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->