### PR TITLE
Drop Gemini 3.0-pro model and config example update docs

### DIFF
--- a/deploy/config/llm-providers.yaml.example
+++ b/deploy/config/llm-providers.yaml.example
@@ -36,9 +36,9 @@ llm_providers:
       url_context: true
 
   # Next-gen model
-  gemini-3-pro:
+  gemini-3.1-pro:
     type: google
-    model: gemini-3-pro-preview
+    model: gemini-3.1-pro-preview
     api_key_env: GOOGLE_API_KEY
     max_tool_result_tokens: 950000
     native_tools:

--- a/deploy/config/tarsy.yaml.example
+++ b/deploy/config/tarsy.yaml.example
@@ -377,7 +377,7 @@ agent_chains:
         synthesis:
           agent: "SynthesisAgent"
           llm_backend: "google-native"
-          llm_provider: "gemini-3-pro"
+          llm_provider: "gemini-3.1-pro"
 
   # Replica chain (run same agent multiple times)
   kubernetes-2-replicas:
@@ -404,3 +404,37 @@ agent_chains:
       enabled: true
       agent: "ChatAgent"
       max_iterations: 20
+
+  # ── Orchestrator chains ──────────────────────────────────────
+  # The built-in Orchestrator agent dispatches sub-agents dynamically.
+  # No need to define it in agents: — reference it by name.
+
+  # Minimal orchestrator chain — uses defaults for everything
+  orchestrator-minimal:
+    alert_types: ["HighErrorRate"]
+    description: "Orchestrated investigation using built-in Orchestrator"
+    executive_summary_provider: "google-default"
+    stages:
+      - name: "orchestrate"
+        agents:
+          - name: "Orchestrator"
+            sub_agents: [KubernetesAgent, GeneralWorker]
+
+  # Comprehensive orchestrator chain — overrides for orchestrator and sub-agents
+  orchestrator-comprehensive:
+    alert_types: ["LatencySpike", "HighErrorRate-Deep"]
+    description: "Deep orchestrated investigation with custom overrides"
+    executive_summary_provider: "google-default"
+    stages:
+      - name: "orchestrate"
+        agents:
+          - name: "Orchestrator"
+            llm_provider: "gemini-3.1-pro"        # use a more capable model for orchestration
+            llm_backend: "google-native"
+            sub_agents:
+              - name: KubernetesAgent             # built-in: K8s pod/deployment inspection
+              - name: WebResearcher               # built-in: web search + URL analysis
+              - name: CodeExecutor                # built-in: Python code execution
+              - name: GeneralWorker               # built-in: pure reasoning / summarization
+                mcp_servers: [kubernetes-server]  # give GeneralWorker K8s access
+                max_iterations: 5

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -368,7 +368,7 @@ agent_chains:
         agents:
           - name: "KubernetesAgent"
             llm_backend: "google-native"
-            llm_provider: "gemini-3-pro"
+            llm_provider: "gemini-3.1-pro"
             custom_instructions: "Focus on pod health, resource limits, and recent restarts"
           - name: "KubernetesAgent"
             llm_backend: "langchain"

--- a/docs/functional-areas-design.md
+++ b/docs/functional-areas-design.md
@@ -298,7 +298,7 @@ stages:
         llm_backend: "langchain"
     synthesis:
       llm_backend: "google-native"
