### PR TITLE
Add lightweight GET /api/v1/sessions/:id/status endpoint for session status check

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ TARSy uses a hybrid Go + Python architecture where the Go orchestrator handles a
 - `GET /api/v1/sessions/filter-options` -- Available filter values
 - `GET /api/v1/sessions/:id` -- Session detail with chronological timeline
 - `GET /api/v1/sessions/:id/summary` -- Final analysis and executive summary
+- `GET /api/v1/sessions/:id/status` -- Lightweight polling status (id, status, analysis, error)
 - `POST /api/v1/sessions/:id/cancel` -- Cancel an active or paused session
 
 ### Chat

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ TARSy uses a hybrid Go + Python architecture where the Go orchestrator handles a
 - `GET /api/v1/sessions/filter-options` -- Available filter values
 - `GET /api/v1/sessions/:id` -- Session detail with chronological timeline
 - `GET /api/v1/sessions/:id/summary` -- Final analysis and executive summary
-- `GET /api/v1/sessions/:id/status` -- Lightweight polling status (id, status, analysis, error)
+- `GET /api/v1/sessions/:id/status` -- Lightweight polling status (id, status, final_analysis, executive_summary, error_message)
 - `POST /api/v1/sessions/:id/cancel` -- Cancel an active or paused session
 
 ### Chat

--- a/docs/functional-areas-design.md
+++ b/docs/functional-areas-design.md
@@ -855,6 +855,7 @@ AlertSession (session metadata, status, alert data)
 | GET | `/api/v1/sessions/filter-options` | Distinct alert types and chain IDs |
 | GET | `/api/v1/sessions/:id` | Session details |
 | GET | `/api/v1/sessions/:id/summary` | Final analysis + executive summary |
+| GET | `/api/v1/sessions/:id/status` | Lightweight polling status (id, status, analysis, error) |
 | GET | `/api/v1/sessions/:id/timeline` | Timeline events ordered by sequence |
 | POST | `/api/v1/sessions/:id/cancel` | Cancel running session or chat |
 | GET | `/health` | Health check (DB, worker pool) |

--- a/docs/functional-areas-design.md
+++ b/docs/functional-areas-design.md
@@ -855,7 +855,7 @@ AlertSession (session metadata, status, alert data)
 | GET | `/api/v1/sessions/filter-options` | Distinct alert types and chain IDs |
 | GET | `/api/v1/sessions/:id` | Session details |
 | GET | `/api/v1/sessions/:id/summary` | Final analysis + executive summary |
-| GET | `/api/v1/sessions/:id/status` | Lightweight polling status (id, status, analysis, error) |
+| GET | `/api/v1/sessions/:id/status` | Lightweight polling status (id, status, final_analysis, executive_summary, error_message) |
 | GET | `/api/v1/sessions/:id/timeline` | Timeline events ordered by sequence |
 | POST | `/api/v1/sessions/:id/cancel` | Cancel running session or chat |
 | GET | `/health` | Health check (DB, worker pool) |

--- a/pkg/api/handler_session.go
+++ b/pkg/api/handler_session.go
@@ -136,6 +136,21 @@ func (s *Server) sessionSummaryHandler(c *echo.Context) error {
 	return c.JSON(http.StatusOK, summary)
 }
 
+// sessionStatusHandler handles GET /api/v1/sessions/:id/status.
+func (s *Server) sessionStatusHandler(c *echo.Context) error {
+	sessionID := c.Param("id")
+	if sessionID == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "session id is required")
+	}
+
+	status, err := s.sessionService.GetSessionStatus(c.Request().Context(), sessionID)
+	if err != nil {
+		return mapServiceError(err)
+	}
+
+	return c.JSON(http.StatusOK, status)
+}
+
 // cancelSessionHandler handles POST /api/v1/sessions/:id/cancel.
 func (s *Server) cancelSessionHandler(c *echo.Context) error {
 	sessionID := c.Param("id")

--- a/pkg/api/handler_session_test.go
+++ b/pkg/api/handler_session_test.go
@@ -92,3 +92,22 @@ func TestListSessionsHandler_Validation(t *testing.T) {
 		}
 	})
 }
+
+func TestSessionStatusHandler_Validation(t *testing.T) {
+	s := &Server{}
+
+	t.Run("missing session id returns 400", func(t *testing.T) {
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/sessions//status", nil)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+
+		err := s.sessionStatusHandler(c)
+		if assert.Error(t, err) {
+			he, ok := err.(*echo.HTTPError)
+			if assert.True(t, ok, "expected echo.HTTPError") {
+				assert.Equal(t, http.StatusBadRequest, he.Code)
+			}
+		}
+	})
+}

