### PR TITLE
Add orchestrator support and validation for agent configuration

### DIFF
--- a/docs/proposals/orchestrator-impl-design.md
+++ b/docs/proposals/orchestrator-impl-design.md
@@ -1047,7 +1047,7 @@ New: the dashboard queries `parent_execution_id` to build the trace tree.
 - Pass resolved native tools through to the LLM client
 - Independent of orchestrator — useful on its own
 
-### PR1: Config foundation
+### PR1: Config foundation ✅ DONE
 - `sub_agents` override at chain/stage/agent level (full hierarchy) — new fields on `ChainConfig`, `StageConfig`, `StageAgentConfig`
 - `orchestrator` nested config section on `AgentConfig`
 - `defaults.orchestrator` global defaults — new `Orchestrator` field on `Defaults` struct

--- a/pkg/config/agent.go
+++ b/pkg/config/agent.go
@@ -5,6 +5,7 @@ package config
 import (
 	"fmt"
 	"sync"
+	"time"
 )
 
 // AgentConfig defines agent configuration (metadata only — see agent.AgentFactory for instantiation).
@@ -16,7 +17,7 @@ type AgentConfig struct {
 	Description string `yaml:"description,omitempty"`
 
 	// MCP servers this agent uses
-	MCPServers []string `yaml:"mcp_servers" validate:"required,min=1"`
+	MCPServers []string `yaml:"mcp_servers" validate:"omitempty"`
 
 	// Custom instructions override built-in agent behavior
 	CustomInstructions string `yaml:"custom_instructions"`
@@ -31,6 +32,17 @@ type AgentConfig struct {
 	// provider's NativeTools on a per-key basis: agent keys override provider keys,
 	// missing keys fall through to the provider default.
 	NativeTools map[GoogleNativeTool]bool `yaml:"native_tools,omitempty"`
+
+	// Orchestrator-specific configuration (only valid when Type == orchestrator)
+	Orchestrator *OrchestratorConfig `yaml:"orchestrator,omitempty"`
+}
+
+// OrchestratorConfig holds orchestrator-specific settings.
+// Resolved at runtime by merging defaults.orchestrator → agent-level orchestrator.
+type OrchestratorConfig struct {
+	MaxConcurrentAgents *int           `yaml:"max_concurrent_agents,omitempty"`
+	AgentTimeout        *time.Duration `yaml:"agent_timeout,omitempty"`
+	MaxBudget           *time.Duration `yaml:"max_budget,omitempty"`
 }
 
 // AgentRegistry stores agent configurations in memory with thread-safe access

--- a/pkg/config/builtin.go
+++ b/pkg/config/builtin.go
@@ -25,6 +25,8 @@ type BuiltinAgentConfig struct {
 	Type               AgentType
 	MCPServers         []string
 	CustomInstructions string
+	LLMBackend         LLMBackend
+	NativeTools        map[GoogleNativeTool]bool
 }
 
 var (
@@ -77,6 +79,33 @@ Your task:
 7. GENERATE actionable recommendations leveraging insights from the strongest investigations
 
 Focus on solving the original alert/issue, not on meta-analyzing agent performance or comparing approaches.`,
+		},
+		"WebResearcher": {
+			Description: "Searches the web and analyzes URLs for real-time information",
+			LLMBackend:  LLMBackendNativeGemini,
+			NativeTools: map[GoogleNativeTool]bool{
+				GoogleNativeToolGoogleSearch:  true,
+				GoogleNativeToolURLContext:    true,
+				GoogleNativeToolCodeExecution: false,
+			},
+			CustomInstructions: `You research topics using web search and URL analysis.
+Report findings with sources. Be thorough but concise.`,
+		},
+		"CodeExecutor": {
+			Description: "Executes Python code for computation, data analysis, and calculations",
+			LLMBackend:  LLMBackendNativeGemini,
+			NativeTools: map[GoogleNativeTool]bool{
+				GoogleNativeToolGoogleSearch:  false,
+				GoogleNativeToolCodeExecution: true,
+				GoogleNativeToolURLContext:    false,
+			},
+			CustomInstructions: `You solve computational tasks by writing and executing Python code.
+Show your work. Report results clearly.`,
+		},
+		"GeneralWorker": {
+			Description: "General-purpose agent for analysis, summarization, reasoning, and other tasks",
+			CustomInstructions: `You are a general-purpose worker. Complete the assigned task
+thoroughly and concisely.`,
 		},
 	}
 }

--- a/pkg/config/builtin_test.go
+++ b/pkg/config/builtin_test.go
@@ -73,6 +73,30 @@ func TestBuiltinAgents(t *testing.T) {
 			wantCustomInstructions:  true,
 			customInstructionsMatch: "Incident Commander",
 		},
+		{
+			name:                    "WebResearcher",
+			agentID:                 "WebResearcher",
+			wantDesc:                "Searches the web and analyzes URLs for real-time information",
+			wantType:                AgentTypeDefault,
+			wantCustomInstructions:  true,
+			customInstructionsMatch: "web search",
+		},
+		{
+			name:                    "CodeExecutor",
+			agentID:                 "CodeExecutor",
+			wantDesc:                "Executes Python code for computation, data analysis, and calculations",
+			wantType:                AgentTypeDefault,
+			wantCustomInstructions:  true,
+			customInstructionsMatch: "Python code",
+		},
+		{
+			name:                    "GeneralWorker",
+			agentID:                 "GeneralWorker",
+			wantDesc:                "General-purpose agent for analysis, summarization, reasoning, and other tasks",
+			wantType:                AgentTypeDefault,
+			wantCustomInstructions:  true,
+			customInstructionsMatch: "general-purpose worker",
+		},
 	}
 
 	for _, tt := range tests {
@@ -88,6 +112,43 @@ func TestBuiltinAgents(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBuiltinAgentNativeToolsAndBackend(t *testing.T) {
+	cfg := GetBuiltinConfig()
+
+	t.Run("WebResearcher has native Gemini backend and tools", func(t *testing.T) {
+		agent, exists := cfg.Agents["WebResearcher"]
+		require.True(t, exists)
+		assert.Equal(t, LLMBackendNativeGemini, agent.LLMBackend)
+		assert.True(t, agent.NativeTools[GoogleNativeToolGoogleSearch])
+		assert.True(t, agent.NativeTools[GoogleNativeToolURLContext])
+		assert.False(t, agent.NativeTools[GoogleNativeToolCodeExecution])
+	})
+
+	t.Run("CodeExecutor has native Gemini backend and code_execution", func(t *testing.T) {
+		agent, exists := cfg.Agents["CodeExecutor"]
+		require.True(t, exists)
+		assert.Equal(t, LLMBackendNativeGemini, agent.LLMBackend)
+		assert.True(t, agent.NativeTools[GoogleNativeToolCodeExecution])
+		assert.False(t, agent.NativeTools[GoogleNativeToolGoogleSearch])
+		assert.False(t, agent.NativeTools[GoogleNativeToolURLContext])
+	})
+
+	t.Run("GeneralWorker has no backend or native tools", func(t *testing.T) {
+		agent, exists := cfg.Agents["GeneralWorker"]
+		require.True(t, exists)
+		assert.Empty(t, agent.LLMBackend)
+		assert.Nil(t, agent.NativeTools)
+		assert.Empty(t, agent.MCPServers)
+	})
+
+	t.Run("KubernetesAgent has no backend or native tools", func(t *testing.T) {
+		agent, exists := cfg.Agents["KubernetesAgent"]
+		require.True(t, exists)
+		assert.Empty(t, agent.LLMBackend)
+		assert.Nil(t, agent.NativeTools)
+	})
 }
 
 func TestBuiltinChatAgentInheritsFromDefaults(t *testing.T) {

--- a/pkg/config/builtin_test.go
+++ b/pkg/config/builtin_test.go
@@ -123,7 +123,10 @@ func TestBuiltinAgentNativeToolsAndBackend(t *testing.T) {
 		assert.Equal(t, LLMBackendNativeGemini, agent.LLMBackend)
 		assert.True(t, agent.NativeTools[GoogleNativeToolGoogleSearch])
 		assert.True(t, agent.NativeTools[GoogleNativeToolURLContext])
-		assert.False(t, agent.NativeTools[GoogleNativeToolCodeExecution])
+
+		val, present := agent.NativeTools[GoogleNativeToolCodeExecution]
+		assert.True(t, present, "CodeExecution key must be explicitly present")
+		assert.False(t, val, "CodeExecution must be explicitly disabled")
 	})
 
 	t.Run("CodeExecutor has native Gemini backend and code_execution", func(t *testing.T) {
@@ -131,8 +134,14 @@ func TestBuiltinAgentNativeToolsAndBackend(t *testing.T) {
 		require.True(t, exists)
 		assert.Equal(t, LLMBackendNativeGemini, agent.LLMBackend)
 		assert.True(t, agent.NativeTools[GoogleNativeToolCodeExecution])
-		assert.False(t, agent.NativeTools[GoogleNativeToolGoogleSearch])
-		assert.False(t, agent.NativeTools[GoogleNativeToolURLContext])
+
+		val, present := agent.NativeTools[GoogleNativeToolGoogleSearch]
+		assert.True(t, present, "GoogleSearch key must be explicitly present")
+		assert.False(t, val, "GoogleSearch must be explicitly disabled")
+
+		val, present = agent.NativeTools[GoogleNativeToolURLContext]
+		assert.True(t, present, "URLContext key must be explicitly present")
+		assert.False(t, val, "URLContext must be explicitly disabled")
 	})
 
 	t.Run("GeneralWorker has no backend or native tools", func(t *testing.T) {

--- a/pkg/config/chain.go
+++ b/pkg/config/chain.go
@@ -36,6 +36,9 @@ type ChainConfig struct {
 
 	// Chain-level MCP servers override
 	MCPServers []string `yaml:"mcp_servers,omitempty"`
+
+	// Sub-agents available to orchestrator agents in this chain
+	SubAgents []string `yaml:"sub_agents,omitempty"`
 }
 
 // StageConfig defines a single stage in a chain
@@ -60,6 +63,9 @@ type StageConfig struct {
 
 	// Stage-level MCP servers override
 	MCPServers []string `yaml:"mcp_servers,omitempty"`
+
+	// Sub-agents available to orchestrator agents in this stage
+	SubAgents []string `yaml:"sub_agents,omitempty"`
 
 	// Optional synthesis configuration (for parallel execution)
 	Synthesis *SynthesisConfig `yaml:"synthesis,omitempty"`

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -26,6 +26,9 @@ type Defaults struct {
 
 	// Alert data masking configuration
 	AlertMasking *AlertMaskingDefaults `yaml:"alert_masking,omitempty"`
+
+	// Global orchestrator defaults (applied to all orchestrator agents unless overridden)
+	Orchestrator *OrchestratorConfig `yaml:"orchestrator,omitempty"`
 }
 
 // AlertMaskingDefaults holds alert payload masking settings.

--- a/pkg/config/enums.go
+++ b/pkg/config/enums.go
@@ -10,12 +10,14 @@ const (
 	AgentTypeSynthesis AgentType = "synthesis"
 	// AgentTypeScoring evaluates session quality (single-shot)
 	AgentTypeScoring AgentType = "scoring"
+	// AgentTypeOrchestrator dispatches and coordinates sub-agents (iterating controller)
+	AgentTypeOrchestrator AgentType = "orchestrator"
 )
 
 // IsValid checks if the agent type is valid (empty string is valid — means default).
 func (t AgentType) IsValid() bool {
 	switch t {
-	case AgentTypeDefault, AgentTypeSynthesis, AgentTypeScoring:
+	case AgentTypeDefault, AgentTypeSynthesis, AgentTypeScoring, AgentTypeOrchestrator:
 		return true
 	default:
 		return false

--- a/pkg/config/enums_test.go
+++ b/pkg/config/enums_test.go
@@ -15,6 +15,7 @@ func TestAgentTypeIsValid(t *testing.T) {
 		{"default (empty)", AgentTypeDefault, true},
 		{"synthesis", AgentTypeSynthesis, true},
 		{"scoring", AgentTypeScoring, true},
+		{"orchestrator", AgentTypeOrchestrator, true},
 		{"invalid", AgentType("invalid"), false},
 	}
 

--- a/pkg/config/merge.go
+++ b/pkg/config/merge.go
@@ -10,11 +10,23 @@ func mergeAgents(builtinAgents map[string]BuiltinAgentConfig, userAgents map[str
 		// Defensive copy of MCPServers slice to prevent shared state
 		mcpCopy := make([]string, len(builtin.MCPServers))
 		copy(mcpCopy, builtin.MCPServers)
+
+		// Defensive copy of NativeTools map
+		var nativeToolsCopy map[GoogleNativeTool]bool
+		if builtin.NativeTools != nil {
+			nativeToolsCopy = make(map[GoogleNativeTool]bool, len(builtin.NativeTools))
+			for k, v := range builtin.NativeTools {
+				nativeToolsCopy[k] = v
+			}
+		}
+
 		result[name] = &AgentConfig{
 			Type:               builtin.Type,
 			Description:        builtin.Description,
 			MCPServers:         mcpCopy,
 			CustomInstructions: builtin.CustomInstructions,
+			LLMBackend:         builtin.LLMBackend,
+			NativeTools:        nativeToolsCopy,
 		}
 	}
 

--- a/pkg/config/sub_agent_registry.go
+++ b/pkg/config/sub_agent_registry.go
@@ -20,7 +20,7 @@ type SubAgentRegistry struct {
 func BuildSubAgentRegistry(agents map[string]*AgentConfig) *SubAgentRegistry {
 	var entries []SubAgentEntry
 	for name, agent := range agents {
-		if agent.Description == "" || agent.Type == AgentTypeOrchestrator {
+		if agent == nil || agent.Description == "" || agent.Type == AgentTypeOrchestrator {
 			continue
 		}
 		entry := SubAgentEntry{

--- a/pkg/config/sub_agent_registry.go
+++ b/pkg/config/sub_agent_registry.go
@@ -1,0 +1,67 @@
+package config
+
+import "sort"
+
+// SubAgentEntry describes an agent available for orchestrator dispatch.
+type SubAgentEntry struct {
+	Name        string
+	Description string
+	MCPServers  []string
+	NativeTools []string
+}
+
+// SubAgentRegistry holds agents eligible for orchestrator dispatch.
+type SubAgentRegistry struct {
+	entries []SubAgentEntry
+}
+
+// BuildSubAgentRegistry creates a registry from the merged agent map.
+// Includes agents with non-empty Description, excludes orchestrator agents.
+func BuildSubAgentRegistry(agents map[string]*AgentConfig) *SubAgentRegistry {
+	var entries []SubAgentEntry
+	for name, agent := range agents {
+		if agent.Description == "" || agent.Type == AgentTypeOrchestrator {
+			continue
+		}
+		entry := SubAgentEntry{
+			Name:        name,
+			Description: agent.Description,
+			MCPServers:  agent.MCPServers,
+		}
+		for tool, enabled := range agent.NativeTools {
+			if enabled {
+				entry.NativeTools = append(entry.NativeTools, string(tool))
+			}
+		}
+		sort.Strings(entry.NativeTools)
+		entries = append(entries, entry)
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Name < entries[j].Name
+	})
+	return &SubAgentRegistry{entries: entries}
+}
+
+// Entries returns all entries in the registry.
+func (r *SubAgentRegistry) Entries() []SubAgentEntry {
+	return r.entries
+}
+
+// Filter returns a new registry containing only agents whose names are in allowedNames.
+// If allowedNames is nil, returns the full registry (no copy — caller must not mutate).
+func (r *SubAgentRegistry) Filter(allowedNames []string) *SubAgentRegistry {
+	if allowedNames == nil {
+		return r
+	}
+	allowed := make(map[string]bool, len(allowedNames))
+	for _, name := range allowedNames {
+		allowed[name] = true
+	}
+	var filtered []SubAgentEntry
+	for _, entry := range r.entries {
+		if allowed[entry.Name] {
+			filtered = append(filtered, entry)
+		}
+	}
+	return &SubAgentRegistry{entries: filtered}
+}

--- a/pkg/config/sub_agent_registry_test.go
+++ b/pkg/config/sub_agent_registry_test.go
@@ -74,6 +74,17 @@ func TestBuildSubAgentRegistry_Empty(t *testing.T) {
 	assert.Empty(t, registry.Entries())
 }
 
+func TestBuildSubAgentRegistry_NilEntry(t *testing.T) {
+	agents := map[string]*AgentConfig{
+		"Valid":  {Description: "A valid agent"},
+		"NilPtr": nil,
+	}
+	registry := BuildSubAgentRegistry(agents)
+	entries := registry.Entries()
+	require.Len(t, entries, 1)
+	assert.Equal(t, "Valid", entries[0].Name)
+}
+
 func TestSubAgentRegistry_DefensiveCopies(t *testing.T) {
 	source := map[string]*AgentConfig{
 		"Agent": {
@@ -101,6 +112,13 @@ func TestSubAgentRegistry_DefensiveCopies(t *testing.T) {
 		filtered := registry.Filter(nil)
 		filtered.Entries()[0] = SubAgentEntry{Name: "Replaced"}
 		assert.Equal(t, "Agent", registry.Entries()[0].Name)
+	})
+
+	t.Run("Filter non-nil returns independent copy", func(t *testing.T) {
+		filtered := registry.Filter([]string{"Agent"})
+		e := filtered.Entries()
+		e[0].MCPServers[0] = "mutated"
+		assert.Equal(t, "server-a", registry.Entries()[0].MCPServers[0])
 	})
 }
 

--- a/pkg/config/sub_agent_registry_test.go
+++ b/pkg/config/sub_agent_registry_test.go
@@ -1,0 +1,146 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildSubAgentRegistry(t *testing.T) {
+	agents := map[string]*AgentConfig{
+		"LogAnalyzer": {
+			Description: "Analyzes logs",
+			MCPServers:  []string{"loki"},
+		},
+		"MetricChecker": {
+			Description: "Checks metrics",
+			MCPServers:  []string{"prometheus"},
+		},
+		"WebResearcher": {
+			Description: "Web research",
+			NativeTools: map[GoogleNativeTool]bool{
+				GoogleNativeToolGoogleSearch: true,
+				GoogleNativeToolURLContext:   true,
+			},
+		},
+		"NoDescAgent": {
+			MCPServers: []string{"some-server"},
+		},
+		"MyOrchestrator": {
+			Type:        AgentTypeOrchestrator,
+			Description: "An orchestrator",
+		},
+	}
+
+	registry := BuildSubAgentRegistry(agents)
+	entries := registry.Entries()
+
+	// Should include agents with Description, excluding orchestrators and no-description
+	require.Len(t, entries, 3)
+
+	// Sorted by name
+	assert.Equal(t, "LogAnalyzer", entries[0].Name)
+	assert.Equal(t, "Analyzes logs", entries[0].Description)
+	assert.Equal(t, []string{"loki"}, entries[0].MCPServers)
+
+	assert.Equal(t, "MetricChecker", entries[1].Name)
+	assert.Equal(t, []string{"prometheus"}, entries[1].MCPServers)
+
+	assert.Equal(t, "WebResearcher", entries[2].Name)
+	assert.Equal(t, []string{"google_search", "url_context"}, entries[2].NativeTools)
+}
+
+func TestBuildSubAgentRegistry_DisabledNativeToolsExcluded(t *testing.T) {
+	agents := map[string]*AgentConfig{
+		"CodeExec": {
+			Description: "Code execution",
+			NativeTools: map[GoogleNativeTool]bool{
+				GoogleNativeToolCodeExecution: true,
+				GoogleNativeToolGoogleSearch:  false,
+			},
+		},
+	}
+
+	registry := BuildSubAgentRegistry(agents)
+	entries := registry.Entries()
+
+	require.Len(t, entries, 1)
+	assert.Equal(t, []string{"code_execution"}, entries[0].NativeTools)
+}
+
+func TestBuildSubAgentRegistry_Empty(t *testing.T) {
+	registry := BuildSubAgentRegistry(map[string]*AgentConfig{})
+	assert.Empty(t, registry.Entries())
+}
+
+func TestBuildSubAgentRegistry_WithBuiltinAgents(t *testing.T) {
+	builtin := GetBuiltinConfig()
+	merged := mergeAgents(builtin.Agents, map[string]AgentConfig{})
+	registry := BuildSubAgentRegistry(merged)
+
+	entries := registry.Entries()
+	require.NotEmpty(t, entries, "built-in agents should produce non-empty registry")
+
+	entryNames := make(map[string]bool, len(entries))
+	for _, e := range entries {
+		entryNames[e.Name] = true
+		assert.NotEmpty(t, e.Description, "entry %s should have a description", e.Name)
+	}
+
+	assert.True(t, entryNames["WebResearcher"], "WebResearcher should be in registry")
+	assert.True(t, entryNames["CodeExecutor"], "CodeExecutor should be in registry")
+	assert.True(t, entryNames["GeneralWorker"], "GeneralWorker should be in registry")
+
+	// Verify native tools survived the merge→registry pipeline
+	for _, e := range entries {
+		if e.Name == "WebResearcher" {
+			assert.Contains(t, e.NativeTools, "google_search")
+			assert.Contains(t, e.NativeTools, "url_context")
+		}
+		if e.Name == "CodeExecutor" {
+			assert.Contains(t, e.NativeTools, "code_execution")
+		}
+	}
+
+	// Orchestrator agents (if any are built-in) must be excluded
+	for _, e := range entries {
+		agent := merged[e.Name]
+		assert.NotEqual(t, AgentTypeOrchestrator, agent.Type, "orchestrator %s should not be in registry", e.Name)
+	}
+}
+
+func TestSubAgentRegistry_Filter(t *testing.T) {
+	agents := map[string]*AgentConfig{
+		"A": {Description: "Agent A"},
+		"B": {Description: "Agent B"},
+		"C": {Description: "Agent C"},
+	}
+	registry := BuildSubAgentRegistry(agents)
+
+	t.Run("nil returns full registry", func(t *testing.T) {
+		filtered := registry.Filter(nil)
+		assert.Same(t, registry, filtered)
+		assert.Len(t, filtered.Entries(), 3)
+	})
+
+	t.Run("filter to subset", func(t *testing.T) {
+		filtered := registry.Filter([]string{"A", "C"})
+		entries := filtered.Entries()
+		require.Len(t, entries, 2)
+		assert.Equal(t, "A", entries[0].Name)
+		assert.Equal(t, "C", entries[1].Name)
+	})
+
+	t.Run("filter with unknown names ignores them", func(t *testing.T) {
+		filtered := registry.Filter([]string{"A", "Unknown"})
+		entries := filtered.Entries()
+		require.Len(t, entries, 1)
+		assert.Equal(t, "A", entries[0].Name)
+	})
+
+	t.Run("filter with empty list returns empty", func(t *testing.T) {
+		filtered := registry.Filter([]string{})
+		assert.Empty(t, filtered.Entries())
+	})
+}

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -49,6 +49,7 @@ type StageAgentConfig struct {
 	LLMBackend    LLMBackend `yaml:"llm_backend,omitempty"`
 	MaxIterations *int       `yaml:"max_iterations,omitempty" validate:"omitempty,min=1"`
 	MCPServers    []string   `yaml:"mcp_servers,omitempty"`
+	SubAgents     []string   `yaml:"sub_agents,omitempty"`
 }
 
 // SynthesisConfig defines synthesis agent configuration


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Orchestrator agent type with configurable concurrency, timeouts, and budget; global defaults support
  * Sub-agent grouping: chain/stage/agent-level sub_agents and a registry to list/filter available non-orchestrator sub-agents
  * Three built-in agents: WebResearcher, CodeExecutor, GeneralWorker
  * MCP server config made optional; built-ins carry backend/tooling and are defensively copied

* **Tests**
  * Extensive validation and unit tests for orchestrator rules, sub-agent refs, registry behavior, and merging

* **Chores**
  * Documentation heading updated to indicate completion status
<!-- end of auto-generated comment: release notes by coderabbit.ai -->