### PR TITLE
Rename built-in kubernetes chain

### DIFF
--- a/.cursor/commands/check-and-fix.md
+++ b/.cursor/commands/check-and-fix.md
@@ -1,0 +1,10 @@
+# Check and Fix
+
+Run `make check` and fix all issues including failed tests.
+
+1. Run `make check` to see all problems (runs fmt, build, lint-fix, test)
+2. Fix all compilation errors, lint issues, and test failures
+3. For test failures, read the failing test and the code under test to understand the root cause
+4. Apply fixes to the source code (not the tests) unless the test itself is wrong
+5. Re-run the specific failing target (`make build`, `make lint`, or `make test`) to verify each fix
+6. Repeat until `make check` passes cleanly

--- a/deploy/config/README.md
+++ b/deploy/config/README.md
@@ -163,7 +163,7 @@ TARSy includes built-in configurations that work out-of-the-box:
 
 ### Built-in Chains
 
-- **kubernetes-agent-chain** - Single-stage Kubernetes analysis
+- **kubernetes** - Single-stage Kubernetes analysis
 
 You can override any built-in configuration by defining the same name/ID in your YAML files.
 

--- a/deploy/config/tarsy.yaml.example
+++ b/deploy/config/tarsy.yaml.example
@@ -311,7 +311,7 @@ agents:
 # AGENT CHAIN DEFINITIONS
 # =============================================================================
 # Define multi-stage agent chains for different alert types
-# Built-in chains: kubernetes-agent-chain
+# Built-in chains: kubernetes
 
 agent_chains:
   # Single-stage chain with native thinking

--- a/docs/functional-areas-design.md
+++ b/docs/functional-areas-design.md
@@ -919,7 +919,7 @@ graph TB
 
 ```yaml
 agent_chains:
-  kubernetes-agent-chain:
+  kubernetes:
     chat:
       enabled: true
       agent: "ChatAgent"

--- a/pkg/config/builtin.go
+++ b/pkg/config/builtin.go
@@ -242,7 +242,7 @@ func initBuiltinLLMProviders() map[string]LLMProviderConfig {
 
 func initBuiltinChains() map[string]ChainConfig {
 	return map[string]ChainConfig{
-		"kubernetes-agent-chain": {
+		"kubernetes": {
 			AlertTypes:  []string{"kubernetes"},
 			Description: "Single-stage Kubernetes analysis",
 			Stages: []StageConfig{

--- a/pkg/config/builtin_test.go
+++ b/pkg/config/builtin_test.go
@@ -298,9 +298,9 @@ func TestBuiltinLLMProviders(t *testing.T) {
 func TestBuiltinChains(t *testing.T) {
 	cfg := GetBuiltinConfig()
 
-	t.Run("kubernetes-agent-chain", func(t *testing.T) {
-		chain, exists := cfg.ChainDefinitions["kubernetes-agent-chain"]
-		require.True(t, exists, "kubernetes-agent-chain should exist")
+	t.Run("kubernetes", func(t *testing.T) {
+		chain, exists := cfg.ChainDefinitions["kubernetes"]
+		require.True(t, exists, "kubernetes chain should exist")
 
 		assert.Contains(t, chain.AlertTypes, "kubernetes")
 		assert.NotEmpty(t, chain.Description)

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -39,7 +39,7 @@ func TestInitialize(t *testing.T) {
 
 	// Verify built-in configs are loaded
 	assert.True(t, cfg.AgentRegistry.Has("KubernetesAgent"))
-	assert.True(t, cfg.ChainRegistry.Has("kubernetes-agent-chain"))
+	assert.True(t, cfg.ChainRegistry.Has("kubernetes"))
 	assert.True(t, cfg.MCPServerRegistry.Has("kubernetes-server"))
 	assert.True(t, cfg.LLMProviderRegistry.Has("google-default"))
 

--- a/test/e2e/dashboard_test.go
+++ b/test/e2e/dashboard_test.go
@@ -465,11 +465,11 @@ func TestDashboardEndpoints(t *testing.T) {
 		assert.Equal(t, false, nativeTools["url_context"])
 	})
 
-	// ── Alert Types (from config, not DB: concurrency-chain + kubernetes-agent-chain) ──
+	// ── Alert Types (from config, not DB: concurrency-chain + kubernetes) ──
 	t.Run("AlertTypes", func(t *testing.T) {
 		types := app.GetAlertTypes(t)
 
-		// Chains sorted alphabetically: concurrency-chain then kubernetes-agent-chain.
+		// Chains sorted alphabetically: concurrency-chain then kubernetes.
 		assert.Equal(t, "concurrency-chain", types["default_chain_id"])
 
 		alertTypes, ok := types["alert_types"].([]interface{})
@@ -482,7 +482,7 @@ func TestDashboardEndpoints(t *testing.T) {
 
 		at1 := alertTypes[1].(map[string]interface{})
 		assert.Equal(t, "kubernetes", at1["type"])
-		assert.Equal(t, "kubernetes-agent-chain", at1["chain_id"])
+		assert.Equal(t, "kubernetes", at1["chain_id"])
 		assert.Equal(t, "Single-stage Kubernetes analysis", at1["description"])
 	})
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the built-in Kubernetes chain identifier across configuration, code, and examples.

* **Documentation**
  * Updated examples and design docs to reflect the new chain name.
  * Added a "Check and Fix" checklist for running and resolving project checks.

* **Tests**
  * Updated unit and end-to-end test expectations to match the renamed chain.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->