### PR TITLE
Add native tools support for agents

### DIFF
--- a/docs/proposals/orchestrator-impl-design.md
+++ b/docs/proposals/orchestrator-impl-design.md
@@ -1041,7 +1041,7 @@ New: the dashboard queries `parent_execution_id` to build the trace tree.
 
 > **Decision:** Horizontal layers — 6 PRs. See [questions](orchestrator-impl-questions.md), Q11.
 
-### PR0: `native_tools` on AgentConfig (prerequisite)
+### PR0: `native_tools` on AgentConfig (prerequisite) ✅ DONE
 - `native_tools` field on `AgentConfig` — per-agent override of provider's native tools
 - Merge logic: agent-level keys override provider-level keys
 - Pass resolved native tools through to the LLM client

--- a/pkg/config/agent.go
+++ b/pkg/config/agent.go
@@ -26,6 +26,11 @@ type AgentConfig struct {
 
 	// Max iterations for this agent (forces conclusion when reached, no pause/resume)
 	MaxIterations *int `yaml:"max_iterations,omitempty" validate:"omitempty,min=1"`
+
+	// Per-agent native tool overrides (Google/Gemini). Merges with the LLM
+	// provider's NativeTools on a per-key basis: agent keys override provider keys,
+	// missing keys fall through to the provider default.
+	NativeTools map[GoogleNativeTool]bool `yaml:"native_tools,omitempty"`
 }
 
 // AgentRegistry stores agent configurations in memory with thread-safe access

--- a/pkg/config/validator.go
+++ b/pkg/config/validator.go
@@ -152,6 +152,13 @@ func (v *Validator) validateAgents() error {
 		if agent.MaxIterations != nil && *agent.MaxIterations < 1 {
 			return NewValidationError("agent", name, "max_iterations", fmt.Errorf("must be at least 1"))
 		}
+
+		// Validate native tool keys if specified
+		for tool := range agent.NativeTools {
+			if !tool.IsValid() {
+				return NewValidationError("agent", name, "native_tools", fmt.Errorf("invalid native tool: %s", tool))
+			}
+		}
 	}
 
 	return nil

--- a/pkg/config/validator_test.go
+++ b/pkg/config/validator_test.go
@@ -104,6 +104,32 @@ func TestValidateAgents(t *testing.T) {
 			wantErr: true,
 			errMsg:  "invalid LLM backend",
 		},
+		{
+			name: "agent with valid native tools",
+			agents: map[string]*AgentConfig{
+				"test-agent": {
+					NativeTools: map[GoogleNativeTool]bool{
+						GoogleNativeToolGoogleSearch:  true,
+						GoogleNativeToolCodeExecution: false,
+					},
+				},
+			},
+			servers: map[string]*MCPServerConfig{},
+			wantErr: false,
+		},
+		{
+			name: "agent with invalid native tool key",
+			agents: map[string]*AgentConfig{
+				"test-agent": {
+					NativeTools: map[GoogleNativeTool]bool{
+						"invalid_tool": true,
+					},
+				},
+			},
+			servers: map[string]*MCPServerConfig{},
+			wantErr: true,
+			errMsg:  "invalid native tool",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
- Introduced `NativeTools` field in `AgentConfig` to allow per-agent overrides of provider's native tools.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agents can now specify native tool overrides that merge with provider defaults on a per-key basis, allowing fine-grained control over tool availability per agent.

* **Tests**
  * Added comprehensive test coverage for native tool resolution and validation across configurations.

* **Documentation**
  * Updated design documentation to mark completion of a prerequisite feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->