-      llm_provider: "gemini-3-pro"
+      llm_provider: "gemini-3.1-pro"
 ```
 
 **Replica Parallelism** (same agent runs multiple times):
@@ -695,7 +695,7 @@ Shared convention between Go and Python:
 | `google-default` | google | gemini-3-flash-preview | 1M |
 | `gemini-2.5-flash` | google | gemini-2.5-flash | 1M |
 | `gemini-2.5-pro` | google | gemini-2.5-pro | 1M |
-| `gemini-3-pro` | google | gemini-3-pro-preview | 1M |
+| `gemini-3.1-pro` | google | gemini-3.1-pro-preview | 1M |
 | `openai-default` | openai | gpt-5.2 | 400K |
 | `anthropic-default` | anthropic | claude-sonnet-4-6 | 1M (beta) |
 | `xai-default` | xai | grok-4-1-fast-reasoning | 2M |

--- a/docs/proposals/dashboard-orchestrator-design.md
+++ b/docs/proposals/dashboard-orchestrator-design.md
@@ -1,0 +1,208 @@
+# Dashboard Orchestrator Support — Implementation Design
+
+**Status:** Draft — pending decisions from [dashboard-orchestrator-questions.md](dashboard-orchestrator-questions.md)
+**Related:** [orchestrator-impl-design.md](orchestrator-impl-design.md)
+**Last updated:** 2026-02-26
+
+## Overview
+
+This document designs the dashboard changes needed to display orchestrator agent executions with clear parent-child hierarchy. The backend (PR0–PR6) already serves nested sub-agent data in API responses and publishes WebSocket events for sub-agent executions. The dashboard must surface this data in both the Reasoning view (SessionDetailPage) and the Trace view (TracePage), with real-time streaming support.
+
+The core challenge: orchestrator sub-agents are not parallel agents (statically defined at config time) — they're dynamically dispatched at runtime. The dashboard must show **when** they were dispatched, **what task** they received, their **real-time progress**, and their **results** — all nested under the parent orchestrator execution.
+
+## Design Principles
+
+1. **Backend already done.** The API responses (`ExecutionOverview.sub_agents`, `TraceExecutionGroup.sub_agents`) already nest sub-agents correctly. The dashboard consumes existing data — no new API endpoints needed.
+
+2. **Reuse existing components.** The dashboard has battle-tested patterns for parallel agents (tabbed views, agent cards, streaming renderers). Adapt these for orchestrator sub-agents rather than building from scratch.
+
+3. **Progressive disclosure.** Show the orchestrator's own reasoning flow at the top level. Sub-agent details are available via expand/drill-down, not forced onto the user.
+
+4. **Real-time from day one.** Sub-agent progress must stream in real-time, matching the existing experience for regular agents. No "refresh to see sub-agent results."
+
+## Architecture
+
+### What the Backend Already Provides
+
+**Session Detail API** (`GET /sessions/:id`):
+- `ExecutionOverview` includes `parent_execution_id`, `task`, and `sub_agents: ExecutionOverview[]`
+- Top-level `stages[].executions[]` only has orchestrator (parent) executions
+- Sub-agents are nested inside their parent's `sub_agents` array
+
+**Trace API** (`GET /sessions/:id/trace`):
+- `TraceExecutionGroup` includes `sub_agents: TraceExecutionGroup[]`
+- Top-level `stages[].executions[]` only has orchestrator (parent) executions
+- Sub-agents are nested with their own `llm_interactions` and `mcp_interactions`
+
+**Timeline API** (`GET /sessions/:id/timeline`):
+- Flat list of all timeline events (orchestrator + sub-agents)
+- Each event has `execution_id` — sub-agent events have the sub-agent's execution_id
+- No `parent_execution_id` on timeline events (it's on AgentExecution, not TimelineEvent)
+
+**WebSocket events**:
+- Sub-agents publish the same events: `timeline_event.created`, `stream.chunk`, `execution.status`, `execution.progress`
+- Events carry `execution_id` — the sub-agent's own ID
+- No `parent_execution_id` in event payloads
+
+### Component Change Map
+
+```
+SessionDetailPage ──────── No structural changes. Types + WS handler updates.
+  └─ ConversationTimeline ─ Passes sub-agent overviews to StageContent.
+      └─ StageContent ───── Detects orchestrator executions, renders sub-agent
+                             section below the orchestrator's own items.
+
+TracePage ─────────────── No structural changes. Types update.
+  └─ TraceTimeline ─────── No changes (renders stage accordions as before).
+      └─ StageAccordion ── Detects orchestrator, renders sub-agents.
+          └─ ParallelExecutionTabs ── Handles sub_agents on TraceExecutionGroup
+                                       (or new SubAgentSection component).
+
+Types/session.ts ──── Add parent_execution_id, task, sub_agents to ExecutionOverview.
+Types/events.ts ───── Add parent_execution_id to ExecutionStatusPayload + ExecutionProgressPayload.
+```
+
+### Data Flow for Sub-Agent Events
+
+```
+1. Sub-agent starts → execution.status { execution_id: "sub-123", status: "active" }
+2. Sub-agent streams → timeline_event.created + stream.chunk (execution_id: "sub-123")
+3. Sub-agent completes → execution.status { execution_id: "sub-123", status: "completed" }
+
+Problem: How does the dashboard know "sub-123" belongs to orchestrator "orch-456"?
+
+Solution options:
+  A. Add parent_execution_id to WS event payloads (backend change)
+  B. Build a mapping from REST data (ExecutionOverview.sub_agents)
+  C. Don't map — just re-fetch on sub-agent events
+```
+
+> **Open question:** How to associate sub-agent WS events with their parent orchestrator — see [questions document](dashboard-orchestrator-questions.md), Q1.
+
+## Reasoning View (SessionDetailPage)
+
+### Timeline Item Flow for Orchestrator Stages
+
+When the orchestrator runs, the timeline contains:
+1. **Orchestrator thinking** — LLM reasoning about what to investigate
+2. **dispatch_agent tool calls** — tool call items with `server_name: "orchestrator"`, `tool_name: "dispatch_agent"`
+3. **More thinking** — LLM processing, possibly dispatching more agents
+4. **list_agents / cancel_agent** — status check or cancellation tool calls
+5. **Sub-agent result messages** — injected user-role messages like `[Sub-agent completed] LogAnalyzer (exec abc): ...`
+6. **Final analysis** — orchestrator's synthesized output
+
+All these items already flow through the existing pipeline as normal `FlowItem`s with the orchestrator's `execution_id`. The orchestrator's reasoning view works out of the box.
+
+### Sub-Agent Visibility in Reasoning View
+
+> **Open question:** How to display sub-agent detail in the Reasoning view — see [questions document](dashboard-orchestrator-questions.md), Q2.
+
+### Orchestrator Detection
+
+An execution is an orchestrator if:
+- Its `ExecutionOverview` has `sub_agents` array with length > 0
+- Or: the timeline contains `dispatch_agent` tool calls for this execution (metadata: `server_name: "orchestrator"`, `tool_name: "dispatch_agent"`)
+
+The first approach (REST-based) is more reliable and immediate. The second is a fallback during streaming before REST data is available.
+
+## Trace View (TracePage)
+
+### Current Structure
+
+```
+StageAccordion
+├─ Single agent: metadata box + interaction cards
+└─ Parallel agents: ParallelExecutionTabs (tabs per agent)
+    └─ Per tab: metadata box + interaction cards
+```
+
+### With Orchestrator Sub-Agents
+
+The trace API already nests `sub_agents` inside `TraceExecutionGroup`. The trace view needs to render this nesting.
+
+> **Open question:** How to display sub-agents in the Trace view — see [questions document](dashboard-orchestrator-questions.md), Q3.
+
+### Interaction Count Adjustments
+
+`countStageInteractions` currently sums across `stage.executions[]`. Sub-agents are nested inside parent executions. The function needs to optionally include sub-agent interactions in the count, or show them separately.
+
+> **Open question:** How to count interactions — see [questions document](dashboard-orchestrator-questions.md), Q4.
+
+## TypeScript Type Updates
+
+### `ExecutionOverview` (types/session.ts)
+
+```typescript
+export interface ExecutionOverview {
+  // ... existing fields ...
+  parent_execution_id?: string | null;
+  task?: string | null;
+  sub_agents?: ExecutionOverview[];
+}
+```
+
+These fields already exist in the Go `ExecutionOverview` struct (added in PR2). The TypeScript type just needs to match.
+
+### `TraceExecutionGroup` (types/trace.ts)
+
+Already has `sub_agents?: TraceExecutionGroup[]` — no change needed.
+
+### WebSocket Event Payloads
+
+> **Open question:** Whether to add `parent_execution_id` to WS payloads — see [questions document](dashboard-orchestrator-questions.md), Q1.
+
+## Real-Time Streaming for Sub-Agents
+
+### Timeline Events
+
+Sub-agent timeline events (thinking, tool calls, responses) arrive on the same `session:{id}` WebSocket channel. They have the sub-agent's own `execution_id` and `stage_id` (same stage as the orchestrator).
+
+**Problem:** `StageContent` groups items by `execution_id`. Sub-agent items will create additional execution groups within the same stage, appearing as parallel agents alongside the orchestrator.
+
+> **Open question:** How to handle sub-agent timeline items in the Reasoning view — see [questions document](dashboard-orchestrator-questions.md), Q5.
+
+### Execution Status Events
+
+`execution.status` events for sub-agents carry the sub-agent's `execution_id`. The current `executionStatuses` map in SessionDetailPage stores all execution statuses regardless of parentage.
+
+**Impact on StageContent:** The `mergedExecutions` logic in StageContent builds execution groups from items + streaming + REST overviews + WS statuses. Sub-agent `execution.status` events (with the same `stage_id`) would create phantom agent cards in the orchestrator's stage.
+
+> **Open question:** How to filter sub-agent execution status events — see [questions document](dashboard-orchestrator-questions.md), Q6.
+
+## Dashboard List View (DashboardPage)
+
+No changes needed. `DashboardSessionItem` doesn't include execution-level details. Sessions with orchestrator agents look the same in the list — the chain/stage/status view is sufficient.
+
+## Implementation Phases
+
+> **Open question:** Should this be one PR or split? — see [questions document](dashboard-orchestrator-questions.md), Q7.
+
+### Work Items
+
+1. **Type updates**: Add `parent_execution_id`, `task`, `sub_agents` to `ExecutionOverview`
+2. **Trace view**: Render sub-agents nested under parent in `StageAccordion` / `ParallelExecutionTabs`
+3. **Reasoning view**: Show sub-agent information within the orchestrator's timeline
+4. **Real-time**: Handle sub-agent WS events correctly (filtering, mapping)
+5. **Trace helpers**: Update `findExecutionOverview` to search nested sub-agents; update `countStageInteractions` for sub-agent interactions
+6. **Timeline parser**: Handle sub-agent timeline events (filtering or nesting)
+7. **Testing**: Update/add Vitest tests for new components and modified logic
+
+## Edge Cases
+
+### Orchestrator as Sole Agent in Stage (Common Case)
+The orchestrator is typically the only agent in its stage. StageContent renders it as a single agent (no tabs). Sub-agents appear as a nested section within.
+
+### Orchestrator in Parallel Stage (Rare)
+Multiple agents in the same stage, one of which is an orchestrator. The tabbed view shows all agents; the orchestrator tab has sub-agent nesting inside it.
+
+### Multiple Orchestrators in Same Stage (Edge)
+Each orchestrator has its own sub-agents. Sub-agents are scoped by `parent_execution_id` — no collision.
+
+### Sub-Agent Failure
+Backend sets `status: "failed"` on the sub-agent `ExecutionOverview`. The orchestrator itself may complete successfully. Show the sub-agent failure clearly without implying the orchestrator failed.
+
+### Session Cancellation
+All executions (orchestrator + sub-agents) end up `cancelled`. The dashboard already handles cancelled state — just needs to show it for nested sub-agents too.
+
+### No Sub-Agents Dispatched
+Orchestrator runs but decides no sub-agents are needed (edge case). `sub_agents` is empty. Renders exactly like a normal agent — no special UI.

--- a/docs/proposals/dashboard-orchestrator-questions.md
+++ b/docs/proposals/dashboard-orchestrator-questions.md
@@ -1,0 +1,238 @@
+# Dashboard Orchestrator Support — Design Questions
+
+**Status:** Open — decisions pending
+**Related:** [Design document](dashboard-orchestrator-design.md)
+
+Each question has options with trade-offs and a recommendation. Go through them one by one to form the design, then update the design document.
+
+---
+
+## Q1: How to associate sub-agent WebSocket events with their parent orchestrator?
+
+Sub-agent events (`execution.status`, `execution.progress`, `timeline_event.created`, `stream.chunk`) arrive on the same `session:{id}` channel and carry only `execution_id` — not `parent_execution_id`. The dashboard needs to know which sub-agent belongs to which orchestrator to render events correctly (e.g., avoid creating phantom agent cards in StageContent, route streaming to the right section).
+
+### Option A: Add `parent_execution_id` to WS event payloads (backend change)
+
+Add `parent_execution_id` (nullable) to `ExecutionStatusPayload`, `ExecutionProgressPayload`, `TimelineCreatedPayload`, and `StreamChunkPayload`. Sub-agent events carry their parent's execution ID; regular agents have `null`.
+
+- **Pro:** Dashboard has all info from the event itself — no lookup needed. Clean, deterministic.
+- **Pro:** Minimal frontend complexity. Filter `parent_execution_id != null` events from top-level processing.
+- **Con:** Requires a backend change in PR7 (modifying WS payloads). Small scope — adding one optional field to 4 payload structs.
+
+### Option B: Build a client-side mapping from REST data
+
+On page load, build a `Map<string, string>` (execution_id → parent_execution_id) from `ExecutionOverview.sub_agents`. When WS events arrive, check the map. If the execution_id is in the map, it's a sub-agent.
+
+- **Pro:** No backend changes.
+- **Con:** Race condition: sub-agent WS events can arrive before REST data is loaded (or before a re-fetch captures the new sub-agent). Events during this window create phantom entries.
+- **Con:** Requires re-fetching session detail whenever a new sub-agent is dispatched (to learn about it).
+- **Con:** More complex frontend logic — stale maps, timing-dependent behavior.
+
+### Option C: Hybrid — REST mapping + defensive filtering
+
+Use REST mapping (Option B) for normal operation. Add defensive checks in StageContent: don't create phantom agent cards for unknown execution IDs. Re-fetch session detail on `execution.status` events for unknown IDs to discover new sub-agents.
+
+- **Pro:** No backend changes.
+- **Pro:** Handles the race condition via re-fetch.
+- **Con:** More re-fetches and complex logic.
+- **Con:** Brief UI gaps before sub-agents appear (until re-fetch completes).
+
+**Recommendation:** Option A. A single optional field on WS payloads is a trivial backend change that dramatically simplifies frontend logic. The alternative introduces timing-dependent bugs and extra re-fetches. The field is useful for any future feature that nests executions.
+
+---
+
+## Q2: How to display sub-agent detail in the Reasoning view?
+
+The Reasoning view (SessionDetailPage → ConversationTimeline → StageContent) shows the orchestrator's timeline items. Sub-agents' own timeline items (thinking, tool calls, final_analysis) are separate events with the sub-agent's `execution_id`.
+
+### Option A: Collapsible sub-agent cards within the orchestrator's timeline
+
+After the orchestrator's `dispatch_agent` tool call or after the sub-agent result message, render a collapsible card showing the sub-agent's name, task, status, and (when expanded) its own timeline items. Cards are embedded inline in the orchestrator's reasoning flow.
+
+- **Pro:** Shows the full orchestrator workflow with sub-agents inline — natural reading order.
+- **Pro:** Progressive disclosure — collapsed by default, expand for details.
+- **Con:** Complex rendering — mixing orchestrator FlowItems with sub-agent cards requires careful interleaving.
+- **Con:** Sub-agent timeline items need to be fetched/routed separately from the orchestrator's.
+
+### Option B: Sub-agent summary section below the orchestrator's timeline
+
+After all orchestrator FlowItems, render a "Sub-Agents" section with a card per sub-agent showing: name, task, status, duration, tokens, error. Each card can expand to show the sub-agent's own timeline items.
+
+- **Pro:** Clean separation — orchestrator's reasoning flow is uninterrupted.
+- **Pro:** Simpler implementation — sub-agent cards are a separate section, not interleaved.
+- **Pro:** Natural grouping — all sub-agents visible at a glance with status.
+- **Con:** Less context about **when** each sub-agent was dispatched (temporal relationship is lost).
+
+### Option C: No sub-agent timeline in Reasoning view — summary only
+
+Show sub-agent cards (name, task, status, duration, tokens) below the orchestrator's items, but no drill-down into sub-agent timeline items. Users go to the Trace view for interaction-level detail.
+
+- **Pro:** Simplest implementation.
+- **Pro:** Reasoning view stays focused on the orchestrator's reasoning flow.
+- **Pro:** Trace view is already designed for interaction-level detail.
+- **Con:** Operators can't see sub-agent reasoning without switching views.
+
+**Recommendation:** Option B. Clean separation keeps the orchestrator's reasoning flow readable while providing full sub-agent detail on demand. The temporal relationship is already visible through the orchestrator's `dispatch_agent` tool calls and result messages — operators can see "dispatched LogAnalyzer" in the orchestrator's flow and then expand the LogAnalyzer card below for details.
+
+---
+
+## Q3: How to display sub-agents in the Trace view?
+
+The Trace view (StageAccordion → ParallelExecutionTabs) currently handles parallel agents with tabs. Orchestrator sub-agents are nested inside the parent execution's `TraceExecutionGroup.sub_agents`.
+
+### Option A: Nested section within the parent execution's tab/panel
+
+In the single-agent case (orchestrator is the only agent in stage), show orchestrator's metadata and interactions first, then a "Sub-Agents" section with tabs (one per sub-agent). Each sub-agent tab shows metadata + interaction cards.
+
+In the parallel case (orchestrator is one of multiple agents), the orchestrator's tab panel gets the nested Sub-Agents section.
+
+- **Pro:** Reuses the existing `ParallelExecutionTabs` pattern for sub-agent tabs.
+- **Pro:** Visual hierarchy: stage → orchestrator → sub-agents.
+- **Pro:** Sub-agent interactions are visible without leaving the stage accordion.
+- **Con:** Deep nesting: stage accordion → orchestrator → sub-agent tabs → interaction cards. Can feel cramped.
+
+### Option B: Flat expansion — sub-agents as additional tabs alongside orchestrator
+
+Show the orchestrator as one tab and each sub-agent as additional tabs at the same level. Mark sub-agent tabs visually (indented label, different color, "sub-agent" badge).
+
+- **Pro:** Simple — reuses existing tab infrastructure.
+- **Pro:** Less nesting depth.
+- **Con:** Loses hierarchical relationship — orchestrator and sub-agents appear as peers.
+- **Con:** Confusing when there are also real parallel agents alongside the orchestrator.
+
+### Option C: Tree/accordion within the parent execution
+
+Render sub-agents as mini-accordions inside the parent execution's panel. Each accordion shows the sub-agent name, task, status, and expands to show interactions.
+
+- **Pro:** Compact — sub-agents are collapsed by default.
+- **Pro:** Clear hierarchy within the execution panel.
+- **Con:** Accordions inside accordions (stage accordion → sub-agent accordions) — somewhat cluttered.
+
+**Recommendation:** Option A. The tabbed pattern is already proven for parallel agents. Nesting it inside the orchestrator's execution panel provides clear hierarchy. The nesting depth is acceptable — operators are already used to stage → agent → interaction.
+
+---
+
+## Q4: How to count interactions (including sub-agents)?
+
+`countStageInteractions` sums LLM + MCP interactions across `stage.executions[]`. Sub-agent interactions are nested in `execution.sub_agents[].llm_interactions` and `execution.sub_agents[].mcp_interactions`. The count affects badges on stage accordions and the progress header.
+
+### Option A: Include sub-agent interactions in the total
+
+Recursively count all interactions (orchestrator + sub-agents). The stage shows the true total.
+
+- **Pro:** Accurate total — operators see all work done in the stage.
+- **Con:** A stage with an orchestrator may show "47 LLM interactions" which is misleading — most are from sub-agents.
+
+### Option B: Show separate counts
+
+Show orchestrator interactions and sub-agent interactions separately in the badge: "3 LLM (orchestrator) + 12 LLM (sub-agents)" or similar.
+
+- **Pro:** Clear attribution.
+- **Con:** Cluttered badges. Hard to fit in the current chip layout.
+
+### Option C: Include sub-agent interactions in total with a sub-agent indicator
+
+Total count includes everything, but add a badge like "+ 5 sub-agents" next to the interaction counts.
+
+- **Pro:** Operators see the total scope AND know sub-agents are involved.
+- **Pro:** Fits existing UI — one total count plus a "sub-agents" chip.
+- **Con:** Slightly more complex than Option A.
+
+**Recommendation:** Option C. The total gives operators a sense of scale, and the sub-agent chip signals that nesting is involved. Operators who want the breakdown can expand the stage.
+
+---
+
+## Q5: How to handle sub-agent timeline items in the Reasoning view?
+
+Sub-agent timeline events arrive as flat items in the `GET /sessions/:id/timeline` response and via WS `timeline_event.created`. They have the sub-agent's `execution_id` but the same `stage_id` as the orchestrator. The timeline parser groups items by stage and execution.
+
+### Option A: Filter sub-agent items from the main timeline; show them only in sub-agent cards
+
+During `parseTimelineToFlow`, exclude items whose `execution_id` belongs to a sub-agent (looked up from `ExecutionOverview.sub_agents`). Sub-agent items are fetched/shown only when the user expands a sub-agent card.
+
+- **Pro:** The orchestrator's reasoning flow is clean — only orchestrator items.
+- **Pro:** No phantom agent tabs/cards for sub-agents in StageContent.
+- **Con:** Requires knowing sub-agent execution IDs at parse time (from REST data).
+- **Con:** Sub-agent items arriving via WS before REST data is loaded would briefly appear in the flow.
+
+### Option B: Don't filter — let sub-agents create execution groups in StageContent
+
+Sub-agent items create additional `ExecutionGroup` entries in StageContent's `groupItemsByExecution`. StageContent detects orchestrator vs. parallel using `ExecutionOverview.sub_agents` and renders sub-agent groups differently (as nested cards instead of peer tabs).
+
+- **Pro:** No filtering needed — items flow through the existing pipeline.
+- **Pro:** Real-time: sub-agent items appear immediately as they stream in.
+- **Con:** StageContent becomes more complex — needs to distinguish orchestrator sub-agent groups from parallel agent groups.
+- **Con:** The orchestrator stage would show multiple execution groups (orchestrator + each sub-agent) — the current single-agent path would wrongly switch to multi-agent tabs.
+
+### Option C: Filter at StageContent level — separate sub-agent execution groups
+
+In `parseTimelineToFlow`, don't filter. In StageContent, after grouping by execution, partition groups into "orchestrator" and "sub-agents" using the `ExecutionOverview.sub_agents` mapping. Render the orchestrator group as the main timeline and sub-agent groups in a nested section below.
+
+- **Pro:** Items flow through existing pipeline (no parse-time filtering).
+- **Pro:** Real-time works naturally.
+- **Pro:** Clean separation at the component level.
+- **Con:** StageContent needs the sub-agent ID mapping.
+
+**Recommendation:** Option C. Filtering at the component level is pragmatic — StageContent already receives `executionOverviews` which contain `sub_agents`. It can build the partition map locally. No changes to the timeline parser. Real-time items flow through the standard pipeline and land in the right groups.
+
+---
+
+## Q6: How to filter sub-agent execution status events?
+
+`execution.status` WS events for sub-agents carry the sub-agent's `execution_id` and `stage_id`. The current `executionStatuses` map in SessionDetailPage stores all statuses, and StageContent's `mergedExecutions` creates execution groups from them. Sub-agent status events would create phantom agent cards.
+
+### Option A: Filter using `parent_execution_id` from WS payload (requires Q1 = Option A)
+
+If Q1 is decided as Option A (add `parent_execution_id` to WS payloads), sub-agent status events are identifiable immediately. Store them in a separate `subAgentStatuses` map or filter them out of `executionStatuses`.
+
+- **Pro:** Clean, immediate filtering. No race conditions.
+- **Con:** Depends on Q1 = Option A.
+
+### Option B: Filter using a client-side sub-agent ID set
+
+Build a `Set<string>` of known sub-agent execution IDs from REST `ExecutionOverview.sub_agents`. In the WS handler, skip execution.status events whose ID is in this set (or store them separately).
+
+- **Pro:** No backend change.
+- **Con:** Race condition: sub-agent events arrive before the ID is known. Brief phantom cards.
+
+### Option C: Filter at StageContent level
+
+Don't filter in the WS handler. In StageContent, partition `executionStatuses` into orchestrator and sub-agent using `ExecutionOverview.sub_agents`. Sub-agent statuses go to the nested section, not the main execution group.
+
+- **Pro:** Centralized logic in one component.
+- **Pro:** Works regardless of Q1 decision.
+- **Con:** StageContent becomes responsible for more filtering logic.
+
+**Recommendation:** Option A (if Q1 = A) or Option C (if Q1 ≠ A). With `parent_execution_id` on WS events, filtering at the handler level is cleanest. Without it, StageContent-level partitioning is the pragmatic fallback.
+
+---
+
+## Q7: One PR or split into multiple?
+
+### Option A: Single PR
+
+All dashboard changes in one PR: types, Reasoning view, Trace view, real-time, tests.
+
+- **Pro:** Coherent — everything ships together, no intermediate broken states.
+- **Pro:** Simpler review context — reviewer sees the full picture.
+- **Con:** Larger PR. Dashboard PRs tend to be UI-heavy with many component changes.
+
+### Option B: Two PRs — foundation + views
+
+PR7a: Types, WS payload backend change (Q1), helper updates, sub-agent filtering logic.
+PR7b: Reasoning view sub-agent cards, Trace view nesting, tests.
+
+- **Pro:** Smaller, focused PRs.
+- **Con:** PR7a alone doesn't add visible UI — needs PR7b to be useful.
+- **Con:** Intermediate state where types are updated but UI doesn't use them.
+
+### Option C: Two PRs — Trace first, then Reasoning
+
+PR7a: Types, Trace view sub-agent nesting (simpler — data is already hierarchical in the API).
+PR7b: Reasoning view sub-agent cards, real-time streaming, WS filtering.
+
+- **Pro:** Trace view is simpler and can ship independently.
+- **Pro:** Natural progression: basic visibility first, then rich streaming.
+- **Con:** Two PRs for a single feature.
+
+**Recommendation:** Option A. The dashboard changes are interconnected (types feed both views, WS filtering affects both). A single PR keeps everything coherent. The orchestrator backend was 6 PRs because each layer was independently testable — the dashboard doesn't have that property.

--- a/llm-service/tests/test_google_native.py
+++ b/llm-service/tests/test_google_native.py
@@ -95,7 +95,7 @@ class TestGoogleNativeProvider:
 
     def test_get_thinking_config_default(self, provider):
         """Test thinking config for other models uses default."""
-        config = provider._get_thinking_config("gemini-3.0")
+        config = provider._get_thinking_config("gemini-3.1")
         
         assert config.thinking_level == genai_types.ThinkingLevel.HIGH
         assert config.include_thoughts is True

--- a/pkg/config/builtin.go
+++ b/pkg/config/builtin.go
@@ -193,13 +193,6 @@ func initBuiltinLLMProviders() map[string]LLMProviderConfig {
 			MaxToolResultTokens: 950000, // Conservative for 1M context
 			NativeTools:         geminiNativeTools(),
 		},
-		"gemini-3-pro": {
-			Type:                LLMProviderTypeGoogle,
-			Model:               "gemini-3-pro-preview",
-			APIKeyEnv:           "GOOGLE_API_KEY",
-			MaxToolResultTokens: 950000, // Conservative for 1M context
-			NativeTools:         geminiNativeTools(),
-		},
 		"gemini-3.1-pro": {
 			Type:                LLMProviderTypeGoogle,
 			Model:               "gemini-3.1-pro-preview",

--- a/pkg/config/builtin_test.go
+++ b/pkg/config/builtin_test.go
@@ -270,13 +270,6 @@ func TestBuiltinLLMProviders(t *testing.T) {
 			checkAPIKey:   true,
 		},
 		{
-			name:          "gemini-3-pro",
-			providerID:    "gemini-3-pro",
-			wantType:      LLMProviderTypeGoogle,
-			wantMinTokens: 900000,
-			checkAPIKey:   true,
-		},
-		{
 			name:          "gemini-3.1-pro",
 			providerID:    "gemini-3.1-pro",
 			wantType:      LLMProviderTypeGoogle,


### PR DESCRIPTION
1. Gemini 3.0-pro is being discontinued. We should use 3.1-pro instead.
2. Also update some configuration examples for Orchestrator Agents.
3. Orchistrator Agents Dashboard design docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two new orchestrator chain configurations (minimal and comprehensive) supporting dynamic sub-agent dispatching.
  * Upgraded to Gemini 3.1 provider.

* **Documentation**
  * Added design documentation for dashboard orchestrator support with real-time sub-agent visualization and streaming.
  * Added design guidance and implementation roadmap for orchestration features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->