### PR TITLE
Fix MCP tool calls and default alert

### DIFF
--- a/llm-service/llm/providers/google_native.py
+++ b/llm-service/llm/providers/google_native.py
@@ -27,6 +27,62 @@ EMPTY_RESPONSE_RETRY_DELAY = 3  # seconds
 MODEL_CONTENT_CACHE_TTL = 3600  # 1 hour
 
 
+def _normalize_schema_for_gemini(schema: dict) -> dict:
+    """Normalize JSON Schema for Gemini API compatibility.
+
+    Gemini's FunctionDeclaration expects ``type`` to be a single enum string
+    (e.g. ``"object"``), but JSON Schema allows ``type`` to be a list
+    (e.g. ``["null", "object"]`` for nullable fields). This walks the schema
+    recursively and converts list types to a single type + ``nullable: true``.
+
+    Also flattens ``anyOf``/``oneOf`` nullable wrappers like:
+        {"anyOf": [{"type": "null"}, {"type": "object", ...}]}
+    into:
+        {"type": "object", ..., "nullable": true}
+    """
+    if not isinstance(schema, dict):
+        return schema
+
+    result = dict(schema)
+
+    # --- Handle anyOf / oneOf nullable wrappers ---
+    for keyword in ("anyOf", "oneOf"):
+        variants = result.get(keyword)
+        if not isinstance(variants, list):
+            continue
+        null_variants = [v for v in variants if isinstance(v, dict) and v.get("type") == "null"]
+        non_null = [v for v in variants if v not in null_variants]
+        if null_variants and len(non_null) == 1:
+            merged = {k: v for k, v in result.items() if k != keyword}
+            merged.update(_normalize_schema_for_gemini(non_null[0]))
+            merged["nullable"] = True
+            return merged
+
+    # --- Handle type-as-list  (e.g. ["null", "object"]) ---
+    type_val = result.get("type")
+    if isinstance(type_val, list):
+        non_null_types = [t for t in type_val if t != "null"]
+        if len(non_null_types) < len(type_val):
+            result["nullable"] = True
+        result["type"] = non_null_types[0] if non_null_types else "string"
+
+    # --- Recurse into nested schemas ---
+    if isinstance(result.get("properties"), dict):
+        result["properties"] = {
+            k: _normalize_schema_for_gemini(v)
+            for k, v in result["properties"].items()
+        }
+    if isinstance(result.get("items"), dict):
+        result["items"] = _normalize_schema_for_gemini(result["items"])
+    if isinstance(result.get("additionalProperties"), dict):
+        result["additionalProperties"] = _normalize_schema_for_gemini(result["additionalProperties"])
+    for keyword in ("anyOf", "oneOf", "allOf"):
+        if isinstance(result.get(keyword), list):
+            result[keyword] = [_normalize_schema_for_gemini(v) for v in result[keyword]]
+
+    return result
+
+
 class GoogleNativeProvider(LLMProvider):
     """LLM provider using Google's native genai SDK.
 
@@ -206,6 +262,8 @@ class GoogleNativeProvider(LLMProvider):
                     params = json.loads(tool.parameters_schema) if tool.parameters_schema else {}
                 except json.JSONDecodeError:
                     params = {}
+                if params:
+                    params = _normalize_schema_for_gemini(params)
                 declarations.append(
                     genai_types.FunctionDeclaration(
                         name=tool_name_to_api(tool.name),

--- a/llm-service/tests/test_google_native.py
+++ b/llm-service/tests/test_google_native.py
@@ -1,11 +1,12 @@
 """Tests for GoogleNativeProvider."""
+import json
 import os
 import pytest
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 from google.genai import types as genai_types
 
 from llm_proto import llm_service_pb2 as pb
-from llm.providers.google_native import GoogleNativeProvider
+from llm.providers.google_native import GoogleNativeProvider, _normalize_schema_for_gemini
 from llm.providers.tool_names import tool_name_to_api, tool_name_from_api
 
 pytestmark = pytest.mark.unit
@@ -221,6 +222,33 @@ class TestGoogleNativeProvider:
         
         assert len(result) == 1
         assert hasattr(result[0], "function_declarations")
+
+    def test_convert_tools_normalizes_nullable_type(self, provider):
+        """Test that list-typed nullable schemas are accepted by Gemini SDK after normalization."""
+        tools = [
+            pb.ToolDefinition(
+                name="server.search",
+                description="Search with filter",
+                parameters_schema=json.dumps({
+                    "type": "object",
+                    "properties": {
+                        "query": {"type": "string"},
+                        "contentFilter": {"type": ["null", "object"], "properties": {"key": {"type": "string"}}},
+                    },
+                }),
+            ),
+        ]
+
+        # Should not raise — before normalization this would fail with:
+        # "Input should be 'TYPE_UNSPECIFIED', 'STRING', ... [type=enum, input_value=['null', 'object']]"
+        result = provider._convert_tools(tools, {})
+
+        decl = result[0].function_declarations[0]
+        assert decl.name == "server__search"
+        assert decl.parameters is not None
+        cf = decl.parameters.properties["contentFilter"]
+        assert cf.type == "OBJECT"
+        assert cf.nullable is True
 
     def test_model_content_caching(self, provider):
         """Test model Content caching and retrieval per execution."""
@@ -791,3 +819,75 @@ class TestBuildGroundingDelta:
         assert list(responses[1].grounding.web_search_queries) == ["Euro 2024 winner"]
         assert responses[2].HasField("usage")
         assert responses[3].is_final
+
+
+class TestNormalizeSchemaForGemini:
+    """Test _normalize_schema_for_gemini utility."""
+
+    def test_passthrough_simple_schema(self):
+        schema = {"type": "object", "properties": {"name": {"type": "string"}}}
+        assert _normalize_schema_for_gemini(schema) == schema
+
+    def test_type_list_nullable(self):
+        schema = {"type": ["null", "object"], "properties": {"key": {"type": "string"}}}
+        result = _normalize_schema_for_gemini(schema)
+        assert result["type"] == "object"
+        assert result["nullable"] is True
+        assert result["properties"]["key"]["type"] == "string"
+
+    def test_type_list_non_null_only(self):
+        schema = {"type": ["string"]}
+        result = _normalize_schema_for_gemini(schema)
+        assert result["type"] == "string"
+        assert "nullable" not in result
+
+    def test_type_list_null_only(self):
+        schema = {"type": ["null"]}
+        result = _normalize_schema_for_gemini(schema)
+        assert result["type"] == "string"
+        assert result["nullable"] is True
+
+    def test_nested_properties(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "filter": {
+                    "type": ["null", "object"],
+                    "properties": {"q": {"type": ["null", "string"]}},
+                },
+            },
+        }
+        result = _normalize_schema_for_gemini(schema)
+        filt = result["properties"]["filter"]
+        assert filt["type"] == "object"
+        assert filt["nullable"] is True
+        assert filt["properties"]["q"]["type"] == "string"
+        assert filt["properties"]["q"]["nullable"] is True
+
+    def test_items_normalized(self):
+        schema = {"type": "array", "items": {"type": ["null", "integer"]}}
+        result = _normalize_schema_for_gemini(schema)
+        assert result["items"]["type"] == "integer"
+        assert result["items"]["nullable"] is True
+
+    def test_anyof_nullable_flattened(self):
+        schema = {"anyOf": [{"type": "null"}, {"type": "object", "properties": {"a": {"type": "string"}}}]}
+        result = _normalize_schema_for_gemini(schema)
+        assert result["type"] == "object"
+        assert result["nullable"] is True
+        assert "anyOf" not in result
+
+    def test_oneof_nullable_flattened(self):
+        schema = {"oneOf": [{"type": "null"}, {"type": "string"}]}
+        result = _normalize_schema_for_gemini(schema)
+        assert result["type"] == "string"
+        assert result["nullable"] is True
+        assert "oneOf" not in result
+
+    def test_anyof_non_nullable_preserved(self):
+        schema = {"anyOf": [{"type": "string"}, {"type": "integer"}]}
+        result = _normalize_schema_for_gemini(schema)
+        assert "anyOf" in result
+
+    def test_non_dict_passthrough(self):
+        assert _normalize_schema_for_gemini("not a dict") == "not a dict"

--- a/test/e2e/dashboard_test.go
+++ b/test/e2e/dashboard_test.go
@@ -468,8 +468,9 @@ func TestDashboardEndpoints(t *testing.T) {
 	t.Run("AlertTypes", func(t *testing.T) {
 		types := app.GetAlertTypes(t)
 
-		// Chains sorted alphabetically: concurrency-chain then kubernetes.
-		assert.Equal(t, "concurrency-chain", types["default_chain_id"])
+		// Default alert type "kubernetes" (from builtin defaults) resolves to "kubernetes" chain.
+		assert.Equal(t, "kubernetes", types["default_chain_id"])
+		assert.Equal(t, "kubernetes", types["default_alert_type"])
 
 		alertTypes, ok := types["alert_types"].([]interface{})
 		require.True(t, ok, "alert_types should be an array")

--- a/web/dashboard/src/components/alert/ManualAlertForm.tsx
+++ b/web/dashboard/src/components/alert/ManualAlertForm.tsx
@@ -200,8 +200,11 @@ export function ManualAlertForm() {
 
           setAvailableAlertTypes(finalTypes);
 
-          // Determine default: first type from API
-          const apiDefault = types.length > 0 ? types[0] : '';
+          // Determine default: use configured default from backend, fall back to first type
+          const apiDefault =
+            (resp.default_alert_type && types.includes(resp.default_alert_type))
+              ? resp.default_alert_type
+              : (types.length > 0 ? types[0] : '');
           setDefaultAlertType(apiDefault);
 
           if (resubmitDefault) {

--- a/web/dashboard/src/types/system.ts
+++ b/web/dashboard/src/types/system.ts
@@ -79,6 +79,7 @@ export interface AlertTypeInfo {
 export interface AlertTypesResponse {
   alert_types: AlertTypeInfo[];
   default_chain_id: string;
+  default_alert_type: string;
 }
 
 /** Filter options response. */


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API now returns a default_alert_type field so the backend can specify a configurable default.
  * Alert form now prefers the backend-configured default alert type when present.
  * Tool integration accepts raw JSON Schema for tool parameters and exposes parameter schemas for downstream use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->