### PR TITLE
Rename controllers

### DIFF
--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -205,7 +205,7 @@ sequenceDiagram
         A->>MCP: List available tools
         MCP-->>A: Tool definitions
 
-        loop Function Calling iterations
+        loop IteratingController iterations
             A->>LLM: Generate (messages + tools) via gRPC
             LLM-->>A: Stream response chunks
             A-->>WS: Stream thinking + response to dashboard

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -120,8 +120,8 @@ Agents are specialized AI-powered components that analyze alerts using domain ex
 
 **Two controller types** (text-based ReAct parsing was completely removed):
 
-- **FunctionCallingController**: Structured function calling with tool definitions bound to the LLM. Works with any `LLMBackend` — `google-native` (Gemini native SDK) or `langchain` (multi-provider)
-- **SynthesisController**: Tool-less single LLM call for synthesizing multi-agent investigation results
+- **IteratingController**: Multi-turn tool-calling loop with tool definitions bound to the LLM. Works with any `LLMBackend` — `google-native` (Gemini native SDK) or `langchain` (multi-provider)
+- **SingleShotController**: Tool-less single LLM call, parameterized via `SingleShotConfig`. Used for synthesis (and future scoring)
 
 **Forced Conclusion**: When agents reach their maximum iteration limit, the system forces a conclusion -- one extra LLM call without tools, asking the agent to provide the best analysis with available data. There is no pause/resume mechanism.
 

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -229,9 +229,9 @@ sequenceDiagram
     D->>D: Engineers review analysis
 ```
 
-### FunctionCalling Iteration Detail
+### IteratingController Iteration Detail
 
-For agents using the FunctionCalling controller, the investigation follows a structured function calling pattern:
+For agents using the IteratingController, the investigation follows a structured function calling pattern:
 
 ```mermaid
 sequenceDiagram
@@ -281,7 +281,7 @@ When an agent reaches its configured `max_iterations` limit, the system forces a
 
 After a session reaches a terminal state (completed, failed, or timed out), engineers can start a chat conversation to ask follow-up questions. The chat agent receives the full investigation timeline as context and has access to the same MCP tools. Responses stream in real-time and appear inline in the conversation timeline.
 
-Chat is a **prompt concern, not a controller concern** -- the same FunctionCalling and Synthesis controllers handle both investigation and chat. The `ChatContext` on the execution context triggers chat-specific prompting.
+Chat is a **prompt concern, not a controller concern** -- the same IteratingController and SingleShotController handle both investigation and chat. The `ChatContext` on the execution context triggers chat-specific prompting.
 
 ## Authentication & Access Control
 

--- a/docs/functional-areas-design.md
+++ b/docs/functional-areas-design.md
@@ -906,7 +906,7 @@ graph TB
 - `GetOrCreateChat()` -- one Chat per session
 - Chat metadata, context snapshot, pod tracking
 
-**Design principle**: Chat is a prompt concern, not a controller concern. The same FunctionCalling and Synthesis controllers handle both investigation and chat -- the `ChatContext` on `ExecutionContext` triggers chat-specific prompting. Same iteration limits, same `forceConclusion()` at max iterations.
+**Design principle**: Chat is a prompt concern, not a controller concern. The same Iterating and SingleShot controllers handle both investigation and chat -- the `ChatContext` on `ExecutionContext` triggers chat-specific prompting. Same iteration limits, same `forceConclusion()` at max iterations.
 
 #### Lifecycle Constraints
 

--- a/docs/functional-areas-design.md
+++ b/docs/functional-areas-design.md
@@ -368,8 +368,8 @@ graph TB
     end
 
     subgraph controllers [Controllers]
-        FC["FunctionCallingController<br/>(iterating - multi-turn with tools)"]
-        SC["SynthesisController<br/>(single-shot - one LLM call, no tools)"]
+        FC["IteratingController<br/>(multi-turn with tools)"]
+        SC["SingleShotController<br/>(one LLM call, no tools)"]
     end
 
     subgraph backends [LLM Backends]
