### PR TITLE
SubAgentRunner + CompositeToolExecutor for Orchestrator Agent 

### DIFF
--- a/pkg/agent/orchestrator/runner.go
+++ b/pkg/agent/orchestrator/runner.go
@@ -1,0 +1,405 @@
+package orchestrator
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+
+	"github.com/codeready-toolchain/tarsy/ent/agentexecution"
+	"github.com/codeready-toolchain/tarsy/ent/timelineevent"
+	"github.com/codeready-toolchain/tarsy/pkg/agent"
+	"github.com/codeready-toolchain/tarsy/pkg/config"
+	"github.com/codeready-toolchain/tarsy/pkg/models"
+)
+
+// SubAgentRunner manages the lifecycle of sub-agent goroutines within an
+// orchestrator execution. It provides push-based result delivery (via a
+// buffered channel) and lifecycle management (cancel, wait).
+type SubAgentRunner struct {
+	mu         sync.Mutex
+	executions map[string]*subAgentExecution
+
+	// Buffered channel for completed sub-agent results.
+	// Capacity = MaxConcurrentAgents to prevent goroutine blocking.
+	resultsCh chan *SubAgentResult
+
+	// Closed during CancelAll to signal goroutines that the orchestrator is
+	// shutting down and results should be dropped. Individual sub-agent
+	// cancellations still deliver their result to resultsCh.
+	closeCh chan struct{}
+
+	// Atomic count of sub-agents whose results have not yet been consumed.
+	pending int32
+
+	deps         *SubAgentDeps
+	parentExecID string
+	sessionID    string
+	stageID      string
+
+	// Atomic counter for sub-agent agent_index (starts at 1).
+	nextSubAgentIndex int32
+
+	registry   *config.SubAgentRegistry
+	guardrails *OrchestratorGuardrails
+}
+
+// NewSubAgentRunner creates a runner for managing sub-agents within an
+// orchestrator execution.
+func NewSubAgentRunner(
+	deps *SubAgentDeps,
+	parentExecID string,
+	sessionID string,
+	stageID string,
+	registry *config.SubAgentRegistry,
+	guardrails *OrchestratorGuardrails,
+) *SubAgentRunner {
+	return &SubAgentRunner{
+		executions:   make(map[string]*subAgentExecution),
+		resultsCh:    make(chan *SubAgentResult, guardrails.MaxConcurrentAgents),
+		closeCh:      make(chan struct{}),
+		deps:         deps,
+		parentExecID: parentExecID,
+		sessionID:    sessionID,
+		stageID:      stageID,
+		registry:     registry,
+		guardrails:   guardrails,
+	}
+}
+
+// Dispatch starts a sub-agent to execute the given task. Returns immediately
+// with the execution ID. The sub-agent result will be delivered to the results
+// channel when the goroutine finishes.
+func (r *SubAgentRunner) Dispatch(ctx context.Context, name, task string) (string, error) {
+	if _, ok := r.registry.Get(name); !ok {
+		return "", fmt.Errorf("%w: %s", ErrAgentNotFound, name)
+	}
+
+	r.mu.Lock()
+	activeCount := 0
+	for _, exec := range r.executions {
+		if exec.status == agent.ExecutionStatusActive {
+			activeCount++
+		}
+	}
+	if activeCount >= r.guardrails.MaxConcurrentAgents {
+		r.mu.Unlock()
+		return "", fmt.Errorf("%w: limit is %d", ErrMaxConcurrentAgents, r.guardrails.MaxConcurrentAgents)
+	}
+	r.mu.Unlock()
+
+	agentIndex := int(atomic.AddInt32(&r.nextSubAgentIndex, 1))
+
+	resolvedConfig, err := agent.ResolveAgentConfig(
+		r.deps.Config, r.deps.Chain,
+		config.StageConfig{},
+		config.StageAgentConfig{Name: name},
+	)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve config for sub-agent %s: %w", name, err)
+	}
+
+	parentID := r.parentExecID
+	exec, err := r.deps.StageService.CreateAgentExecution(ctx, models.CreateAgentExecutionRequest{
+		StageID:           r.stageID,
+		SessionID:         r.sessionID,
+		AgentName:         name,
+		AgentIndex:        agentIndex,
+		LLMBackend:        resolvedConfig.LLMBackend,
+		LLMProvider:       resolvedConfig.LLMProviderName,
+		ParentExecutionID: &parentID,
+		Task:              &task,
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to create sub-agent execution record: %w", err)
+	}
+	executionID := exec.ID
+
+	if updateErr := r.deps.StageService.UpdateAgentExecutionStatus(
+		ctx, executionID, agentexecution.StatusActive, "",
+	); updateErr != nil {
+		slog.Warn("Failed to mark sub-agent execution as active",
+			"execution_id", executionID, "error", updateErr)
+	}
+
+	maxSeq, _ := r.deps.TimelineService.GetMaxSequenceNumber(ctx, executionID)
+	_, _ = r.deps.TimelineService.CreateTimelineEvent(ctx, models.CreateTimelineEventRequest{
+		SessionID:      r.sessionID,
+		StageID:        &r.stageID,
+		ExecutionID:    &executionID,
+		SequenceNumber: maxSeq + 1,
+		EventType:      timelineevent.EventTypeTaskAssigned,
+		Status:         timelineevent.StatusCompleted,
+		Content:        task,
+	})
+
+	subExec := &subAgentExecution{
+		executionID: executionID,
+		agentName:   name,
+		task:        task,
+		status:      agent.ExecutionStatusActive,
+		done:        make(chan struct{}),
+	}
+
+	r.mu.Lock()
+	r.executions[executionID] = subExec
+	r.mu.Unlock()
+
+	atomic.AddInt32(&r.pending, 1)
+
+	subCtx, cancel := context.WithTimeout(ctx, r.guardrails.AgentTimeout)
+	subExec.cancel = cancel
+
+	go r.runSubAgent(subCtx, cancel, subExec, resolvedConfig, agentIndex)
+
+	return executionID, nil
+}
+
+// runSubAgent executes a sub-agent in a goroutine and delivers the result.
+func (r *SubAgentRunner) runSubAgent(
+	ctx context.Context,
+	cancel context.CancelFunc,
+	exec *subAgentExecution,
+	resolvedConfig *agent.ResolvedAgentConfig,
+	agentIndex int,
+) {
+	defer cancel()
+	defer close(exec.done)
+
+	logger := slog.With(
+		"parent_exec_id", r.parentExecID,
+		"sub_exec_id", exec.executionID,
+		"sub_agent", exec.agentName,
+	)
+
+	toolExecutor := r.createSubAgentToolExecutor(ctx, resolvedConfig, logger)
+	defer func() { _ = toolExecutor.Close() }()
+
+	execCtx := &agent.ExecutionContext{
+		SessionID:      r.sessionID,
+		StageID:        r.stageID,
+		ExecutionID:    exec.executionID,
+		AgentName:      exec.agentName,
+		AgentIndex:     agentIndex,
+		AlertData:      r.deps.AlertData,
+		AlertType:      r.deps.AlertType,
+		RunbookContent: r.deps.RunbookContent,
+		Config:         resolvedConfig,
+		LLMClient:      r.deps.LLMClient,
+		ToolExecutor:   toolExecutor,
+		EventPublisher: r.deps.EventPublisher,
+		PromptBuilder:  r.deps.PromptBuilder,
+		Services: &agent.ServiceBundle{
+			Timeline:    r.deps.TimelineService,
+			Message:     r.deps.MessageService,
+			Interaction: r.deps.InteractionService,
+			Stage:       r.deps.StageService,
+		},
+	}
+
+	agentInstance, err := r.deps.AgentFactory.CreateAgent(execCtx)
+	if err != nil {
+		logger.Error("Failed to create sub-agent", "error", err)
+		r.completeSubAgent(exec, agent.ExecutionStatusFailed, "", err.Error())
+		return
+	}
+
+	result, err := agentInstance.Execute(ctx, execCtx, "")
+	if err != nil {
+		status := agent.ExecutionStatusFailed
+		if ctx.Err() == context.DeadlineExceeded {
+			status = agent.ExecutionStatusTimedOut
+		} else if ctx.Err() != nil {
+			status = agent.ExecutionStatusCancelled
+		}
+		logger.Error("Sub-agent execution error", "error", err, "resolved_status", status)
+		r.completeSubAgent(exec, status, "", err.Error())
+		return
+	}
+
+	// BaseAgent wraps controller errors in result.Error (returning (result, nil)).
+	var errMsg string
+	if result.Error != nil {
+		errMsg = result.Error.Error()
+	}
+	r.completeSubAgent(exec, result.Status, result.FinalAnalysis, errMsg)
+}
+
+// completeSubAgent updates the execution record and delivers the result.
+func (r *SubAgentRunner) completeSubAgent(
+	exec *subAgentExecution,
+	status agent.ExecutionStatus,
+	finalAnalysis string,
+	errMsg string,
+) {
+	r.mu.Lock()
+	exec.status = status
+	r.mu.Unlock()
+
+	entStatus := mapToEntStatus(status)
+	if updateErr := r.deps.StageService.UpdateAgentExecutionStatus(
+		context.Background(), exec.executionID, entStatus, errMsg,
+	); updateErr != nil {
+		slog.Warn("Failed to update sub-agent execution status",
+			"execution_id", exec.executionID, "status", status, "error", updateErr)
+	}
+
+	result := &SubAgentResult{
+		ExecutionID: exec.executionID,
+		AgentName:   exec.agentName,
+		Task:        exec.task,
+		Status:      status,
+		Result:      finalAnalysis,
+		Error:       errMsg,
+	}
+
+	// Non-blocking on shutdown: if closeCh is closed (CancelAll during cleanup),
+	// drop the result. The orchestrator is shutting down and won't consume it.
+	// Individual sub-agent cancellations still deliver their result normally.
+	select {
+	case r.resultsCh <- result:
+	case <-r.closeCh:
+	}
+}
+
+// createSubAgentToolExecutor builds a ToolExecutor for the sub-agent's MCP servers.
+func (r *SubAgentRunner) createSubAgentToolExecutor(
+	ctx context.Context,
+	resolvedConfig *agent.ResolvedAgentConfig,
+	logger *slog.Logger,
+) agent.ToolExecutor {
+	if r.deps.MCPFactory != nil && len(resolvedConfig.MCPServers) > 0 {
+		mcpExecutor, _, mcpErr := r.deps.MCPFactory.CreateToolExecutor(
+			ctx, resolvedConfig.MCPServers, nil,
+		)
+		if mcpErr != nil {
+			logger.Warn("Failed to create MCP tool executor for sub-agent, using stub",
+				"error", mcpErr)
+			return agent.NewStubToolExecutor(nil)
+		}
+		return mcpExecutor
+	}
+	return agent.NewStubToolExecutor(nil)
+}
+
+// TryGetNext returns a completed sub-agent result without blocking.
+// Returns (nil, false) if no results are available.
+func (r *SubAgentRunner) TryGetNext() (*SubAgentResult, bool) {
+	select {
+	case result := <-r.resultsCh:
+		atomic.AddInt32(&r.pending, -1)
+		return result, true
+	default:
+		return nil, false
+	}
+}
+
+// WaitForNext blocks until a sub-agent result is available or the context
+// is cancelled. Called when the LLM has no tool calls but sub-agents are
+// still pending.
+func (r *SubAgentRunner) WaitForNext(ctx context.Context) (*SubAgentResult, error) {
+	select {
+	case result := <-r.resultsCh:
+		atomic.AddInt32(&r.pending, -1)
+		return result, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+// HasPending returns true if any sub-agent results have not been consumed.
+func (r *SubAgentRunner) HasPending() bool {
+	return atomic.LoadInt32(&r.pending) > 0
+}
+
+// Cancel cancels a specific sub-agent by execution ID.
+// Returns a human-readable status string.
+func (r *SubAgentRunner) Cancel(executionID string) (string, error) {
+	r.mu.Lock()
+	exec, ok := r.executions[executionID]
+	if !ok {
+		r.mu.Unlock()
+		return "", fmt.Errorf("%w: %s", ErrExecutionNotFound, executionID)
+	}
+	if exec.status != agent.ExecutionStatusActive {
+		status := exec.status
+		r.mu.Unlock()
+		return fmt.Sprintf("already %s", status), nil
+	}
+	r.mu.Unlock()
+
+	exec.cancel()
+	return "cancellation requested", nil
+}
+
+// List returns a snapshot of all dispatched sub-agents and their statuses.
+func (r *SubAgentRunner) List() []SubAgentStatus {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	statuses := make([]SubAgentStatus, 0, len(r.executions))
+	for _, exec := range r.executions {
+		statuses = append(statuses, SubAgentStatus{
+			ExecutionID: exec.executionID,
+			AgentName:   exec.agentName,
+			Task:        exec.task,
+			Status:      exec.status,
+		})
+	}
+	return statuses
+}
+
+// CancelAll cancels all running sub-agent contexts and signals goroutines
+// to drop undelivered results (via closeCh).
+func (r *SubAgentRunner) CancelAll() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	select {
+	case <-r.closeCh:
+		// already closed
+	default:
+		close(r.closeCh)
+	}
+
+	for _, exec := range r.executions {
+		if exec.status == agent.ExecutionStatusActive && exec.cancel != nil {
+			exec.cancel()
+		}
+	}
+}
+
+// WaitAll waits for all sub-agent goroutines to finish. Called during cleanup
+// from CompositeToolExecutor.Close.
+func (r *SubAgentRunner) WaitAll(ctx context.Context) {
+	r.mu.Lock()
+	execs := make([]*subAgentExecution, 0, len(r.executions))
+	for _, exec := range r.executions {
+		execs = append(execs, exec)
+	}
+	r.mu.Unlock()
+
+	for _, exec := range execs {
+		select {
+		case <-exec.done:
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func mapToEntStatus(status agent.ExecutionStatus) agentexecution.Status {
+	switch status {
+	case agent.ExecutionStatusCompleted:
+		return agentexecution.StatusCompleted
+	case agent.ExecutionStatusFailed:
+		return agentexecution.StatusFailed
+	case agent.ExecutionStatusTimedOut:
+		return agentexecution.StatusTimedOut
+	case agent.ExecutionStatusCancelled:
+		return agentexecution.StatusCancelled
+	default:
+		return agentexecution.StatusFailed
+	}
+}

--- a/pkg/agent/orchestrator/runner_test.go
+++ b/pkg/agent/orchestrator/runner_test.go
@@ -1,0 +1,639 @@
+package orchestrator
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/codeready-toolchain/tarsy/pkg/agent"
+	"github.com/codeready-toolchain/tarsy/pkg/config"
+	"github.com/codeready-toolchain/tarsy/pkg/events"
+	"github.com/codeready-toolchain/tarsy/pkg/models"
+	"github.com/codeready-toolchain/tarsy/pkg/services"
+	testdb "github.com/codeready-toolchain/tarsy/test/database"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ─── Channel mechanics tests (no DB) ────────────────────────────────────────
+
+func TestSubAgentRunner_TryGetNext_Empty(t *testing.T) {
+	r := newMinimalRunner(1)
+	result, ok := r.TryGetNext()
+	assert.Nil(t, result)
+	assert.False(t, ok)
+}
+
+func TestSubAgentRunner_TryGetNext_WithResult(t *testing.T) {
+	r := newMinimalRunner(1)
+	atomic.StoreInt32(&r.pending, 1)
+	r.resultsCh <- &SubAgentResult{
+		ExecutionID: "exec-1",
+		AgentName:   "TestAgent",
+		Status:      agent.ExecutionStatusCompleted,
+		Result:      "done",
+	}
+
+	result, ok := r.TryGetNext()
+	require.True(t, ok)
+	assert.Equal(t, "exec-1", result.ExecutionID)
+	assert.Equal(t, agent.ExecutionStatusCompleted, result.Status)
+	assert.False(t, r.HasPending())
+}
+
+func TestSubAgentRunner_WaitForNext_GetsResult(t *testing.T) {
+	r := newMinimalRunner(1)
+	atomic.StoreInt32(&r.pending, 1)
+
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		r.resultsCh <- &SubAgentResult{
+			ExecutionID: "exec-2",
+			Status:      agent.ExecutionStatusCompleted,
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	result, err := r.WaitForNext(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "exec-2", result.ExecutionID)
+	assert.False(t, r.HasPending())
+}
+
+func TestSubAgentRunner_WaitForNext_ContextCancelled(t *testing.T) {
+	r := newMinimalRunner(1)
+	atomic.StoreInt32(&r.pending, 1)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	result, err := r.WaitForNext(ctx)
+	assert.Nil(t, result)
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestSubAgentRunner_HasPending(t *testing.T) {
+	r := newMinimalRunner(5)
+	assert.False(t, r.HasPending())
+
+	atomic.StoreInt32(&r.pending, 3)
+	assert.True(t, r.HasPending())
+
+	atomic.StoreInt32(&r.pending, 0)
+	assert.False(t, r.HasPending())
+}
+
+func TestSubAgentRunner_CancelAll_WaitAll(t *testing.T) {
+	r := newMinimalRunner(5)
+
+	cancelled := make(chan struct{})
+	ctx, ctxCancel := context.WithCancel(context.Background())
+	defer ctxCancel()
+
+	exec1 := &subAgentExecution{
+		executionID: "exec-1",
+		status:      agent.ExecutionStatusActive,
+		cancel: func() {
+			close(cancelled)
+		},
+		done: make(chan struct{}),
+	}
+	r.mu.Lock()
+	r.executions["exec-1"] = exec1
+	r.mu.Unlock()
+
+	// Simulate goroutine completing after cancel
+	go func() {
+		<-cancelled
+		close(exec1.done)
+	}()
+
+	r.CancelAll()
+
+	select {
+	case <-cancelled:
+		// cancel was called
+	case <-time.After(time.Second):
+		t.Fatal("cancel was not called within timeout")
+	}
+
+	r.WaitAll(ctx)
+	// If we get here, WaitAll returned successfully
+}
+
+func TestSubAgentRunner_WaitAll_ContextTimeout(t *testing.T) {
+	r := newMinimalRunner(1)
+	exec := &subAgentExecution{
+		executionID: "stuck",
+		status:      agent.ExecutionStatusActive,
+		cancel:      func() {},
+		done:        make(chan struct{}), // never closes
+	}
+	r.mu.Lock()
+	r.executions["stuck"] = exec
+	r.mu.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	r.WaitAll(ctx)
+	// Should return after timeout without hanging
+}
+
+// ─── Dispatch validation tests (no DB) ──────────────────────────────────────
+
+func TestSubAgentRunner_Dispatch_AgentNotFound(t *testing.T) {
+	r := newMinimalRunner(5)
+
+	_, err := r.Dispatch(context.Background(), "NonExistentAgent", "some task")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrAgentNotFound)
+}
+
+func TestSubAgentRunner_Dispatch_MaxConcurrentExceeded(t *testing.T) {
+	r := newMinimalRunner(1)
+
+	// Pre-populate with an active execution to hit the limit
+	r.mu.Lock()
+	r.executions["existing"] = &subAgentExecution{
+		executionID: "existing",
+		status:      agent.ExecutionStatusActive,
+	}
+	r.mu.Unlock()
+
+	_, err := r.Dispatch(context.Background(), "TestAgent", "some task")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrMaxConcurrentAgents)
+}
+
+// ─── Dispatch integration tests (testcontainers DB + mock agent) ────────────
+
+func TestSubAgentRunner_Dispatch_Success(t *testing.T) {
+	ctx := context.Background()
+	runner, cleanup := setupIntegrationRunner(t, func(_ context.Context) (*agent.ExecutionResult, error) {
+		return &agent.ExecutionResult{
+			Status:        agent.ExecutionStatusCompleted,
+			FinalAnalysis: "investigation complete",
+		}, nil
+	})
+	defer cleanup()
+
+	execID, err := runner.Dispatch(ctx, "TestAgent", "analyze logs")
+	require.NoError(t, err)
+	assert.NotEmpty(t, execID)
+
+	result, err := runner.WaitForNext(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, execID, result.ExecutionID)
+	assert.Equal(t, "TestAgent", result.AgentName)
+	assert.Equal(t, "analyze logs", result.Task)
+	assert.Equal(t, agent.ExecutionStatusCompleted, result.Status)
+	assert.Equal(t, "investigation complete", result.Result)
+	assert.Empty(t, result.Error)
+	assert.False(t, runner.HasPending())
+}
+
+func TestSubAgentRunner_Dispatch_AgentFailure(t *testing.T) {
+	ctx := context.Background()
+	runner, cleanup := setupIntegrationRunner(t, func(_ context.Context) (*agent.ExecutionResult, error) {
+		return &agent.ExecutionResult{
+			Status: agent.ExecutionStatusFailed,
+			Error:  fmt.Errorf("LLM call failed"),
+		}, nil
+	})
+	defer cleanup()
+
+	execID, err := runner.Dispatch(ctx, "TestAgent", "failing task")
+	require.NoError(t, err)
+
+	result, err := runner.WaitForNext(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, execID, result.ExecutionID)
+	assert.Equal(t, agent.ExecutionStatusFailed, result.Status)
+}
+
+func TestSubAgentRunner_Dispatch_AgentError(t *testing.T) {
+	ctx := context.Background()
+	runner, cleanup := setupIntegrationRunner(t, func(_ context.Context) (*agent.ExecutionResult, error) {
+		return nil, fmt.Errorf("infrastructure failure")
+	})
+	defer cleanup()
+
+	_, err := runner.Dispatch(ctx, "TestAgent", "erroring task")
+	require.NoError(t, err)
+
+	result, err := runner.WaitForNext(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, agent.ExecutionStatusFailed, result.Status)
+	assert.Contains(t, result.Error, "infrastructure failure")
+}
+
+func TestSubAgentRunner_Dispatch_Timeout(t *testing.T) {
+	ctx := context.Background()
+	runner, cleanup := setupIntegrationRunner(t, func(runCtx context.Context) (*agent.ExecutionResult, error) {
+		<-runCtx.Done() // blocks until timeout
+		return nil, runCtx.Err()
+	})
+	defer cleanup()
+	runner.guardrails.AgentTimeout = 200 * time.Millisecond
+
+	_, err := runner.Dispatch(ctx, "TestAgent", "slow task")
+	require.NoError(t, err)
+
+	result, err := runner.WaitForNext(ctx)
+	require.NoError(t, err)
+	// The agent sees DeadlineExceeded and maps to TimedOut or Cancelled
+	assert.Contains(t, []agent.ExecutionStatus{
+		agent.ExecutionStatusTimedOut,
+		agent.ExecutionStatusCancelled,
+		agent.ExecutionStatusFailed,
+	}, result.Status)
+}
+
+func TestSubAgentRunner_Cancel_RunningAgent(t *testing.T) {
+	ctx := context.Background()
+	started := make(chan struct{})
+	runner, cleanup := setupIntegrationRunner(t, func(runCtx context.Context) (*agent.ExecutionResult, error) {
+		close(started)
+		<-runCtx.Done()
+		return nil, runCtx.Err()
+	})
+	defer cleanup()
+
+	execID, err := runner.Dispatch(ctx, "TestAgent", "cancellable task")
+	require.NoError(t, err)
+
+	// Wait for the agent to start
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("agent did not start in time")
+	}
+
+	status, err := runner.Cancel(execID)
+	require.NoError(t, err)
+	assert.Equal(t, "cancellation requested", status)
+
+	result, err := runner.WaitForNext(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, execID, result.ExecutionID)
+	assert.Contains(t, []agent.ExecutionStatus{
+		agent.ExecutionStatusCancelled,
+		agent.ExecutionStatusFailed,
+	}, result.Status)
+}
+
+func TestSubAgentRunner_Cancel_NotFound(t *testing.T) {
+	r := newMinimalRunner(5)
+	_, err := r.Cancel("nonexistent")
+	assert.ErrorIs(t, err, ErrExecutionNotFound)
+}
+
+func TestSubAgentRunner_Cancel_AlreadyCompleted(t *testing.T) {
+	r := newMinimalRunner(5)
+	r.mu.Lock()
+	r.executions["done-exec"] = &subAgentExecution{
+		executionID: "done-exec",
+		status:      agent.ExecutionStatusCompleted,
+		cancel:      func() {},
+		done:        make(chan struct{}),
+	}
+	r.mu.Unlock()
+
+	status, err := r.Cancel("done-exec")
+	require.NoError(t, err)
+	assert.Contains(t, status, "already completed")
+}
+
+func TestSubAgentRunner_List(t *testing.T) {
+	r := newMinimalRunner(5)
+	r.mu.Lock()
+	r.executions["e1"] = &subAgentExecution{
+		executionID: "e1", agentName: "AgentA", task: "task A",
+		status: agent.ExecutionStatusActive,
+	}
+	r.executions["e2"] = &subAgentExecution{
+		executionID: "e2", agentName: "AgentB", task: "task B",
+		status: agent.ExecutionStatusCompleted,
+	}
+	r.mu.Unlock()
+
+	statuses := r.List()
+	assert.Len(t, statuses, 2)
+
+	found := make(map[string]SubAgentStatus)
+	for _, s := range statuses {
+		found[s.ExecutionID] = s
+	}
+	assert.Equal(t, agent.ExecutionStatusActive, found["e1"].Status)
+	assert.Equal(t, agent.ExecutionStatusCompleted, found["e2"].Status)
+}
+
+// ─── Concurrent dispatch + result collection (integration) ──────────────────
+
+func TestSubAgentRunner_Dispatch_ConcurrentMultipleAgents(t *testing.T) {
+	ctx := context.Background()
+	runner, cleanup := setupIntegrationRunner(t, func(_ context.Context) (*agent.ExecutionResult, error) {
+		time.Sleep(50 * time.Millisecond) // simulate brief work
+		return &agent.ExecutionResult{
+			Status:        agent.ExecutionStatusCompleted,
+			FinalAnalysis: "done",
+		}, nil
+	})
+	defer cleanup()
+
+	const n = 3
+	execIDs := make([]string, n)
+	for i := 0; i < n; i++ {
+		id, err := runner.Dispatch(ctx, "TestAgent", fmt.Sprintf("task-%d", i))
+		require.NoError(t, err)
+		execIDs[i] = id
+	}
+
+	// Collect all results
+	collected := make(map[string]*SubAgentResult, n)
+	for i := 0; i < n; i++ {
+		result, err := runner.WaitForNext(ctx)
+		require.NoError(t, err)
+		collected[result.ExecutionID] = result
+	}
+
+	assert.Len(t, collected, n)
+	for _, id := range execIDs {
+		r, ok := collected[id]
+		require.True(t, ok, "missing result for %s", id)
+		assert.Equal(t, agent.ExecutionStatusCompleted, r.Status)
+	}
+	assert.False(t, runner.HasPending())
+}
+
+// ─── DB record verification (integration) ───────────────────────────────────
+
+func TestSubAgentRunner_Dispatch_SetsParentExecutionAndTask(t *testing.T) {
+	ctx := context.Background()
+	runner, cleanup := setupIntegrationRunner(t, func(_ context.Context) (*agent.ExecutionResult, error) {
+		return &agent.ExecutionResult{
+			Status:        agent.ExecutionStatusCompleted,
+			FinalAnalysis: "verified",
+		}, nil
+	})
+	defer cleanup()
+
+	execID, err := runner.Dispatch(ctx, "TestAgent", "check DB linkage")
+	require.NoError(t, err)
+
+	// Wait for the sub-agent to complete
+	_, err = runner.WaitForNext(ctx)
+	require.NoError(t, err)
+
+	// Verify the DB record has correct parent linkage and task
+	dbExec, err := runner.deps.StageService.GetAgentExecutionByID(ctx, execID)
+	require.NoError(t, err)
+
+	require.NotNil(t, dbExec.ParentExecutionID, "parent_execution_id should be set")
+	assert.Equal(t, runner.parentExecID, *dbExec.ParentExecutionID)
+
+	require.NotNil(t, dbExec.Task, "task should be set")
+	assert.Equal(t, "check DB linkage", *dbExec.Task)
+
+	assert.Equal(t, "TestAgent", dbExec.AgentName)
+}
+
+// ─── CancelAll idempotent ───────────────────────────────────────────────────
+
+func TestSubAgentRunner_CancelAll_Idempotent(t *testing.T) {
+	r := newMinimalRunner(5)
+	r.mu.Lock()
+	r.executions["e1"] = &subAgentExecution{
+		executionID: "e1",
+		status:      agent.ExecutionStatusActive,
+		cancel:      func() {},
+		done:        make(chan struct{}),
+	}
+	r.mu.Unlock()
+
+	// First call closes closeCh and cancels
+	r.CancelAll()
+	// Second call must not panic (closeCh already closed)
+	r.CancelAll()
+}
+
+// ─── FormatSubAgentResult ───────────────────────────────────────────────────
+
+func TestFormatSubAgentResult_Completed(t *testing.T) {
+	msg := FormatSubAgentResult(&SubAgentResult{
+		ExecutionID: "exec-1",
+		AgentName:   "LogAnalyzer",
+		Status:      agent.ExecutionStatusCompleted,
+		Result:      "Found 42 errors",
+	})
+	assert.Equal(t, agent.RoleUser, msg.Role)
+	assert.Contains(t, msg.Content, "[Sub-agent completed]")
+	assert.Contains(t, msg.Content, "LogAnalyzer")
+	assert.Contains(t, msg.Content, "Found 42 errors")
+}
+
+func TestFormatSubAgentResult_Failed(t *testing.T) {
+	msg := FormatSubAgentResult(&SubAgentResult{
+		ExecutionID: "exec-2",
+		AgentName:   "Checker",
+		Status:      agent.ExecutionStatusFailed,
+		Error:       "connection refused",
+	})
+	assert.Equal(t, agent.RoleUser, msg.Role)
+	assert.Contains(t, msg.Content, "[Sub-agent failed]")
+	assert.Contains(t, msg.Content, "connection refused")
+}
+
+// ─── Test helpers ───────────────────────────────────────────────────────────
+
+// newMinimalRunner creates a SubAgentRunner with a test registry (containing
+// "TestAgent") and no DB deps. Suitable for channel mechanics and validation
+// tests that don't call Dispatch.
+func newMinimalRunner(maxConcurrent int) *SubAgentRunner {
+	registry := config.BuildSubAgentRegistry(map[string]*config.AgentConfig{
+		"TestAgent": {Description: "A test agent"},
+	})
+	return NewSubAgentRunner(
+		&SubAgentDeps{},
+		"parent-exec", "session-1", "stage-1",
+		registry,
+		&OrchestratorGuardrails{
+			MaxConcurrentAgents: maxConcurrent,
+			AgentTimeout:        5 * time.Minute,
+			MaxBudget:           10 * time.Minute,
+		},
+	)
+}
+
+// mockControllerFactory returns a factory that produces controllers
+// calling resultFn when Run is invoked. resultFn receives ctx so tests
+// can respect context cancellation/timeout.
+type mockControllerFactory struct {
+	resultFn func(ctx context.Context) (*agent.ExecutionResult, error)
+}
+
+func (f *mockControllerFactory) CreateController(_ config.AgentType, _ *agent.ExecutionContext) (agent.Controller, error) {
+	return &mockController{resultFn: f.resultFn}, nil
+}
+
+type mockController struct {
+	resultFn func(ctx context.Context) (*agent.ExecutionResult, error)
+}
+
+func (c *mockController) Run(ctx context.Context, _ *agent.ExecutionContext, _ string) (*agent.ExecutionResult, error) {
+	return c.resultFn(ctx)
+}
+
+// Compile-time check that noopEventPublisher satisfies agent.EventPublisher.
+var _ agent.EventPublisher = noopEventPublisher{}
+
+// noopEventPublisher satisfies agent.EventPublisher with no-ops.
+type noopEventPublisher struct{}
+
+func (noopEventPublisher) PublishTimelineCreated(_ context.Context, _ string, _ events.TimelineCreatedPayload) error {
+	return nil
+}
+func (noopEventPublisher) PublishTimelineCompleted(_ context.Context, _ string, _ events.TimelineCompletedPayload) error {
+	return nil
+}
+func (noopEventPublisher) PublishStreamChunk(_ context.Context, _ string, _ events.StreamChunkPayload) error {
+	return nil
+}
+func (noopEventPublisher) PublishSessionStatus(_ context.Context, _ string, _ events.SessionStatusPayload) error {
+	return nil
+}
+func (noopEventPublisher) PublishStageStatus(_ context.Context, _ string, _ events.StageStatusPayload) error {
+	return nil
+}
+func (noopEventPublisher) PublishChatCreated(_ context.Context, _ string, _ events.ChatCreatedPayload) error {
+	return nil
+}
+func (noopEventPublisher) PublishInteractionCreated(_ context.Context, _ string, _ events.InteractionCreatedPayload) error {
+	return nil
+}
+func (noopEventPublisher) PublishSessionProgress(_ context.Context, _ events.SessionProgressPayload) error {
+	return nil
+}
+func (noopEventPublisher) PublishExecutionProgress(_ context.Context, _ string, _ events.ExecutionProgressPayload) error {
+	return nil
+}
+func (noopEventPublisher) PublishExecutionStatus(_ context.Context, _ string, _ events.ExecutionStatusPayload) error {
+	return nil
+}
+
+// setupIntegrationRunner creates a fully wired SubAgentRunner backed by
+// testcontainers PostgreSQL. resultFn controls what the mock agent returns.
+func setupIntegrationRunner(
+	t *testing.T,
+	resultFn func(ctx context.Context) (*agent.ExecutionResult, error),
+) (*SubAgentRunner, func()) {
+	t.Helper()
+
+	dbClient := testdb.NewTestClient(t)
+	ctx := context.Background()
+
+	stageService := services.NewStageService(dbClient.Client)
+	timelineService := services.NewTimelineService(dbClient.Client)
+	messageService := services.NewMessageService(dbClient.Client)
+	interactionService := services.NewInteractionService(dbClient.Client, messageService)
+	mcpRegistry := config.NewMCPServerRegistry(nil)
+	sessionService := services.NewSessionService(
+		dbClient.Client,
+		config.NewChainRegistry(map[string]*config.ChainConfig{
+			"test-chain": {
+				AlertTypes: []string{"test"},
+				Stages: []config.StageConfig{{
+					Name:   "stage1",
+					Agents: []config.StageAgentConfig{{Name: "TestAgent"}},
+				}},
+			},
+		}),
+		mcpRegistry,
+	)
+
+	session, err := sessionService.CreateSession(ctx, models.CreateSessionRequest{
+		SessionID: uuid.New().String(),
+		AlertData: "test alert",
+		AgentType: "test",
+		ChainID:   "test-chain",
+	})
+	require.NoError(t, err)
+
+	// CreateSession creates an initial stage + execution. Query them with edges.
+	stages, err := stageService.GetStagesBySession(ctx, session.ID, true)
+	require.NoError(t, err)
+	require.NotEmpty(t, stages)
+	stageID := stages[0].ID
+
+	// Use the pre-created execution as the parent orchestrator execution.
+	executions, err := stageService.GetAgentExecutions(ctx, stageID)
+	require.NoError(t, err)
+	require.NotEmpty(t, executions)
+	parentExecID := executions[0].ID
+
+	testProvider := &config.LLMProviderConfig{
+		Type:                config.LLMProviderTypeGoogle,
+		Model:               "test-model",
+		MaxToolResultTokens: 10000,
+	}
+
+	cfg := &config.Config{
+		Defaults: &config.Defaults{LLMProvider: "test-provider"},
+		AgentRegistry: config.NewAgentRegistry(map[string]*config.AgentConfig{
+			"TestAgent": {Description: "A test agent"},
+		}),
+		LLMProviderRegistry: config.NewLLMProviderRegistry(map[string]*config.LLMProviderConfig{
+			"test-provider": testProvider,
+		}),
+		MCPServerRegistry: config.NewMCPServerRegistry(nil),
+	}
+
+	chain := &config.ChainConfig{
+		AlertTypes: []string{"test"},
+		Stages: []config.StageConfig{{
+			Name:   "stage1",
+			Agents: []config.StageAgentConfig{{Name: "TestAgent"}},
+		}},
+	}
+
+	agentFactory := agent.NewAgentFactory(&mockControllerFactory{resultFn: resultFn})
+
+	registry := config.BuildSubAgentRegistry(cfg.AgentRegistry.GetAll())
+
+	deps := &SubAgentDeps{
+		Config:             cfg,
+		Chain:              chain,
+		AgentFactory:       agentFactory,
+		MCPFactory:         nil, // sub-agents get stub executor
+		LLMClient:          nil, // controller is mocked, LLM not called
+		EventPublisher:     nil,
+		PromptBuilder:      nil,
+		StageService:       stageService,
+		TimelineService:    timelineService,
+		MessageService:     messageService,
+		InteractionService: interactionService,
+		AlertData:          "test alert",
+		AlertType:          "test",
+	}
+
+	runner := NewSubAgentRunner(
+		deps,
+		parentExecID,
+		session.ID,
+		stageID,
+		registry,
+		&OrchestratorGuardrails{
+			MaxConcurrentAgents: 5,
+			AgentTimeout:        30 * time.Second,
+			MaxBudget:           60 * time.Second,
+		},
+	)
+
+	return runner, func() {}
+}

--- a/pkg/agent/orchestrator/tool_executor.go
+++ b/pkg/agent/orchestrator/tool_executor.go
@@ -1,0 +1,214 @@
+package orchestrator
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/codeready-toolchain/tarsy/pkg/agent"
+	"github.com/codeready-toolchain/tarsy/pkg/config"
+)
+
+// Compile-time check that CompositeToolExecutor implements agent.ToolExecutor.
+var _ agent.ToolExecutor = (*CompositeToolExecutor)(nil)
+
+// CompositeToolExecutor wraps an MCP tool executor and adds orchestration tools
+// (dispatch_agent, cancel_agent, list_agents). It routes calls by name: known
+// orchestration tool names go to the SubAgentRunner; everything else goes to
+// the inner MCP executor.
+type CompositeToolExecutor struct {
+	mcpExecutor agent.ToolExecutor
+	runner      *SubAgentRunner
+	registry    *config.SubAgentRegistry
+}
+
+// NewCompositeToolExecutor creates a composite executor. mcpExecutor may be nil
+// if the orchestrator has no MCP servers of its own.
+func NewCompositeToolExecutor(
+	mcpExecutor agent.ToolExecutor,
+	runner *SubAgentRunner,
+	registry *config.SubAgentRegistry,
+) *CompositeToolExecutor {
+	return &CompositeToolExecutor{
+		mcpExecutor: mcpExecutor,
+		runner:      runner,
+		registry:    registry,
+	}
+}
+
+// ListTools returns the combined tool set: orchestration tools + MCP tools.
+func (c *CompositeToolExecutor) ListTools(ctx context.Context) ([]agent.ToolDefinition, error) {
+	tools := make([]agent.ToolDefinition, len(orchestrationTools))
+	copy(tools, orchestrationTools)
+
+	if c.mcpExecutor != nil {
+		mcpTools, err := c.mcpExecutor.ListTools(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list MCP tools: %w", err)
+		}
+		tools = append(tools, mcpTools...)
+	}
+
+	return tools, nil
+}
+
+// Execute routes the tool call to either the orchestration handler or the MCP executor.
+func (c *CompositeToolExecutor) Execute(ctx context.Context, call agent.ToolCall) (*agent.ToolResult, error) {
+	if orchestrationToolNames[call.Name] {
+		return c.executeOrchestrationTool(ctx, call)
+	}
+	if c.mcpExecutor != nil {
+		return c.mcpExecutor.Execute(ctx, call)
+	}
+	return &agent.ToolResult{
+		CallID:  call.ID,
+		Name:    call.Name,
+		Content: fmt.Sprintf("unknown tool: %s", call.Name),
+		IsError: true,
+	}, nil
+}
+
+// Close cancels any still-running sub-agents, waits for them to finish, then
+// closes the MCP executor.
+//
+// Uses context.Background() intentionally: Close() is called from a defer in
+// executeAgent, where the parent context may already be cancelled. Cleanup must
+// proceed regardless — the 30s timeout is the real upper bound.
+func (c *CompositeToolExecutor) Close() error {
+	c.runner.CancelAll()
+
+	waitCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	c.runner.WaitAll(waitCtx)
+
+	if c.mcpExecutor != nil {
+		return c.mcpExecutor.Close()
+	}
+	return nil
+}
+
+func (c *CompositeToolExecutor) executeOrchestrationTool(ctx context.Context, call agent.ToolCall) (*agent.ToolResult, error) {
+	switch call.Name {
+	case ToolDispatchAgent:
+		return c.handleDispatch(ctx, call)
+	case ToolCancelAgent:
+		return c.handleCancel(ctx, call)
+	case ToolListAgents:
+		return c.handleList(call)
+	default:
+		return &agent.ToolResult{
+			CallID:  call.ID,
+			Name:    call.Name,
+			Content: fmt.Sprintf("unknown orchestration tool: %s", call.Name),
+			IsError: true,
+		}, nil
+	}
+}
+
+func (c *CompositeToolExecutor) handleDispatch(ctx context.Context, call agent.ToolCall) (*agent.ToolResult, error) {
+	var args struct {
+		Name string `json:"name"`
+		Task string `json:"task"`
+	}
+	if err := json.Unmarshal([]byte(call.Arguments), &args); err != nil {
+		return &agent.ToolResult{
+			CallID:  call.ID,
+			Name:    call.Name,
+			Content: fmt.Sprintf("invalid arguments: %v", err),
+			IsError: true,
+		}, nil
+	}
+	if args.Name == "" || args.Task == "" {
+		return &agent.ToolResult{
+			CallID:  call.ID,
+			Name:    call.Name,
+			Content: "both 'name' and 'task' are required",
+			IsError: true,
+		}, nil
+	}
+
+	execID, err := c.runner.Dispatch(ctx, args.Name, args.Task)
+	if err != nil {
+		return &agent.ToolResult{
+			CallID:  call.ID,
+			Name:    call.Name,
+			Content: fmt.Sprintf("dispatch failed: %v", err),
+			IsError: true,
+		}, nil
+	}
+
+	resp, _ := json.Marshal(map[string]string{
+		"execution_id": execID,
+		"status":       "accepted",
+	})
+	return &agent.ToolResult{
+		CallID:  call.ID,
+		Name:    call.Name,
+		Content: string(resp),
+	}, nil
+}
+
+func (c *CompositeToolExecutor) handleCancel(ctx context.Context, call agent.ToolCall) (*agent.ToolResult, error) {
+	var args struct {
+		ExecutionID string `json:"execution_id"`
+	}
+	if err := json.Unmarshal([]byte(call.Arguments), &args); err != nil {
+		return &agent.ToolResult{
+			CallID:  call.ID,
+			Name:    call.Name,
+			Content: fmt.Sprintf("invalid arguments: %v", err),
+			IsError: true,
+		}, nil
+	}
+	if args.ExecutionID == "" {
+		return &agent.ToolResult{
+			CallID:  call.ID,
+			Name:    call.Name,
+			Content: "'execution_id' is required",
+			IsError: true,
+		}, nil
+	}
+
+	status, err := c.runner.Cancel(args.ExecutionID)
+	if err != nil {
+		return &agent.ToolResult{
+			CallID:  call.ID,
+			Name:    call.Name,
+			Content: fmt.Sprintf("cancel failed: %v", err),
+			IsError: true,
+		}, nil
+	}
+
+	return &agent.ToolResult{
+		CallID:  call.ID,
+		Name:    call.Name,
+		Content: fmt.Sprintf("cancel %s: %s", args.ExecutionID, status),
+	}, nil
+}
+
+func (c *CompositeToolExecutor) handleList(call agent.ToolCall) (*agent.ToolResult, error) {
+	statuses := c.runner.List()
+	if len(statuses) == 0 {
+		return &agent.ToolResult{
+			CallID:  call.ID,
+			Name:    call.Name,
+			Content: "No sub-agents dispatched yet.",
+		}, nil
+	}
+
+	var b strings.Builder
+	for i, s := range statuses {
+		if i > 0 {
+			b.WriteByte('\n')
+		}
+		fmt.Fprintf(&b, "- %s (exec %s): status=%s, task=%q",
+			s.AgentName, s.ExecutionID, s.Status, s.Task)
+	}
+	return &agent.ToolResult{
+		CallID:  call.ID,
+		Name:    call.Name,
+		Content: b.String(),
+	}, nil
+}

--- a/pkg/agent/orchestrator/tool_executor.go
+++ b/pkg/agent/orchestrator/tool_executor.go
@@ -14,6 +14,10 @@ import (
 // Compile-time check that CompositeToolExecutor implements agent.ToolExecutor.
 var _ agent.ToolExecutor = (*CompositeToolExecutor)(nil)
 
+// closeTimeout is the maximum time Close() waits for sub-agent goroutines
+// to finish. Package-level var to allow tests to use a short duration.
+var closeTimeout = 30 * time.Second
+
 // CompositeToolExecutor wraps an MCP tool executor and adds orchestration tools
 // (dispatch_agent, cancel_agent, list_agents). It routes calls by name: known
 // orchestration tool names go to the SubAgentRunner; everything else goes to
@@ -79,7 +83,7 @@ func (c *CompositeToolExecutor) Execute(ctx context.Context, call agent.ToolCall
 func (c *CompositeToolExecutor) Close() error {
 	c.runner.CancelAll()
 
-	waitCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	waitCtx, cancel := context.WithTimeout(context.Background(), closeTimeout)
 	defer cancel()
 	c.runner.WaitAll(waitCtx)
 

--- a/pkg/agent/orchestrator/tool_executor_test.go
+++ b/pkg/agent/orchestrator/tool_executor_test.go
@@ -1,0 +1,291 @@
+package orchestrator
+
+import (
+	"context"
+	"encoding/json"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/codeready-toolchain/tarsy/pkg/agent"
+	"github.com/codeready-toolchain/tarsy/pkg/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompositeToolExecutor_ListTools_CombinesMCPAndOrchestration(t *testing.T) {
+	mcpStub := agent.NewStubToolExecutor([]agent.ToolDefinition{
+		{Name: "server1.read_file", Description: "Reads a file"},
+		{Name: "server1.write_file", Description: "Writes a file"},
+	})
+	runner := newMinimalRunner(5)
+	registry := config.BuildSubAgentRegistry(nil)
+
+	c := NewCompositeToolExecutor(mcpStub, runner, registry)
+	tools, err := c.ListTools(context.Background())
+	require.NoError(t, err)
+
+	// Orchestration tools come first, then MCP tools
+	assert.Len(t, tools, len(orchestrationTools)+2)
+	assert.Equal(t, ToolDispatchAgent, tools[0].Name)
+	assert.Equal(t, ToolCancelAgent, tools[1].Name)
+	assert.Equal(t, ToolListAgents, tools[2].Name)
+	assert.Equal(t, "server1.read_file", tools[3].Name)
+	assert.Equal(t, "server1.write_file", tools[4].Name)
+}
+
+func TestCompositeToolExecutor_ListTools_NilMCPExecutor(t *testing.T) {
+	runner := newMinimalRunner(5)
+	registry := config.BuildSubAgentRegistry(nil)
+
+	c := NewCompositeToolExecutor(nil, runner, registry)
+	tools, err := c.ListTools(context.Background())
+	require.NoError(t, err)
+	assert.Len(t, tools, len(orchestrationTools))
+}
+
+func TestCompositeToolExecutor_Execute_DispatchAgent(t *testing.T) {
+	runner := newMinimalRunner(5)
+	// Pre-populate an execution to verify dispatch goes through the runner.
+	// Since runner has no DB deps, dispatch will fail. We assert the error is
+	// returned as a non-fatal tool result (IsError=true), not a Go error.
+	registry := config.BuildSubAgentRegistry(nil)
+	c := NewCompositeToolExecutor(nil, runner, registry)
+
+	args, _ := json.Marshal(map[string]string{"name": "TestAgent", "task": "do something"})
+	result, err := c.Execute(context.Background(), agent.ToolCall{
+		ID:        "call-1",
+		Name:      ToolDispatchAgent,
+		Arguments: string(args),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "call-1", result.CallID)
+	// Runner dispatches to the registry, but StageService is nil.
+	// The dispatch goes through registry validation first. "TestAgent" is in the
+	// registry that was built from a map containing "TestAgent".
+	// But with a nil StageService, it will fail at the CreateAgentExecution step.
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Content, "dispatch failed")
+}
+
+func TestCompositeToolExecutor_Execute_DispatchAgent_ValidationError(t *testing.T) {
+	runner := newMinimalRunner(5)
+	registry := config.BuildSubAgentRegistry(nil)
+	c := NewCompositeToolExecutor(nil, runner, registry)
+
+	t.Run("missing args", func(t *testing.T) {
+		args, _ := json.Marshal(map[string]string{"name": "TestAgent"})
+		result, err := c.Execute(context.Background(), agent.ToolCall{
+			ID: "call-1", Name: ToolDispatchAgent, Arguments: string(args),
+		})
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+		assert.Contains(t, result.Content, "'task' are required")
+	})
+
+	t.Run("bad json", func(t *testing.T) {
+		result, err := c.Execute(context.Background(), agent.ToolCall{
+			ID: "call-2", Name: ToolDispatchAgent, Arguments: "not json",
+		})
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+		assert.Contains(t, result.Content, "invalid arguments")
+	})
+}
+
+func TestCompositeToolExecutor_Execute_CancelAgent(t *testing.T) {
+	runner := newMinimalRunner(5)
+
+	// Pre-populate an active execution in the runner
+	runner.mu.Lock()
+	runner.executions["exec-42"] = &subAgentExecution{
+		executionID: "exec-42",
+		agentName:   "TestAgent",
+		status:      agent.ExecutionStatusActive,
+		cancel:      func() {},
+		done:        make(chan struct{}),
+	}
+	runner.mu.Unlock()
+
+	registry := config.BuildSubAgentRegistry(nil)
+	c := NewCompositeToolExecutor(nil, runner, registry)
+
+	args, _ := json.Marshal(map[string]string{"execution_id": "exec-42"})
+	result, err := c.Execute(context.Background(), agent.ToolCall{
+		ID: "call-3", Name: ToolCancelAgent, Arguments: string(args),
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Content, "cancellation requested")
+}
+
+func TestCompositeToolExecutor_Execute_CancelAgent_ValidationError(t *testing.T) {
+	runner := newMinimalRunner(5)
+	registry := config.BuildSubAgentRegistry(nil)
+	c := NewCompositeToolExecutor(nil, runner, registry)
+
+	t.Run("missing execution_id", func(t *testing.T) {
+		result, err := c.Execute(context.Background(), agent.ToolCall{
+			ID: "call-v1", Name: ToolCancelAgent, Arguments: `{}`,
+		})
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+		assert.Contains(t, result.Content, "'execution_id' is required")
+	})
+
+	t.Run("bad json", func(t *testing.T) {
+		result, err := c.Execute(context.Background(), agent.ToolCall{
+			ID: "call-v2", Name: ToolCancelAgent, Arguments: "not json",
+		})
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+		assert.Contains(t, result.Content, "invalid arguments")
+	})
+}
+
+func TestCompositeToolExecutor_Execute_CancelAgent_NotFound(t *testing.T) {
+	runner := newMinimalRunner(5)
+	registry := config.BuildSubAgentRegistry(nil)
+	c := NewCompositeToolExecutor(nil, runner, registry)
+
+	args, _ := json.Marshal(map[string]string{"execution_id": "nonexistent"})
+	result, err := c.Execute(context.Background(), agent.ToolCall{
+		ID: "call-4", Name: ToolCancelAgent, Arguments: string(args),
+	})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Content, "cancel failed")
+}
+
+func TestCompositeToolExecutor_Execute_ListAgents_Empty(t *testing.T) {
+	runner := newMinimalRunner(5)
+	registry := config.BuildSubAgentRegistry(nil)
+	c := NewCompositeToolExecutor(nil, runner, registry)
+
+	result, err := c.Execute(context.Background(), agent.ToolCall{
+		ID: "call-5", Name: ToolListAgents, Arguments: "{}",
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Content, "No sub-agents dispatched")
+}
+
+func TestCompositeToolExecutor_Execute_ListAgents_WithEntries(t *testing.T) {
+	runner := newMinimalRunner(5)
+	runner.mu.Lock()
+	runner.executions["e1"] = &subAgentExecution{
+		executionID: "e1", agentName: "AgentA", task: "task A",
+		status: agent.ExecutionStatusActive,
+	}
+	runner.mu.Unlock()
+
+	registry := config.BuildSubAgentRegistry(nil)
+	c := NewCompositeToolExecutor(nil, runner, registry)
+
+	result, err := c.Execute(context.Background(), agent.ToolCall{
+		ID: "call-6", Name: ToolListAgents, Arguments: "{}",
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Content, "AgentA")
+	assert.Contains(t, result.Content, "active")
+}
+
+func TestCompositeToolExecutor_Execute_MCPTool(t *testing.T) {
+	mcpStub := agent.NewStubToolExecutor([]agent.ToolDefinition{
+		{Name: "server.read_file"},
+	})
+	runner := newMinimalRunner(5)
+	registry := config.BuildSubAgentRegistry(nil)
+	c := NewCompositeToolExecutor(mcpStub, runner, registry)
+
+	result, err := c.Execute(context.Background(), agent.ToolCall{
+		ID: "call-7", Name: "server.read_file", Arguments: `{"path": "/tmp/foo"}`,
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Content, "server.read_file")
+}
+
+func TestCompositeToolExecutor_Execute_UnknownTool_NilMCP(t *testing.T) {
+	runner := newMinimalRunner(5)
+	registry := config.BuildSubAgentRegistry(nil)
+	c := NewCompositeToolExecutor(nil, runner, registry)
+
+	result, err := c.Execute(context.Background(), agent.ToolCall{
+		ID: "call-8", Name: "nonexistent.tool", Arguments: "{}",
+	})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Content, "unknown tool")
+}
+
+func TestCompositeToolExecutor_Close_CancelsAndWaits(t *testing.T) {
+	runner := newMinimalRunner(5)
+
+	cancelled := int32(0)
+	doneCh := make(chan struct{})
+	runner.mu.Lock()
+	runner.executions["e1"] = &subAgentExecution{
+		executionID: "e1",
+		status:      agent.ExecutionStatusActive,
+		cancel: func() {
+			atomic.AddInt32(&cancelled, 1)
+			close(doneCh)
+		},
+		done: doneCh,
+	}
+	runner.mu.Unlock()
+
+	registry := config.BuildSubAgentRegistry(nil)
+	mcpStub := agent.NewStubToolExecutor(nil)
+	c := NewCompositeToolExecutor(mcpStub, runner, registry)
+
+	err := c.Close()
+	require.NoError(t, err)
+
+	assert.Equal(t, int32(1), atomic.LoadInt32(&cancelled), "cancel should have been called")
+}
+
+func TestCompositeToolExecutor_Close_NilMCPExecutor(t *testing.T) {
+	runner := newMinimalRunner(5)
+	registry := config.BuildSubAgentRegistry(nil)
+	c := NewCompositeToolExecutor(nil, runner, registry)
+
+	err := c.Close()
+	require.NoError(t, err)
+}
+
+func TestCompositeToolExecutor_Close_Timeout(t *testing.T) {
+	runner := newMinimalRunner(5)
+	// Create an execution that never completes
+	runner.mu.Lock()
+	runner.executions["stuck"] = &subAgentExecution{
+		executionID: "stuck",
+		status:      agent.ExecutionStatusActive,
+		cancel:      func() {},
+		done:        make(chan struct{}), // never closed
+	}
+	runner.mu.Unlock()
+
+	registry := config.BuildSubAgentRegistry(nil)
+	c := NewCompositeToolExecutor(nil, runner, registry)
+
+	// Override the close timeout to be short for testing purposes.
+	// Close() uses a hard-coded 30s timeout internally, so we test that
+	// it at least doesn't panic and returns within a reasonable time.
+	// For a more thorough test, we'd need to inject the timeout, but
+	// that's not worth the API complexity.
+	done := make(chan struct{})
+	go func() {
+		_ = c.Close()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Close returned (may have timed out internally, that's fine)
+	case <-time.After(35 * time.Second):
+		t.Fatal("Close did not return within 35 seconds")
+	}
+}

--- a/pkg/agent/orchestrator/types.go
+++ b/pkg/agent/orchestrator/types.go
@@ -77,7 +77,6 @@ type subAgentExecution struct {
 	agentName   string
 	task        string
 	status      agent.ExecutionStatus
-	result      *agent.ExecutionResult
 	cancel      func()
 	done        chan struct{}
 }

--- a/pkg/agent/orchestrator/types.go
+++ b/pkg/agent/orchestrator/types.go
@@ -1,0 +1,152 @@
+// Package orchestrator provides the sub-agent runtime for orchestrator agents.
+// It manages sub-agent goroutine lifecycle, result collection, and tool routing.
+package orchestrator
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/codeready-toolchain/tarsy/pkg/agent"
+	"github.com/codeready-toolchain/tarsy/pkg/config"
+	"github.com/codeready-toolchain/tarsy/pkg/mcp"
+	"github.com/codeready-toolchain/tarsy/pkg/services"
+)
+
+// Sentinel errors for orchestration operations.
+var (
+	ErrAgentNotFound       = errors.New("agent not found in registry")
+	ErrMaxConcurrentAgents = errors.New("max concurrent agents exceeded")
+	ErrExecutionNotFound   = errors.New("execution not found")
+)
+
+// SubAgentDeps bundles dependencies needed by SubAgentRunner to dispatch sub-agents.
+// Services are used instead of raw *ent.Client to follow existing data access patterns.
+type SubAgentDeps struct {
+	Config       *config.Config
+	Chain        *config.ChainConfig
+	AgentFactory *agent.AgentFactory
+	MCPFactory   *mcp.ClientFactory
+
+	LLMClient      agent.LLMClient
+	EventPublisher agent.EventPublisher
+	PromptBuilder  agent.PromptBuilder
+
+	StageService       *services.StageService
+	TimelineService    *services.TimelineService
+	MessageService     *services.MessageService
+	InteractionService *services.InteractionService
+
+	// Orchestrator's session context, passed through to sub-agent ExecutionContexts.
+	AlertData      string
+	AlertType      string
+	RunbookContent string
+}
+
+// OrchestratorGuardrails holds resolved orchestrator limits
+// (defaults.orchestrator merged with per-agent orchestrator config).
+type OrchestratorGuardrails struct {
+	MaxConcurrentAgents int
+	AgentTimeout        time.Duration
+	MaxBudget           time.Duration
+}
+
+// SubAgentResult is the outcome of a completed sub-agent execution.
+// Delivered to the orchestrator via the results channel.
+type SubAgentResult struct {
+	ExecutionID string
+	AgentName   string
+	Task        string
+	Status      agent.ExecutionStatus
+	Result      string // FinalAnalysis text on success
+	Error       string // Error message on failure
+}
+
+// SubAgentStatus is a snapshot of a dispatched sub-agent's state.
+// Returned by SubAgentRunner.List.
+type SubAgentStatus struct {
+	ExecutionID string
+	AgentName   string
+	Task        string
+	Status      agent.ExecutionStatus
+}
+
+// subAgentExecution tracks the state of a single dispatched sub-agent.
+type subAgentExecution struct {
+	executionID string
+	agentName   string
+	task        string
+	status      agent.ExecutionStatus
+	result      *agent.ExecutionResult
+	cancel      func()
+	done        chan struct{}
+}
+
+// Orchestration tool names. Plain names (no dots) — naturally separated
+// from MCP tools which use server.tool format.
+const (
+	ToolDispatchAgent = "dispatch_agent"
+	ToolCancelAgent   = "cancel_agent"
+	ToolListAgents    = "list_agents"
+)
+
+// orchestrationTools defines the tool set exposed to the orchestrator LLM.
+var orchestrationTools = []agent.ToolDefinition{
+	{
+		Name:        ToolDispatchAgent,
+		Description: "Dispatch a sub-agent to execute a task. Returns immediately. Results are automatically delivered when the sub-agent finishes — do not poll.",
+		ParametersSchema: `{
+			"type": "object",
+			"properties": {
+				"name": {"type": "string", "description": "Agent name from the available agents list"},
+				"task": {"type": "string", "description": "Natural language task description"}
+			},
+			"required": ["name", "task"]
+		}`,
+	},
+	{
+		Name:        ToolCancelAgent,
+		Description: "Cancel a running sub-agent.",
+		ParametersSchema: `{
+			"type": "object",
+			"properties": {
+				"execution_id": {"type": "string", "description": "Execution ID from dispatch_agent"}
+			},
+			"required": ["execution_id"]
+		}`,
+	},
+	{
+		Name:        ToolListAgents,
+		Description: "List all dispatched sub-agents and their current status. Use for status overview before deciding to cancel or dispatch more.",
+		ParametersSchema: `{
+			"type": "object",
+			"properties": {}
+		}`,
+	},
+}
+
+// orchestrationToolNames is used for quick lookup when routing tool calls.
+var orchestrationToolNames = map[string]bool{
+	ToolDispatchAgent: true,
+	ToolCancelAgent:   true,
+	ToolListAgents:    true,
+}
+
+// FormatSubAgentResult formats a sub-agent result as a conversation message
+// for injection into the orchestrator's conversation. Used by the controller
+// (PR4) to deliver results between iterations.
+func FormatSubAgentResult(result *SubAgentResult) agent.ConversationMessage {
+	var content string
+	if result.Status == agent.ExecutionStatusCompleted {
+		content = fmt.Sprintf(
+			"[Sub-agent completed] %s (exec %s):\n%s",
+			result.AgentName, result.ExecutionID, result.Result,
+		)
+	} else {
+		content = fmt.Sprintf(
+			"[Sub-agent %s] %s (exec %s): %s",
+			result.Status, result.AgentName, result.ExecutionID, result.Error,
+		)
+	}
+	return agent.ConversationMessage{Role: agent.RoleUser, Content: content}
+}

--- a/pkg/config/sub_agent_registry.go
+++ b/pkg/config/sub_agent_registry.go
@@ -67,6 +67,16 @@ func (e SubAgentEntry) clone() SubAgentEntry {
 	return c
 }
 
+// Get returns the entry for the given agent name, or false if not found.
+func (r *SubAgentRegistry) Get(name string) (SubAgentEntry, bool) {
+	for _, e := range r.entries {
+		if e.Name == name {
+			return e.clone(), true
+		}
+	}
+	return SubAgentEntry{}, false
+}
+
 // Filter returns a new registry containing only agents whose names are in allowedNames.
 // If allowedNames is nil, returns a new registry with a copy of all entries.
 func (r *SubAgentRegistry) Filter(allowedNames []string) *SubAgentRegistry {

--- a/pkg/config/sub_agent_registry_test.go
+++ b/pkg/config/sub_agent_registry_test.go
@@ -158,6 +158,35 @@ func TestBuildSubAgentRegistry_WithBuiltinAgents(t *testing.T) {
 	}
 }
 
+func TestSubAgentRegistry_Get(t *testing.T) {
+	agents := map[string]*AgentConfig{
+		"LogAnalyzer":   {Description: "Analyzes logs", MCPServers: []string{"loki"}},
+		"MetricChecker": {Description: "Checks metrics"},
+	}
+	registry := BuildSubAgentRegistry(agents)
+
+	t.Run("found", func(t *testing.T) {
+		entry, ok := registry.Get("LogAnalyzer")
+		require.True(t, ok)
+		assert.Equal(t, "LogAnalyzer", entry.Name)
+		assert.Equal(t, "Analyzes logs", entry.Description)
+		assert.Equal(t, []string{"loki"}, entry.MCPServers)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		_, ok := registry.Get("NonExistent")
+		assert.False(t, ok)
+	})
+
+	t.Run("returns defensive copy", func(t *testing.T) {
+		entry, ok := registry.Get("LogAnalyzer")
+		require.True(t, ok)
+		entry.MCPServers[0] = "mutated"
+		original, _ := registry.Get("LogAnalyzer")
+		assert.Equal(t, "loki", original.MCPServers[0])
+	})
+}
+
 func TestSubAgentRegistry_Filter(t *testing.T) {
 	agents := map[string]*AgentConfig{
 		"A": {Description: "Agent A"},


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added sub-agent orchestration: SubAgentRunner (dispatch, cancel, list, wait/consume results), CompositeToolExecutor (dispatch/cancel/list tools + optional MCP integration), public orchestration types/errors, guardrails, result formatting API, and registry Get lookup.

* **Tests**
  * Added extensive unit and integration tests covering runner, tool executor, registry, dispatch/cancel flows, timeouts, shutdown, and result propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->