--- a/pkg/api/handler_session_test.go
+++ b/pkg/api/handler_session_test.go
@@ -107,6 +107,7 @@ func TestSessionStatusHandler_Validation(t *testing.T) {
 			he, ok := err.(*echo.HTTPError)
 			if assert.True(t, ok, "expected echo.HTTPError") {
 				assert.Equal(t, http.StatusBadRequest, he.Code)
+				assert.Contains(t, he.Message, "session id")
 			}
 		}
 	})

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -237,6 +237,7 @@ func (s *Server) setupRoutes() {
 	// Session detail and actions.
 	v1.GET("/sessions/:id", s.getSessionHandler)
 	v1.GET("/sessions/:id/summary", s.sessionSummaryHandler)
+	v1.GET("/sessions/:id/status", s.sessionStatusHandler)
 	v1.POST("/sessions/:id/cancel", s.cancelSessionHandler)
 	v1.POST("/sessions/:id/chat/messages", s.sendChatMessageHandler)
 	v1.GET("/sessions/:id/timeline", s.getTimelineHandler)

--- a/pkg/models/session.go
+++ b/pkg/models/session.go
@@ -221,6 +221,15 @@ type SessionSummaryResponse struct {
 	ChainStatistics   ChainStatistics `json:"chain_statistics"`
 }
 
+// SessionStatusResponse is returned by GET /api/v1/sessions/:id/status.
+type SessionStatusResponse struct {
+	ID               string  `json:"id"`
+	Status           string  `json:"status"`
+	FinalAnalysis    *string `json:"final_analysis"`
+	ExecutiveSummary *string `json:"executive_summary"`
+	ErrorMessage     *string `json:"error_message"`
+}
+
 // ChainStatistics holds stage counts for the session summary.
 type ChainStatistics struct {
 	TotalStages       int  `json:"total_stages"`

--- a/pkg/services/session_service.go
+++ b/pkg/services/session_service.go
@@ -422,7 +422,7 @@ func (s *SessionService) SearchSessions(ctx context.Context, query string, limit
 // GetSessionDetail returns an enriched session detail DTO with computed fields.
 func (s *SessionService) GetSessionDetail(ctx context.Context, sessionID string) (*models.SessionDetailResponse, error) {
 	session, err := s.client.AlertSession.Query().
-		Where(alertsession.IDEQ(sessionID)).
+		Where(alertsession.IDEQ(sessionID), alertsession.DeletedAtIsNil()).
 		WithStages(func(q *ent.StageQuery) {
 			q.Order(ent.Asc(stage.FieldStageIndex))
 			q.WithAgentExecutions(func(eq *ent.AgentExecutionQuery) {
@@ -589,9 +589,8 @@ func (s *SessionService) GetSessionDetail(ctx context.Context, sessionID string)
 
 // GetSessionSummary returns lightweight statistics for a session.
 func (s *SessionService) GetSessionSummary(ctx context.Context, sessionID string) (*models.SessionSummaryResponse, error) {
-	// Verify session exists.
 	session, err := s.client.AlertSession.Query().
-		Where(alertsession.IDEQ(sessionID)).
+		Where(alertsession.IDEQ(sessionID), alertsession.DeletedAtIsNil()).
 		WithStages().
 		Only(ctx)
 	if err != nil {

--- a/pkg/services/session_service_test.go
+++ b/pkg/services/session_service_test.go
@@ -947,6 +947,20 @@ func TestSessionService_GetSessionDetail(t *testing.T) {
 		_, err := service.GetSessionDetail(ctx, "nonexistent-id")
 		assert.ErrorIs(t, err, ErrNotFound)
 	})
+
+	t.Run("excludes soft-deleted session", func(t *testing.T) {
+		sessionID := seedDashboardSession(t, client.Client,
+			"soft-deleted detail", "pod-crash", "k8s-analysis",
+			10, 5, 15, 0)
+
+		err := client.AlertSession.UpdateOneID(sessionID).
+			SetDeletedAt(time.Now()).
+			Exec(ctx)
+		require.NoError(t, err)
+
+		_, err = service.GetSessionDetail(ctx, sessionID)
+		assert.ErrorIs(t, err, ErrNotFound)
+	})
 }
 
 func TestSessionService_GetSessionSummary(t *testing.T) {
@@ -979,6 +993,20 @@ func TestSessionService_GetSessionSummary(t *testing.T) {
 
 	t.Run("returns ErrNotFound for nonexistent session", func(t *testing.T) {
 		_, err := service.GetSessionSummary(ctx, "nonexistent-id")
+		assert.ErrorIs(t, err, ErrNotFound)
+	})
+
+	t.Run("excludes soft-deleted session", func(t *testing.T) {
+		sessionID := seedDashboardSession(t, client.Client,
+			"soft-deleted summary", "pod-crash", "k8s-analysis",
+			10, 5, 15, 0)
+
+		err := client.AlertSession.UpdateOneID(sessionID).
+			SetDeletedAt(time.Now()).
+			Exec(ctx)
+		require.NoError(t, err)
+
+		_, err = service.GetSessionSummary(ctx, sessionID)
 		assert.ErrorIs(t, err, ErrNotFound)
 	})
 }
@@ -1184,6 +1212,29 @@ func TestSessionService_GetSessionStatus(t *testing.T) {
 	client := testdb.NewTestClient(t)
 	service := setupTestSessionService(t, client.Client)
 	ctx := context.Background()
+
+	t.Run("returns status for in-progress session with nil optional fields", func(t *testing.T) {
+		req := models.CreateSessionRequest{
+			SessionID: uuid.New().String(),
+			AlertData: "alert under investigation",
+			AgentType: "kubernetes",
+			ChainID:   "k8s-analysis",
+		}
+		session, err := service.CreateSession(ctx, req)
+		require.NoError(t, err)
+
+		err = service.UpdateSessionStatus(ctx, session.ID, alertsession.StatusInProgress)
+		require.NoError(t, err)
+
+		status, err := service.GetSessionStatus(ctx, session.ID)
+		require.NoError(t, err)
+
+		assert.Equal(t, session.ID, status.ID)
+		assert.Equal(t, "in_progress", status.Status)
+		assert.Nil(t, status.FinalAnalysis)
+		assert.Nil(t, status.ExecutiveSummary)
+		assert.Nil(t, status.ErrorMessage)
+	})
 
 	t.Run("returns status for completed session", func(t *testing.T) {
 		sessionID := seedDashboardSession(t, client.Client,

--- a/test/e2e/dashboard_test.go
+++ b/test/e2e/dashboard_test.go
@@ -400,6 +400,24 @@ func TestDashboardEndpoints(t *testing.T) {
 		assert.NotNil(t, resp)
 	})
 
+	// ── Session Status (lightweight polling endpoint) ──
+	t.Run("SessionStatus", func(t *testing.T) {
+		status := app.GetSessionStatus(t, ids[0])
+		expA := expectedByID[ids[0]]
+
+		assert.Equal(t, ids[0], status["id"])
+		assert.Equal(t, "completed", status["status"])
+		assert.Equal(t, expA.investText, status["final_analysis"])
+		assert.Equal(t, expA.summaryText, status["executive_summary"])
+		assert.Nil(t, status["error_message"])
+	})
+
+	// ── Session Status 404 ──
+	t.Run("SessionStatus/NotFound", func(t *testing.T) {
+		resp := app.getJSON(t, "/api/v1/sessions/nonexistent-id/status", 404)
+		assert.NotNil(t, resp)
+	})
+
 	// ── Filter Options (reflect actual DB data) ──
 	t.Run("FilterOptions", func(t *testing.T) {
 		options := app.GetFilterOptions(t)

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -152,6 +152,12 @@ func (app *TestApp) GetSessionSummary(t *testing.T, sessionID string) map[string
 	return app.getJSON(t, "/api/v1/sessions/"+sessionID+"/summary", http.StatusOK)
 }
 
+// GetSessionStatus calls GET /api/v1/sessions/:id/status.
+func (app *TestApp) GetSessionStatus(t *testing.T, sessionID string) map[string]interface{} {
+	t.Helper()
+	return app.getJSON(t, "/api/v1/sessions/"+sessionID+"/status", http.StatusOK)
+}
+
 // GetFilterOptions calls GET /api/v1/sessions/filter-options.
 func (app *TestApp) GetFilterOptions(t *testing.T) map[string]interface{} {
 	t.Helper()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a lightweight polling endpoint to retrieve session status, final analysis, executive summary, and error details.

* **Documentation**
  * Added API docs for the new session status endpoint.

* **Tests**
  * Added unit and end-to-end tests covering validation, success, not-found, and status scenarios.

* **Bug Fixes**
  * Ensure soft-deleted sessions are excluded from detail/summary/status (returned as not found).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->