@@ -414,8 +414,8 @@ type Controller interface {
 
 | AgentType | Controller | Pattern | Use Case |
 |-----------|-----------|---------|----------|
-| `""` (default) | FunctionCallingController | Iterating (multi-turn loop with tools) | Investigation agents with tool access |
-| `"synthesis"` | SynthesisController | Single-shot (one LLM call, no tools) | Synthesis of parallel results |
+| `""` (default) | IteratingController | Iterating (multi-turn loop with tools) | Investigation agents with tool access |
+| `"synthesis"` | SingleShotController | Single-shot (one LLM call, no tools) | Synthesis of parallel results |
 | `"scoring"` | *(WIP — not yet implemented)* | Single-shot | Session quality evaluation |
 
 **LLMBackend determines the Python SDK path** (orthogonal to controller):
@@ -425,7 +425,7 @@ type Controller interface {
 | `"google-native"` | GoogleNativeProvider | Gemini native SDK with thinking + function calling |
 | `"langchain"` | LangChainProvider | Multi-provider (OpenAI, Anthropic, xAI, etc.) |
 
-#### FunctionCallingController — iterating (`pkg/agent/controller/function_calling.go`)
+#### IteratingController — iterating (`pkg/agent/controller/iterating.go`)
 
 Multi-turn iterating controller that loops: LLM call → tool execution → LLM call, until the agent produces a final answer or hits the iteration limit. Works with any `LLMBackend`:
 
@@ -437,9 +437,9 @@ Multi-turn iterating controller that loops: LLM call → tool execution → LLM 
    - If **no tool calls**: this is the final answer -- create `final_analysis` event, return
 4. If max iterations reached: `forceConclusion()` -- call LLM WITHOUT tools to force text-only response
 
-#### SynthesisController — single-shot (`pkg/agent/controller/synthesis.go`)
+#### SingleShotController — single-shot (`pkg/agent/controller/single_shot.go`)
 
-Single-shot controller: one LLM call without tools. Used for synthesizing multi-agent investigation results. Receives full investigation history via timeline events (thinking, tool calls, results, analyses). Future single-shot agent types (e.g., scoring) will reuse this pattern.
+Parameterized single-shot controller: one LLM call without tools, configured via `SingleShotConfig`. Used for synthesizing multi-agent investigation results (and future scoring). Receives full investigation history via timeline events (thinking, tool calls, results, analyses).
 
 #### Instruction Composition
 
@@ -465,8 +465,8 @@ At max iterations, `forceConclusion()` makes one extra LLM call without tools, a
 **Key Implementation Files**:
 - `pkg/agent/agent.go` -- Agent interface
 - `pkg/agent/base_agent.go` -- BaseAgent with Controller delegation
-- `pkg/agent/controller/function_calling.go` -- FunctionCallingController
-- `pkg/agent/controller/synthesis.go` -- SynthesisController
+- `pkg/agent/controller/iterating.go` -- IteratingController
+- `pkg/agent/controller/single_shot.go` -- SingleShotController
 - `pkg/agent/controller/tool_execution.go` -- Shared tool execution logic
 - `pkg/agent/controller/summarize.go` -- Tool result summarization
 - `pkg/agent/controller/timeline.go` -- Timeline event helpers
@@ -488,7 +488,7 @@ MCP (Model Context Protocol) servers provide agents with external tools and syst
 ```mermaid
 graph TB
     subgraph agentLayer [Agent Layer]
-        Controller[FunctionCallingController]
+        Controller[IteratingController]
     end
 
     subgraph mcpLayer [MCP Integration]

--- a/pkg/agent/controller/factory.go
+++ b/pkg/agent/controller/factory.go
@@ -21,9 +21,9 @@ func NewFactory() *Factory {
 func (f *Factory) CreateController(agentType config.AgentType, execCtx *agent.ExecutionContext) (agent.Controller, error) {
 	switch agentType {
 	case config.AgentTypeDefault:
-		return NewFunctionCallingController(), nil
+		return NewIteratingController(), nil
 	case config.AgentTypeSynthesis:
-		return NewSynthesisController(), nil
+		return NewSynthesisController(execCtx.PromptBuilder), nil
 	default:
 		return nil, fmt.Errorf("unknown agent type: %q", agentType)
 	}

--- a/pkg/agent/controller/factory_test.go
+++ b/pkg/agent/controller/factory_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/codeready-toolchain/tarsy/pkg/agent"
+	"github.com/codeready-toolchain/tarsy/pkg/agent/prompt"
 	"github.com/codeready-toolchain/tarsy/pkg/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -28,22 +29,30 @@ func TestFactory_CreateController(t *testing.T) {
 		assert.Contains(t, err.Error(), "invalid")
 	})
 
-	t.Run("default agent type returns FunctionCallingController", func(t *testing.T) {
+	t.Run("default agent type returns IteratingController", func(t *testing.T) {
 		controller, err := factory.CreateController(config.AgentTypeDefault, execCtx)
 		require.NoError(t, err)
 		require.NotNil(t, controller)
 
-		_, ok := controller.(*FunctionCallingController)
-		assert.True(t, ok, "expected FunctionCallingController")
+		_, ok := controller.(*IteratingController)
+		assert.True(t, ok, "expected IteratingController")
 	})
 
-	t.Run("synthesis type returns SynthesisController", func(t *testing.T) {
-		controller, err := factory.CreateController(config.AgentTypeSynthesis, execCtx)
+	t.Run("synthesis type returns SingleShotController", func(t *testing.T) {
+		pb := prompt.NewPromptBuilder(config.NewMCPServerRegistry(map[string]*config.MCPServerConfig{}))
+		synthExecCtx := &agent.ExecutionContext{
+			SessionID:     "test-session",
+			StageID:       "test-stage",
+			AgentName:     "test-agent",
+			AgentIndex:    1,
+			PromptBuilder: pb,
+		}
+		controller, err := factory.CreateController(config.AgentTypeSynthesis, synthExecCtx)
 		require.NoError(t, err)
 		require.NotNil(t, controller)
 
-		_, ok := controller.(*SynthesisController)
-		assert.True(t, ok, "expected SynthesisController")
+		_, ok := controller.(*SingleShotController)
+		assert.True(t, ok, "expected SingleShotController")
 	})
 
 	t.Run("scoring type returns error (WIP)", func(t *testing.T) {

--- a/pkg/agent/controller/iterating.go
+++ b/pkg/agent/controller/iterating.go
@@ -10,19 +10,19 @@ import (
 	"github.com/codeready-toolchain/tarsy/pkg/events"
 )
 
-// FunctionCallingController implements the native function calling loop.
+// IteratingController implements the multi-turn tool-calling loop.
 // Used by both google-native (Google SDK) and langchain (multi-provider) backends.
 // Tool calls come as structured ToolCallChunk values (not parsed from text).
 // Completion signal: a response without any ToolCalls.
-type FunctionCallingController struct{}
+type IteratingController struct{}
 
-// NewFunctionCallingController creates a new function calling controller.
-func NewFunctionCallingController() *FunctionCallingController {
-	return &FunctionCallingController{}
+// NewIteratingController creates a new iterating controller.
+func NewIteratingController() *IteratingController {
+	return &IteratingController{}
 }
 
 // Run executes the native thinking iteration loop.
-func (c *FunctionCallingController) Run(
+func (c *IteratingController) Run(
 	ctx context.Context,
 	execCtx *agent.ExecutionContext,
 	prevStageContext string,
@@ -174,7 +174,7 @@ func (c *FunctionCallingController) Run(
 }
 
 // forceConclusion forces the LLM to produce a final answer by calling without tools.
-func (c *FunctionCallingController) forceConclusion(
+func (c *IteratingController) forceConclusion(
 	ctx context.Context,
 	execCtx *agent.ExecutionContext,
 	messages []agent.ConversationMessage,

--- a/pkg/agent/controller/single_shot_test.go
+++ b/pkg/agent/controller/single_shot_test.go
@@ -24,7 +24,7 @@ func TestSynthesisController_HappyPath(t *testing.T) {
 	execCtx := newTestExecCtx(t, llm, executor)
 	execCtx.Config.Type = config.AgentTypeSynthesis
 	execCtx.Config.LLMBackend = config.LLMBackendLangChain
-	ctrl := NewSynthesisController()
+	ctrl := NewSynthesisController(execCtx.PromptBuilder)
 
 	prevContext := "Agent 1: Pods show high memory.\nAgent 2: Logs show OOMKilled."
 	result, err := ctrl.Run(context.Background(), execCtx, prevContext)
@@ -50,7 +50,7 @@ func TestSynthesisController_WithThinking(t *testing.T) {
 	execCtx := newTestExecCtx(t, llm, executor)
 	execCtx.Config.Type = config.AgentTypeSynthesis
 	execCtx.Config.LLMBackend = config.LLMBackendNativeGemini
-	ctrl := NewSynthesisController()
+	ctrl := NewSynthesisController(execCtx.PromptBuilder)
 
 	result, err := ctrl.Run(context.Background(), execCtx, "Agent 1 found no issues.")
 	require.NoError(t, err)
@@ -69,7 +69,7 @@ func TestSynthesisController_LLMError(t *testing.T) {
 	execCtx := newTestExecCtx(t, llm, executor)
 	execCtx.Config.Type = config.AgentTypeSynthesis
 	execCtx.Config.LLMBackend = config.LLMBackendLangChain
-	ctrl := NewSynthesisController()
+	ctrl := NewSynthesisController(execCtx.PromptBuilder)
 
 	_, err := ctrl.Run(context.Background(), execCtx, "")
 	require.Error(t, err)
@@ -95,7 +95,7 @@ func TestSynthesisController_PromptBuilderIntegration(t *testing.T) {
 	execCtx.Config.Type = config.AgentTypeSynthesis
 	execCtx.Config.LLMBackend = config.LLMBackendLangChain
 	execCtx.Config.CustomInstructions = "Custom synthesis instructions."
-	ctrl := NewSynthesisController()
+	ctrl := NewSynthesisController(execCtx.PromptBuilder)
 
 	prevContext := "Agent 1: Pods show high memory.\nAgent 2: Logs show OOMKilled."
 	result, err := ctrl.Run(context.Background(), execCtx, prevContext)
@@ -147,7 +147,7 @@ func TestSynthesisController_WithGrounding(t *testing.T) {
 	execCtx := newTestExecCtx(t, llm, executor)
 	execCtx.Config.Type = config.AgentTypeSynthesis
 	execCtx.Config.LLMBackend = config.LLMBackendNativeGemini
-	ctrl := NewSynthesisController()
+	ctrl := NewSynthesisController(execCtx.PromptBuilder)
 
 	result, err := ctrl.Run(context.Background(), execCtx, "Agent 1 found OOM.")
 	require.NoError(t, err)
@@ -182,7 +182,7 @@ func TestSynthesisController_WithCodeExecution(t *testing.T) {
 	execCtx := newTestExecCtx(t, llm, executor)
 	execCtx.Config.Type = config.AgentTypeSynthesis
 	execCtx.Config.LLMBackend = config.LLMBackendNativeGemini
-	ctrl := NewSynthesisController()
+	ctrl := NewSynthesisController(execCtx.PromptBuilder)
 
 	result, err := ctrl.Run(context.Background(), execCtx, "Agent 1 collected metrics.")
 	require.NoError(t, err)

--- a/pkg/agent/controller/tool_execution.go
+++ b/pkg/agent/controller/tool_execution.go
@@ -15,7 +15,7 @@ import (
 )
 
 // toolCallResult holds the outcome of executeToolCall for the caller to
-// integrate into its conversation format (FunctionCallingController
+// integrate into its conversation format (IteratingController
 // tool message).
 type toolCallResult struct {
 	// Content is the tool result content to feed back to the LLM.

--- a/pkg/agent/iteration.go
+++ b/pkg/agent/iteration.go
@@ -5,7 +5,7 @@ package agent
 const MaxConsecutiveTimeouts = 2
 
 // IterationState tracks loop state across iterations.
-// Shared by FunctionCallingController.
+// Shared by IteratingController.
 type IterationState struct {
 	CurrentIteration           int
 	MaxIterations              int


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Renamed controller types to reflect a multi-turn "Iterating" flow and a configurable single-call "SingleShot" path; preserved forced-conclusion behavior.
  * Controller factory and tests updated to use the new flow names.

* **New Features**
  * Single-shot path is now configurable (custom message building, thinking-text fallback, interaction labels).

* **Documentation**
  * Architecture and functional-area docs updated to describe the new multi-turn vs. single-shot workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->