### PR TITLE
Fix tool result summarization threshold validation

### DIFF
--- a/deploy/config/tarsy.yaml.example
+++ b/deploy/config/tarsy.yaml.example
@@ -167,7 +167,7 @@ mcp_servers:
     
     summarization:
       enabled: true
-      size_threshold_tokens: 5000
+      # size_threshold_tokens: 10000  # Default: 10000 (omit to use default)
       summary_max_token_limit: 1000
 
   # Example: ArgoCD MCP server

--- a/pkg/agent/controller/summarize.go
+++ b/pkg/agent/controller/summarize.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/codeready-toolchain/tarsy/ent/timelineevent"
 	"github.com/codeready-toolchain/tarsy/pkg/agent"
+	"github.com/codeready-toolchain/tarsy/pkg/config"
 	"github.com/codeready-toolchain/tarsy/pkg/events"
 	"github.com/codeready-toolchain/tarsy/pkg/mcp"
 	"github.com/codeready-toolchain/tarsy/pkg/models"
@@ -61,7 +62,7 @@ func maybeSummarize(
 	estimatedTokens := mcp.EstimateTokens(rawContent)
 	threshold := sumConfig.SizeThresholdTokens
 	if threshold <= 0 {
-		threshold = 5000 // Default threshold
+		threshold = config.DefaultSizeThresholdTokens
 	}
 
 	if estimatedTokens <= threshold {

--- a/pkg/config/builtin.go
+++ b/pkg/config/builtin.go
@@ -142,7 +142,7 @@ func initBuiltinMCPServers() map[string]MCPServerConfig {
 			},
 			Summarization: &SummarizationConfig{
 				Enabled:              true,
-				SizeThresholdTokens:  5000,
+				SizeThresholdTokens:  DefaultSizeThresholdTokens,
 				SummaryMaxTokenLimit: 1000,
 			},
 		},

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -64,10 +64,11 @@ type LLMProvidersYAMLConfig struct {
 //  2. Expand environment variables
 //  3. Parse YAML into structs
 //  4. Merge built-in + user-defined configurations
-//  5. Build in-memory registries
-//  6. Apply default values
-//  7. Validate all configuration
-//  8. Return Config ready for use
+//  5. Apply MCP server defaults (e.g. size_threshold_tokens)
+//  6. Build in-memory registries
+//  7. Apply default values
+//  8. Validate all configuration
+//  9. Return Config ready for use
 func Initialize(ctx context.Context, configDir string) (*Config, error) {
 	log := slog.With("config_dir", configDir)
 	log.Info("Initializing configuration")

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -120,13 +120,20 @@ func load(_ context.Context, configDir string) (*Config, error) {
 	chains := mergeChains(builtin.ChainDefinitions, tarsyConfig.AgentChains)
 	llmProvidersMerged := mergeLLMProviders(builtin.LLMProviders, llmProviders)
 
-	// 5. Build registries
+	// 5. Apply MCP server defaults (before validation)
+	for _, server := range mcpServers {
+		if server.Summarization != nil && server.Summarization.Enabled && server.Summarization.SizeThresholdTokens == 0 {
+			server.Summarization.SizeThresholdTokens = DefaultSizeThresholdTokens
+		}
+	}
+
+	// 6. Build registries
 	agentRegistry := NewAgentRegistry(agents)
 	mcpServerRegistry := NewMCPServerRegistry(mcpServers)
 	chainRegistry := NewChainRegistry(chains)
 	llmProviderRegistry := NewLLMProviderRegistry(llmProvidersMerged)
 
-	// 6. Resolve defaults (YAML overrides built-in)
+	// 7. Resolve defaults (YAML overrides built-in)
 	defaults := tarsyConfig.Defaults
 	if defaults == nil {
 		defaults = &Defaults{}

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -33,6 +33,10 @@ type MaskingPattern struct {
 	Description string `yaml:"description,omitempty"`
 }
 
+// DefaultSizeThresholdTokens is the default token count above which MCP
+// responses are summarized (when summarization is enabled).
+const DefaultSizeThresholdTokens = 10000
+
 // SummarizationConfig defines when and how to summarize large MCP responses
 type SummarizationConfig struct {
 	Enabled              bool `yaml:"enabled"`

--- a/pkg/config/validator_test.go
+++ b/pkg/config/validator_test.go
@@ -485,6 +485,39 @@ func TestValidateMCPServers(t *testing.T) {
 			wantErr: true,
 			errMsg:  "pattern 'nonexistent-pattern' not found",
 		},
+		{
+			name: "valid summarization with explicit threshold",
+			servers: map[string]*MCPServerConfig{
+				"test-server": {
+					Transport: TransportConfig{
+						Type:    TransportTypeStdio,
+						Command: "test",
+					},
+					Summarization: &SummarizationConfig{
+						Enabled:             true,
+						SizeThresholdTokens: 5000,
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid summarization threshold too low",
+			servers: map[string]*MCPServerConfig{
+				"test-server": {
+					Transport: TransportConfig{
+						Type:    TransportTypeStdio,
+						Command: "test",
+					},
+					Summarization: &SummarizationConfig{
+						Enabled:             true,
+						SizeThresholdTokens: 50,
+					},
+				},
+			},
+			wantErr: true,
+			errMsg:  "must be at least 100",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Default summarization threshold increased from 5,000 to 10,000 tokens when not specified.
  * Configuration loading now reliably applies summarization defaults if settings are omitted; example config shows the default as a commented placeholder.

* **Tests**
  * Added tests to validate summarization defaulting and threshold validation, including error conditions for too-small thresholds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->