### PR TITLE
Button to expand all tool calls in dashboard

### DIFF
--- a/web/dashboard/src/components/session/ConversationTimeline.tsx
+++ b/web/dashboard/src/components/session/ConversationTimeline.tsx
@@ -104,6 +104,7 @@ export default function ConversationTimeline({
 
   // --- Auto-collapse system ---
   const [expandAllReasoning, setExpandAllReasoning] = useState(false);
+  const [expandAllToolCalls, setExpandAllToolCalls] = useState(false);
   // Manual overrides: items the user has explicitly toggled
   const [manualOverrides, setManualOverrides] = useState<Set<string>>(new Set());
 
@@ -283,6 +284,14 @@ export default function ConversationTimeline({
             >
               {expandAllReasoning ? 'Collapse All Reasoning' : 'Expand All Reasoning'}
             </Button>
+            <Button
+              variant="outlined"
+              size="small"
+              startIcon={expandAllToolCalls ? <ExpandLess /> : <ExpandMore />}
+              onClick={() => setExpandAllToolCalls((v) => !v)}
+            >
+              {expandAllToolCalls ? 'Collapse All Tools' : 'Expand All Tools'}
+            </Button>
             <CopyButton
               text={plainText}
               variant="button"
@@ -419,6 +428,7 @@ export default function ConversationTimeline({
                   shouldAutoCollapse={shouldAutoCollapse}
                   onToggleItemExpansion={toggleItemExpansion}
                   expandAllReasoning={expandAllReasoning}
+                  expandAllToolCalls={expandAllToolCalls}
                   isItemCollapsible={isItemCollapsible}
                   agentProgressStatuses={agentProgressStatuses}
                   executionStatuses={executionStatuses}

--- a/web/dashboard/src/components/timeline/StageContent.tsx
+++ b/web/dashboard/src/components/timeline/StageContent.tsx
@@ -31,6 +31,7 @@ interface StageContentProps {
   shouldAutoCollapse?: (item: FlowItem) => boolean;
   onToggleItemExpansion?: (item: FlowItem) => void;
   expandAllReasoning?: boolean;
+  expandAllToolCalls?: boolean;
   isItemCollapsible?: (item: FlowItem) => boolean;
   // Per-agent progress
   agentProgressStatuses?: Map<string, string>;
@@ -199,6 +200,7 @@ const StageContent: React.FC<StageContentProps> = ({
   shouldAutoCollapse,
   onToggleItemExpansion,
   expandAllReasoning = false,
+  expandAllToolCalls = false,
   isItemCollapsible,
   agentProgressStatuses = new Map(),
   executionStatuses,
@@ -371,6 +373,7 @@ const StageContent: React.FC<StageContentProps> = ({
             isAutoCollapsed={shouldAutoCollapse ? shouldAutoCollapse(item) : false}
             onToggleAutoCollapse={onToggleItemExpansion ? () => onToggleItemExpansion(item) : undefined}
             expandAll={expandAllReasoning}
+            expandAllToolCalls={expandAllToolCalls}
             isCollapsible={isItemCollapsible ? isItemCollapsible(item) : false}
           />
         ))}

--- a/web/dashboard/src/components/timeline/TimelineItem.tsx
+++ b/web/dashboard/src/components/timeline/TimelineItem.tsx
@@ -13,6 +13,7 @@ interface TimelineItemProps {
   isAutoCollapsed?: boolean;
   onToggleAutoCollapse?: () => void;
   expandAll?: boolean;
+  expandAllToolCalls?: boolean;
   isCollapsible?: boolean;
 }
 
@@ -25,6 +26,7 @@ function TimelineItem({
   isAutoCollapsed = false,
   onToggleAutoCollapse,
   expandAll = false,
+  expandAllToolCalls = false,
   isCollapsible = false,
 }: TimelineItemProps) {
   // Hide response/executive_summary items with empty content. Defense-in-depth
@@ -69,7 +71,7 @@ function TimelineItem({
       );
 
     case FLOW_ITEM.TOOL_CALL:
-      return <ToolCallItem item={item} />;
+      return <ToolCallItem item={item} expandAll={expandAllToolCalls} />;
 
     case FLOW_ITEM.TOOL_SUMMARY:
       return (

--- a/web/dashboard/src/components/timeline/ToolCallItem.tsx
+++ b/web/dashboard/src/components/timeline/ToolCallItem.tsx
@@ -9,6 +9,7 @@ import { EXECUTION_STATUS } from '../../constants/sessionStatus';
 
 interface ToolCallItemProps {
   item: FlowItem;
+  expandAll?: boolean;
 }
 
 /**
@@ -57,8 +58,9 @@ const SimpleArgumentsList = ({ args }: { args: Record<string, unknown> }) => (
  * ToolCallItem - renders llm_tool_call timeline events.
  * Expandable box showing tool name, arguments preview, duration, and result.
  */
-function ToolCallItem({ item }: ToolCallItemProps) {
+function ToolCallItem({ item, expandAll = false }: ToolCallItemProps) {
   const [expanded, setExpanded] = useState(false);
+  const isExpanded = expandAll || expanded;
 
   // Extract data from FlowItem metadata
   const toolName = (item.metadata?.tool_name as string) || 'unknown';
@@ -119,7 +121,7 @@ function ToolCallItem({ item }: ToolCallItemProps) {
           cursor: 'pointer', borderRadius: 1.5, transition: 'background-color 0.2s ease',
           '&:hover': { bgcolor: alpha(theme.palette[accentKey].main, 0.2) }
         })}
-        onClick={() => setExpanded(!expanded)}
+        onClick={() => setExpanded(!isExpanded)}
       >
         <StatusIcon sx={(theme) => ({ fontSize: 18, color: theme.palette[accentKey].main })} />
         <Typography variant="body2" sx={(theme) => ({ fontFamily: 'monospace', fontWeight: 600, fontSize: '0.9rem', color: theme.palette[accentKey].main })}>
@@ -134,11 +136,11 @@ function ToolCallItem({ item }: ToolCallItemProps) {
           </Typography>
         )}
         <IconButton size="small" sx={{ p: 0.25 }}>
-          {expanded ? <ExpandLess fontSize="small" /> : <ExpandMore fontSize="small" />}
+          {isExpanded ? <ExpandLess fontSize="small" /> : <ExpandMore fontSize="small" />}
         </IconButton>
       </Box>
 
-      <Collapse in={expanded}>
+      <Collapse in={isExpanded}>
         <Box sx={{ px: 1.5, pb: 1.5, pt: 0.5, borderTop: 1, borderColor: 'divider' }}>
           <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1 }}>
             Server: {serverName}

--- a/web/dashboard/src/components/timeline/ToolCallItem.tsx
+++ b/web/dashboard/src/components/timeline/ToolCallItem.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Box, Typography, Collapse, IconButton, alpha } from '@mui/material';
 import { ExpandMore, ExpandLess, CheckCircle, Error as ErrorIcon, InfoOutlined } from '@mui/icons-material';
 import JsonDisplay from '../shared/JsonDisplay';
@@ -60,6 +60,9 @@ const SimpleArgumentsList = ({ args }: { args: Record<string, unknown> }) => (
  */
 function ToolCallItem({ item, expandAll = false }: ToolCallItemProps) {
   const [expanded, setExpanded] = useState(false);
+  useEffect(() => {
+    setExpanded(expandAll);
+  }, [expandAll]);
   const isExpanded = expandAll || expanded;
 
   // Extract data from FlowItem metadata
@@ -121,7 +124,10 @@ function ToolCallItem({ item, expandAll = false }: ToolCallItemProps) {
           cursor: 'pointer', borderRadius: 1.5, transition: 'background-color 0.2s ease',
           '&:hover': { bgcolor: alpha(theme.palette[accentKey].main, 0.2) }
         })}
-        onClick={() => setExpanded(!isExpanded)}
+        onClick={() => {
+          if (expandAll) return;
+          setExpanded((prev) => !prev);
+        }}
       >
         <StatusIcon sx={(theme) => ({ fontSize: 18, color: theme.palette[accentKey].main })} />
         <Typography variant="body2" sx={(theme) => ({ fontFamily: 'monospace', fontWeight: 600, fontSize: '0.9rem', color: theme.palette[accentKey].main })}>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an expand/collapse-all tool calls control on the session timeline to toggle all tool-call sections at once, matching the existing reasoning control.
  * Timeline items now respect the global expand/collapse setting while still allowing individual manual toggles; toggling the global reasoning control does not affect the tool-call control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->