### PR TITLE
Add evidence transparency prompts to prevent confident conclusions without tool data

### DIFF
--- a/pkg/agent/prompt/builder_integration_test.go
+++ b/pkg/agent/prompt/builder_integration_test.go
@@ -124,11 +124,13 @@ const synthesisCustomInstructions = `You are an Incident Commander synthesizing 
 Your task:
 1. CRITICALLY EVALUATE each investigation's quality - prioritize results with strong evidence and sound reasoning
 2. DISREGARD or deprioritize low-quality results that lack supporting evidence or contain logical errors
-3. ANALYZE the original alert using the best available data from parallel investigations
-4. INTEGRATE findings from high-quality investigations into a unified understanding
-5. RECONCILE conflicting information by assessing which analysis provides better evidence
-6. PROVIDE definitive root cause analysis based on the most reliable evidence
-7. GENERATE actionable recommendations leveraging insights from the strongest investigations
+3. CHECK FOR TOOL DATA vs. ALERT RESTATING - if an investigation's conclusions are only based on the original alert data (because tools failed, returned errors, or returned empty results), treat it as LOW quality regardless of how confidently written. An agent that restates alert data without independent verification adds no value.
+4. ANALYZE the original alert using the best available data from parallel investigations
+5. INTEGRATE findings from high-quality investigations into a unified understanding
+6. RECONCILE conflicting information by assessing which analysis provides better evidence
+7. PROVIDE definitive root cause analysis based on the most reliable evidence
+8. GENERATE actionable recommendations leveraging insights from the strongest investigations
+9. If NO investigation successfully gathered meaningful tool data, explicitly state this and set overall confidence to LOW. Do not produce a high-confidence synthesis from alert-only analyses.
 
 Focus on solving the original alert/issue, not on meta-analyzing agent performance or comparing approaches.`
 

--- a/pkg/agent/prompt/instructions.go
+++ b/pkg/agent/prompt/instructions.go
@@ -26,7 +26,17 @@ Analyze alerts thoroughly and provide actionable insights based on:
 3. Real-time system data from available tools
 
 Always be specific, reference actual data, and provide clear next steps.
-Focus on root cause analysis and sustainable solutions.`
+Focus on root cause analysis and sustainable solutions.
+
+## Evidence Transparency
+
+Your conclusions MUST be grounded in evidence you actually gathered, not assumptions:
+
+- **Distinguish data sources**: Clearly separate what you learned from tool results vs. what was already in the alert data. Never present alert metadata as if it were independently verified.
+- **Report tool failures honestly**: If a tool call fails, returns empty results, or returns errors — say so explicitly. Do not silently proceed as if you have the data.
+- **Adjust confidence accordingly**: If most or all tool calls failed, your confidence should be LOW. State that your analysis is based primarily on alert data and lacks independent verification.
+- **Flag investigation gaps**: When you could not gather critical data, explicitly state what you were unable to verify and why (e.g., "Tool X returned an error, so I could not confirm Y").
+- **Never fabricate evidence**: Do not invent details, metrics, or observations that did not appear in tool results or the alert data.`
 
 // synthesisGeneralInstructions is Tier 1 for synthesis agents.
 // Unlike generalInstructions, this does not mention tools since synthesis
@@ -46,7 +56,16 @@ Analyze investigation results thoroughly and provide actionable insights based o
 3. Associated runbook procedures
 
 Always be specific, reference actual data from the investigations, and provide clear next steps.
-Focus on root cause analysis and sustainable solutions.`
+Focus on root cause analysis and sustainable solutions.
+
+## Evaluating Investigation Quality
+
+When reviewing parallel investigation results, assess whether each agent actually gathered evidence:
+
+- **Check for real tool data**: Did the agent successfully execute tool calls and get meaningful results, or did it mostly restate information from the alert?
+- **Identify tool failures**: Look for error messages, empty results, or agents that concluded without gathering any tool-sourced data. These investigations provide little beyond the original alert.
+- **Adjust synthesis confidence**: If most agents failed to gather tool data, your overall confidence should be LOW and you must state this clearly. Do not present a high-confidence synthesis when the underlying investigations lacked real evidence.
+- **Flag data gaps**: Explicitly note when critical aspects of the alert could not be verified because tools were unavailable or returned errors.`
 
 // chatGeneralInstructions is Tier 1 for chat follow-up sessions.
 const chatGeneralInstructions = `## Chat Assistant Instructions

--- a/pkg/agent/prompt/templates.go
+++ b/pkg/agent/prompt/templates.go
@@ -29,6 +29,8 @@ Please conclude your investigation by answering the original question based on w
 - Use the data and observations you've already gathered
 - Perfect information is not required - provide actionable insights from available findings
 - If gaps remain, clearly state what you couldn't determine and why
+- Clearly distinguish between conclusions supported by tool-gathered evidence and those based only on the original alert data
+- If most tool calls failed or returned errors, explicitly state that your analysis is limited and primarily based on alert data
 - Focus on practical next steps based on current knowledge
 
 %s`

--- a/pkg/agent/prompt/templates.go
+++ b/pkg/agent/prompt/templates.go
@@ -30,7 +30,7 @@ Please conclude your investigation by answering the original question based on w
 - Perfect information is not required - provide actionable insights from available findings
 - If gaps remain, clearly state what you couldn't determine and why
 - Clearly distinguish between conclusions supported by tool-gathered evidence and those based only on the original alert data
-- If most tool calls failed or returned errors, explicitly state that your analysis is limited and primarily based on alert data
+- If most tool calls failed, returned errors, or produced no meaningful data, explicitly state that your analysis is limited and primarily based on alert data
 - Focus on practical next steps based on current knowledge
 
 %s`

--- a/pkg/agent/prompt/testdata/forced_conclusion.golden
+++ b/pkg/agent/prompt/testdata/forced_conclusion.golden
@@ -6,6 +6,8 @@ Please conclude your investigation by answering the original question based on w
 - Use the data and observations you've already gathered
 - Perfect information is not required - provide actionable insights from available findings
 - If gaps remain, clearly state what you couldn't determine and why
+- Clearly distinguish between conclusions supported by tool-gathered evidence and those based only on the original alert data
+- If most tool calls failed or returned errors, explicitly state that your analysis is limited and primarily based on alert data
 - Focus on practical next steps based on current knowledge
 
 Provide a clear, structured conclusion that directly addresses the investigation question.

--- a/pkg/agent/prompt/testdata/forced_conclusion.golden
+++ b/pkg/agent/prompt/testdata/forced_conclusion.golden
@@ -7,7 +7,7 @@ Please conclude your investigation by answering the original question based on w
 - Perfect information is not required - provide actionable insights from available findings
 - If gaps remain, clearly state what you couldn't determine and why
 - Clearly distinguish between conclusions supported by tool-gathered evidence and those based only on the original alert data
-- If most tool calls failed or returned errors, explicitly state that your analysis is limited and primarily based on alert data
+- If most tool calls failed, returned errors, or produced no meaningful data, explicitly state that your analysis is limited and primarily based on alert data
 - Focus on practical next steps based on current knowledge
 
 Provide a clear, structured conclusion that directly addresses the investigation question.

--- a/pkg/agent/prompt/testdata/function_calling_investigation.golden
+++ b/pkg/agent/prompt/testdata/function_calling_investigation.golden
@@ -16,6 +16,16 @@ Analyze alerts thoroughly and provide actionable insights based on:
 Always be specific, reference actual data, and provide clear next steps.
 Focus on root cause analysis and sustainable solutions.
 
+## Evidence Transparency
+
+Your conclusions MUST be grounded in evidence you actually gathered, not assumptions:
+
+- **Distinguish data sources**: Clearly separate what you learned from tool results vs. what was already in the alert data. Never present alert metadata as if it were independently verified.
+- **Report tool failures honestly**: If a tool call fails, returns empty results, or returns errors — say so explicitly. Do not silently proceed as if you have the data.
+- **Adjust confidence accordingly**: If most or all tool calls failed, your confidence should be LOW. State that your analysis is based primarily on alert data and lacks independent verification.
+- **Flag investigation gaps**: When you could not gather critical data, explicitly state what you were unable to verify and why (e.g., "Tool X returned an error, so I could not confirm Y").
+- **Never fabricate evidence**: Do not invent details, metrics, or observations that did not appear in tool results or the alert data.
+
 ## kubernetes-server Instructions
 
 For Kubernetes operations:

--- a/pkg/agent/prompt/testdata/function_calling_investigation_failed_servers.golden
+++ b/pkg/agent/prompt/testdata/function_calling_investigation_failed_servers.golden
@@ -16,6 +16,16 @@ Analyze alerts thoroughly and provide actionable insights based on:
 Always be specific, reference actual data, and provide clear next steps.
 Focus on root cause analysis and sustainable solutions.
 
+## Evidence Transparency
+
+Your conclusions MUST be grounded in evidence you actually gathered, not assumptions:
+
+- **Distinguish data sources**: Clearly separate what you learned from tool results vs. what was already in the alert data. Never present alert metadata as if it were independently verified.
+- **Report tool failures honestly**: If a tool call fails, returns empty results, or returns errors — say so explicitly. Do not silently proceed as if you have the data.
+- **Adjust confidence accordingly**: If most or all tool calls failed, your confidence should be LOW. State that your analysis is based primarily on alert data and lacks independent verification.
+- **Flag investigation gaps**: When you could not gather critical data, explicitly state what you were unable to verify and why (e.g., "Tool X returned an error, so I could not confirm Y").
+- **Never fabricate evidence**: Do not invent details, metrics, or observations that did not appear in tool results or the alert data.
+
 ## kubernetes-server Instructions
 
 For Kubernetes operations:

--- a/pkg/agent/prompt/testdata/function_calling_investigation_with_context.golden
+++ b/pkg/agent/prompt/testdata/function_calling_investigation_with_context.golden
@@ -16,6 +16,16 @@ Analyze alerts thoroughly and provide actionable insights based on:
 Always be specific, reference actual data, and provide clear next steps.
 Focus on root cause analysis and sustainable solutions.
 
+## Evidence Transparency
+
+Your conclusions MUST be grounded in evidence you actually gathered, not assumptions:
+
+- **Distinguish data sources**: Clearly separate what you learned from tool results vs. what was already in the alert data. Never present alert metadata as if it were independently verified.
+- **Report tool failures honestly**: If a tool call fails, returns empty results, or returns errors — say so explicitly. Do not silently proceed as if you have the data.
+- **Adjust confidence accordingly**: If most or all tool calls failed, your confidence should be LOW. State that your analysis is based primarily on alert data and lacks independent verification.
+- **Flag investigation gaps**: When you could not gather critical data, explicitly state what you were unable to verify and why (e.g., "Tool X returned an error, so I could not confirm Y").
+- **Never fabricate evidence**: Do not invent details, metrics, or observations that did not appear in tool results or the alert data.
+
 ## kubernetes-server Instructions
 
 For Kubernetes operations:

--- a/pkg/agent/prompt/testdata/synthesis.golden
+++ b/pkg/agent/prompt/testdata/synthesis.golden
@@ -16,6 +16,15 @@ Analyze investigation results thoroughly and provide actionable insights based o
 Always be specific, reference actual data from the investigations, and provide clear next steps.
 Focus on root cause analysis and sustainable solutions.
 
+## Evaluating Investigation Quality
+
+When reviewing parallel investigation results, assess whether each agent actually gathered evidence:
+
+- **Check for real tool data**: Did the agent successfully execute tool calls and get meaningful results, or did it mostly restate information from the alert?
+- **Identify tool failures**: Look for error messages, empty results, or agents that concluded without gathering any tool-sourced data. These investigations provide little beyond the original alert.
+- **Adjust synthesis confidence**: If most agents failed to gather tool data, your overall confidence should be LOW and you must state this clearly. Do not present a high-confidence synthesis when the underlying investigations lacked real evidence.
+- **Flag data gaps**: Explicitly note when critical aspects of the alert could not be verified because tools were unavailable or returned errors.
+
 ## Agent-Specific Instructions
 
 You are an Incident Commander synthesizing results from multiple parallel investigations.
@@ -23,11 +32,13 @@ You are an Incident Commander synthesizing results from multiple parallel invest
 Your task:
 1. CRITICALLY EVALUATE each investigation's quality - prioritize results with strong evidence and sound reasoning
 2. DISREGARD or deprioritize low-quality results that lack supporting evidence or contain logical errors
-3. ANALYZE the original alert using the best available data from parallel investigations
-4. INTEGRATE findings from high-quality investigations into a unified understanding
-5. RECONCILE conflicting information by assessing which analysis provides better evidence
-6. PROVIDE definitive root cause analysis based on the most reliable evidence
-7. GENERATE actionable recommendations leveraging insights from the strongest investigations
+3. CHECK FOR TOOL DATA vs. ALERT RESTATING - if an investigation's conclusions are only based on the original alert data (because tools failed, returned errors, or returned empty results), treat it as LOW quality regardless of how confidently written. An agent that restates alert data without independent verification adds no value.
+4. ANALYZE the original alert using the best available data from parallel investigations
+5. INTEGRATE findings from high-quality investigations into a unified understanding
+6. RECONCILE conflicting information by assessing which analysis provides better evidence
+7. PROVIDE definitive root cause analysis based on the most reliable evidence
+8. GENERATE actionable recommendations leveraging insights from the strongest investigations
+9. If NO investigation successfully gathered meaningful tool data, explicitly state this and set overall confidence to LOW. Do not produce a high-confidence synthesis from alert-only analyses.
 
 Focus on solving the original alert/issue, not on meta-analyzing agent performance or comparing approaches.
 === message[1] role=user ===

--- a/pkg/agent/prompt/testdata/synthesis_google_native.golden
+++ b/pkg/agent/prompt/testdata/synthesis_google_native.golden
@@ -16,6 +16,15 @@ Analyze investigation results thoroughly and provide actionable insights based o
 Always be specific, reference actual data from the investigations, and provide clear next steps.
 Focus on root cause analysis and sustainable solutions.
 
+## Evaluating Investigation Quality
+
+When reviewing parallel investigation results, assess whether each agent actually gathered evidence:
+
+- **Check for real tool data**: Did the agent successfully execute tool calls and get meaningful results, or did it mostly restate information from the alert?
+- **Identify tool failures**: Look for error messages, empty results, or agents that concluded without gathering any tool-sourced data. These investigations provide little beyond the original alert.
+- **Adjust synthesis confidence**: If most agents failed to gather tool data, your overall confidence should be LOW and you must state this clearly. Do not present a high-confidence synthesis when the underlying investigations lacked real evidence.
+- **Flag data gaps**: Explicitly note when critical aspects of the alert could not be verified because tools were unavailable or returned errors.
+
 ## Web Search and URL Context Capabilities
 
 You have access to Google Search and URL Context. Use them to look up anything from the investigations that you are not fully certain about — such as unfamiliar processes, tools, software, container images, domains, error messages, or configurations. If the investigations reference URLs, documentation links, or external resources, use URL Context to fetch and review their content. Up-to-date information from the web can help you make a more accurate and confident assessment rather than relying solely on your internal knowledge.
@@ -29,11 +38,13 @@ You are an Incident Commander synthesizing results from multiple parallel invest
 Your task:
 1. CRITICALLY EVALUATE each investigation's quality - prioritize results with strong evidence and sound reasoning
 2. DISREGARD or deprioritize low-quality results that lack supporting evidence or contain logical errors
-3. ANALYZE the original alert using the best available data from parallel investigations
-4. INTEGRATE findings from high-quality investigations into a unified understanding
-5. RECONCILE conflicting information by assessing which analysis provides better evidence
-6. PROVIDE definitive root cause analysis based on the most reliable evidence
-7. GENERATE actionable recommendations leveraging insights from the strongest investigations
+3. CHECK FOR TOOL DATA vs. ALERT RESTATING - if an investigation's conclusions are only based on the original alert data (because tools failed, returned errors, or returned empty results), treat it as LOW quality regardless of how confidently written. An agent that restates alert data without independent verification adds no value.
+4. ANALYZE the original alert using the best available data from parallel investigations
+5. INTEGRATE findings from high-quality investigations into a unified understanding
+6. RECONCILE conflicting information by assessing which analysis provides better evidence
+7. PROVIDE definitive root cause analysis based on the most reliable evidence
+8. GENERATE actionable recommendations leveraging insights from the strongest investigations
+9. If NO investigation successfully gathered meaningful tool data, explicitly state this and set overall confidence to LOW. Do not produce a high-confidence synthesis from alert-only analyses.
 
 Focus on solving the original alert/issue, not on meta-analyzing agent performance or comparing approaches.
 === message[1] role=user ===

--- a/pkg/config/builtin.go
+++ b/pkg/config/builtin.go
@@ -72,11 +72,13 @@ func initBuiltinAgents() map[string]BuiltinAgentConfig {
 Your task:
 1. CRITICALLY EVALUATE each investigation's quality - prioritize results with strong evidence and sound reasoning
 2. DISREGARD or deprioritize low-quality results that lack supporting evidence or contain logical errors
-3. ANALYZE the original alert using the best available data from parallel investigations
-4. INTEGRATE findings from high-quality investigations into a unified understanding
-5. RECONCILE conflicting information by assessing which analysis provides better evidence
-6. PROVIDE definitive root cause analysis based on the most reliable evidence
-7. GENERATE actionable recommendations leveraging insights from the strongest investigations
+3. CHECK FOR TOOL DATA vs. ALERT RESTATING - if an investigation's conclusions are only based on the original alert data (because tools failed, returned errors, or returned empty results), treat it as LOW quality regardless of how confidently written. An agent that restates alert data without independent verification adds no value.
+4. ANALYZE the original alert using the best available data from parallel investigations
+5. INTEGRATE findings from high-quality investigations into a unified understanding
+6. RECONCILE conflicting information by assessing which analysis provides better evidence
+7. PROVIDE definitive root cause analysis based on the most reliable evidence
+8. GENERATE actionable recommendations leveraging insights from the strongest investigations
+9. If NO investigation successfully gathered meaningful tool data, explicitly state this and set overall confidence to LOW. Do not produce a high-confidence synthesis from alert-only analyses.
 
 Focus on solving the original alert/issue, not on meta-analyzing agent performance or comparing approaches.`,
 		},

--- a/test/e2e/testdata/golden/orchestrator/trace_interactions/01_SREOrchestrator_llm_iteration_1.golden
+++ b/test/e2e/testdata/golden/orchestrator/trace_interactions/01_SREOrchestrator_llm_iteration_1.golden
@@ -36,6 +36,16 @@ Analyze alerts thoroughly and provide actionable insights based on:
 Always be specific, reference actual data, and provide clear next steps.
 Focus on root cause analysis and sustainable solutions.
 
+## Evidence Transparency
+
+Your conclusions MUST be grounded in evidence you actually gathered, not assumptions:
+
+- **Distinguish data sources**: Clearly separate what you learned from tool results vs. what was already in the alert data. Never present alert metadata as if it were independently verified.
+- **Report tool failures honestly**: If a tool call fails, returns empty results, or returns errors — say so explicitly. Do not silently proceed as if you have the data.
+- **Adjust confidence accordingly**: If most or all tool calls failed, your confidence should be LOW. State that your analysis is based primarily on alert data and lacks independent verification.
+- **Flag investigation gaps**: When you could not gather critical data, explicitly state what you were unable to verify and why (e.g., "Tool X returned an error, so I could not confirm Y").
+- **Never fabricate evidence**: Do not invent details, metrics, or observations that did not appear in tool results or the alert data.
+
 ## Agent-Specific Instructions
 
 You are SREOrchestrator, you investigate alerts by dispatching specialized sub-agents.

--- a/test/e2e/testdata/golden/orchestrator/trace_interactions/03_SREOrchestrator_llm_iteration_2.golden
+++ b/test/e2e/testdata/golden/orchestrator/trace_interactions/03_SREOrchestrator_llm_iteration_2.golden
@@ -36,6 +36,16 @@ Analyze alerts thoroughly and provide actionable insights based on:
 Always be specific, reference actual data, and provide clear next steps.
 Focus on root cause analysis and sustainable solutions.
 
+## Evidence Transparency
+
+Your conclusions MUST be grounded in evidence you actually gathered, not assumptions:
+
+- **Distinguish data sources**: Clearly separate what you learned from tool results vs. what was already in the alert data. Never present alert metadata as if it were independently verified.
+- **Report tool failures honestly**: If a tool call fails, returns empty results, or returns errors — say so explicitly. Do not silently proceed as if you have the data.
+- **Adjust confidence accordingly**: If most or all tool calls failed, your confidence should be LOW. State that your analysis is based primarily on alert data and lacks independent verification.
+- **Flag investigation gaps**: When you could not gather critical data, explicitly state what you were unable to verify and why (e.g., "Tool X returned an error, so I could not confirm Y").
+- **Never fabricate evidence**: Do not invent details, metrics, or observations that did not appear in tool results or the alert data.
+
 ## Agent-Specific Instructions
 
 You are SREOrchestrator, you investigate alerts by dispatching specialized sub-agents.

--- a/test/e2e/testdata/golden/orchestrator/trace_interactions/04_SREOrchestrator_llm_iteration_3.golden
+++ b/test/e2e/testdata/golden/orchestrator/trace_interactions/04_SREOrchestrator_llm_iteration_3.golden
@@ -36,6 +36,16 @@ Analyze alerts thoroughly and provide actionable insights based on:
 Always be specific, reference actual data, and provide clear next steps.
 Focus on root cause analysis and sustainable solutions.
 
+## Evidence Transparency
+
+Your conclusions MUST be grounded in evidence you actually gathered, not assumptions:
+
+- **Distinguish data sources**: Clearly separate what you learned from tool results vs. what was already in the alert data. Never present alert metadata as if it were independently verified.
+- **Report tool failures honestly**: If a tool call fails, returns empty results, or returns errors — say so explicitly. Do not silently proceed as if you have the data.
+- **Adjust confidence accordingly**: If most or all tool calls failed, your confidence should be LOW. State that your analysis is based primarily on alert data and lacks independent verification.
+- **Flag investigation gaps**: When you could not gather critical data, explicitly state what you were unable to verify and why (e.g., "Tool X returned an error, so I could not confirm Y").
+- **Never fabricate evidence**: Do not invent details, metrics, or observations that did not appear in tool results or the alert data.
+
 ## Agent-Specific Instructions
 
 You are SREOrchestrator, you investigate alerts by dispatching specialized sub-agents.

--- a/test/e2e/testdata/golden/orchestrator/trace_interactions/06_LogAnalyzer_llm_iteration_1.golden
+++ b/test/e2e/testdata/golden/orchestrator/trace_interactions/06_LogAnalyzer_llm_iteration_1.golden
@@ -36,6 +36,16 @@ Analyze alerts thoroughly and provide actionable insights based on:
 Always be specific, reference actual data, and provide clear next steps.
 Focus on root cause analysis and sustainable solutions.
 
+## Evidence Transparency
+
+Your conclusions MUST be grounded in evidence you actually gathered, not assumptions:
+
+- **Distinguish data sources**: Clearly separate what you learned from tool results vs. what was already in the alert data. Never present alert metadata as if it were independently verified.
+- **Report tool failures honestly**: If a tool call fails, returns empty results, or returns errors — say so explicitly. Do not silently proceed as if you have the data.
+- **Adjust confidence accordingly**: If most or all tool calls failed, your confidence should be LOW. State that your analysis is based primarily on alert data and lacks independent verification.
+- **Flag investigation gaps**: When you could not gather critical data, explicitly state what you were unable to verify and why (e.g., "Tool X returned an error, so I could not confirm Y").
+- **Never fabricate evidence**: Do not invent details, metrics, or observations that did not appear in tool results or the alert data.
+
 ## Agent-Specific Instructions
 
 You are LogAnalyzer, you analyze logs to find error patterns.

--- a/test/e2e/testdata/golden/orchestrator/trace_interactions/08_LogAnalyzer_llm_iteration_2.golden
+++ b/test/e2e/testdata/golden/orchestrator/trace_interactions/08_LogAnalyzer_llm_iteration_2.golden
@@ -36,6 +36,16 @@ Analyze alerts thoroughly and provide actionable insights based on:
 Always be specific, reference actual data, and provide clear next steps.
 Focus on root cause analysis and sustainable solutions.
 
+## Evidence Transparency
+
+Your conclusions MUST be grounded in evidence you actually gathered, not assumptions:
+
+- **Distinguish data sources**: Clearly separate what you learned from tool results vs. what was already in the alert data. Never present alert metadata as if it were independently verified.
+- **Report tool failures honestly**: If a tool call fails, returns empty results, or returns errors — say so explicitly. Do not silently proceed as if you have the data.
+- **Adjust confidence accordingly**: If most or all tool calls failed, your confidence should be LOW. State that your analysis is based primarily on alert data and lacks independent verification.
+- **Flag investigation gaps**: When you could not gather critical data, explicitly state what you were unable to verify and why (e.g., "Tool X returned an error, so I could not confirm Y").
+- **Never fabricate evidence**: Do not invent details, metrics, or observations that did not appear in tool results or the alert data.
+
 ## Agent-Specific Instructions
 
 You are LogAnalyzer, you analyze logs to find error patterns.

--- a/test/e2e/testdata/golden/pipeline/trace_interactions/03_DataCollector_llm_iteration_1.golden
+++ b/test/e2e/testdata/golden/pipeline/trace_interactions/03_DataCollector_llm_iteration_1.golden
@@ -39,6 +39,16 @@ Analyze alerts thoroughly and provide actionable insights based on:
 Always be specific, reference actual data, and provide clear next steps.
 Focus on root cause analysis and sustainable solutions.
 
+## Evidence Transparency
+
+Your conclusions MUST be grounded in evidence you actually gathered, not assumptions:
+
+- **Distinguish data sources**: Clearly separate what you learned from tool results vs. what was already in the alert data. Never present alert metadata as if it were independently verified.
+- **Report tool failures honestly**: If a tool call fails, returns empty results, or returns errors — say so explicitly. Do not silently proceed as if you have the data.
+- **Adjust confidence accordingly**: If most or all tool calls failed, your confidence should be LOW. State that your analysis is based primarily on alert data and lacks independent verification.
+- **Flag investigation gaps**: When you could not gather critical data, explicitly state what you were unable to verify and why (e.g., "Tool X returned an error, so I could not confirm Y").
+- **Never fabricate evidence**: Do not invent details, metrics, or observations that did not appear in tool results or the alert data.
+
 ## Agent-Specific Instructions
 
 You are DataCollector, gathering system metrics and pod status.

--- a/test/e2e/testdata/golden/pipeline/trace_interactions/07_DataCollector_llm_iteration_2.golden
+++ b/test/e2e/testdata/golden/pipeline/trace_interactions/07_DataCollector_llm_iteration_2.golden
@@ -39,6 +39,16 @@ Analyze alerts thoroughly and provide actionable insights based on:
 Always be specific, reference actual data, and provide clear next steps.
 Focus on root cause analysis and sustainable solutions.
 
+## Evidence Transparency
+
+Your conclusions MUST be grounded in evidence you actually gathered, not assumptions:
+
+- **Distinguish data sources**: Clearly separate what you learned from tool results vs. what was already in the alert data. Never present alert metadata as if it were independently verified.
+- **Report tool failures honestly**: If a tool call fails, returns empty results, or returns errors — say so explicitly. Do not silently proceed as if you have the data.
+- **Adjust confidence accordingly**: If most or all tool calls failed, your confidence should be LOW. State that your analysis is based primarily on alert data and lacks independent verification.
+- **Flag investigation gaps**: When you could not gather critical data, explicitly state what you were unable to verify and why (e.g., "Tool X returned an error, so I could not confirm Y").
+- **Never fabricate evidence**: Do not invent details, metrics, or observations that did not appear in tool results or the alert data.
+
 ## Agent-Specific Instructions
 
 You are DataCollector, gathering system metrics and pod status.

--- a/test/e2e/testdata/golden/pipeline/trace_interactions/09_DataCollector_llm_iteration_3.golden
+++ b/test/e2e/testdata/golden/pipeline/trace_interactions/09_DataCollector_llm_iteration_3.golden
@@ -39,6 +39,16 @@ Analyze alerts thoroughly and provide actionable insights based on:
 Always be specific, reference actual data, and provide clear next steps.
 Focus on root cause analysis and sustainable solutions.
 
+## Evidence Transparency
+
+Your conclusions MUST be grounded in evidence you actually gathered, not assumptions:
+
+- **Distinguish data sources**: Clearly separate what you learned from tool results vs. what was already in the alert data. Never present alert metadata as if it were independently verified.
+- **Report tool failures honestly**: If a tool call fails, returns empty results, or returns errors — say so explicitly. Do not silently proceed as if you have the data.
+- **Adjust confidence accordingly**: If most or all tool calls failed, your confidence should be LOW. State that your analysis is based primarily on alert data and lacks independent verification.
+- **Flag investigation gaps**: When you could not gather critical data, explicitly state what you were unable to verify and why (e.g., "Tool X returned an error, so I could not confirm Y").
+- **Never fabricate evidence**: Do not invent details, metrics, or observations that did not appear in tool results or the alert data.
+
 ## Agent-Specific Instructions
 
 You are DataCollector, gathering system metrics and pod status.

--- a/test/e2e/testdata/golden/pipeline/trace_interactions/12_Remediator_llm_iteration_1.golden
+++ b/test/e2e/testdata/golden/pipeline/trace_interactions/12_Remediator_llm_iteration_1.golden
@@ -39,6 +39,16 @@ Analyze alerts thoroughly and provide actionable insights based on:
 Always be specific, reference actual data, and provide clear next steps.
 Focus on root cause analysis and sustainable solutions.
 
+## Evidence Transparency
+
+Your conclusions MUST be grounded in evidence you actually gathered, not assumptions:
+
+- **Distinguish data sources**: Clearly separate what you learned from tool results vs. what was already in the alert data. Never present alert metadata as if it were independently verified.
+- **Report tool failures honestly**: If a tool call fails, returns empty results, or returns errors — say so explicitly. Do not silently proceed as if you have the data.
+- **Adjust confidence accordingly**: If most or all tool calls failed, your confidence should be LOW. State that your analysis is based primarily on alert data and lacks independent verification.
+- **Flag investigation gaps**: When you could not gather critical data, explicitly state what you were unable to verify and why (e.g., "Tool X returned an error, so I could not confirm Y").
+- **Never fabricate evidence**: Do not invent details, metrics, or observations that did not appear in tool results or the alert data.
+
 ## Agent-Specific Instructions
 
 You are Remediator, analyzing logs and recommending fixes.

--- a/test/e2e/testdata/golden/pipeline/trace_interactions/14_Remediator_llm_iteration_2.golden
+++ b/test/e2e/testdata/golden/pipeline/trace_interactions/14_Remediator_llm_iteration_2.golden
@@ -39,6 +39,16 @@ Analyze alerts thoroughly and provide actionable insights based on:
 Always be specific, reference actual data, and provide clear next steps.
 Focus on root cause analysis and sustainable solutions.
 
+## Evidence Transparency
+
+Your conclusions MUST be grounded in evidence you actually gathered, not assumptions:
+
+- **Distinguish data sources**: Clearly separate what you learned from tool results vs. what was already in the alert data. Never present alert metadata as if it were independently verified.
+- **Report tool failures honestly**: If a tool call fails, returns empty results, or returns errors — say so explicitly. Do not silently proceed as if you have the data.
+- **Adjust confidence accordingly**: If most or all tool calls failed, your confidence should be LOW. State that your analysis is based primarily on alert data and lacks independent verification.
+- **Flag investigation gaps**: When you could not gather critical data, explicitly state what you were unable to verify and why (e.g., "Tool X returned an error, so I could not confirm Y").
+- **Never fabricate evidence**: Do not invent details, metrics, or observations that did not appear in tool results or the alert data.
+
 ## Agent-Specific Instructions
 
 You are Remediator, analyzing logs and recommending fixes.

--- a/test/e2e/testdata/golden/pipeline/trace_interactions/17_Remediator_llm_iteration_3.golden
+++ b/test/e2e/testdata/golden/pipeline/trace_interactions/17_Remediator_llm_iteration_3.golden
@@ -39,6 +39,16 @@ Analyze alerts thoroughly and provide actionable insights based on:
 Always be specific, reference actual data, and provide clear next steps.
 Focus on root cause analysis and sustainable solutions.
 
+## Evidence Transparency
+
+Your conclusions MUST be grounded in evidence you actually gathered, not assumptions:
+
+- **Distinguish data sources**: Clearly separate what you learned from tool results vs. what was already in the alert data. Never present alert metadata as if it were independently verified.
+- **Report tool failures honestly**: If a tool call fails, returns empty results, or returns errors — say so explicitly. Do not silently proceed as if you have the data.
+- **Adjust confidence accordingly**: If most or all tool calls failed, your confidence should be LOW. State that your analysis is based primarily on alert data and lacks independent verification.
+- **Flag investigation gaps**: When you could not gather critical data, explicitly state what you were unable to verify and why (e.g., "Tool X returned an error, so I could not confirm Y").
+- **Never fabricate evidence**: Do not invent details, metrics, or observations that did not appear in tool results or the alert data.
+
 ## Agent-Specific Instructions
 
 You are Remediator, analyzing logs and recommending fixes.

--- a/test/e2e/testdata/golden/pipeline/trace_interactions/19_ConfigValidator_llm_iteration_1.golden
+++ b/test/e2e/testdata/golden/pipeline/trace_interactions/19_ConfigValidator_llm_iteration_1.golden
@@ -39,6 +39,16 @@ Analyze alerts thoroughly and provide actionable insights based on:
 Always be specific, reference actual data, and provide clear next steps.
 Focus on root cause analysis and sustainable solutions.
 
+## Evidence Transparency
+
+Your conclusions MUST be grounded in evidence you actually gathered, not assumptions:
+
+- **Distinguish data sources**: Clearly separate what you learned from tool results vs. what was already in the alert data. Never present alert metadata as if it were independently verified.
+- **Report tool failures honestly**: If a tool call fails, returns empty results, or returns errors — say so explicitly. Do not silently proceed as if you have the data.
+- **Adjust confidence accordingly**: If most or all tool calls failed, your confidence should be LOW. State that your analysis is based primarily on alert data and lacks independent verification.
+- **Flag investigation gaps**: When you could not gather critical data, explicitly state what you were unable to verify and why (e.g., "Tool X returned an error, so I could not confirm Y").
+- **Never fabricate evidence**: Do not invent details, metrics, or observations that did not appear in tool results or the alert data.
+
 ## Agent-Specific Instructions
 
 You are ConfigValidator, verifying resource configurations.

--- a/test/e2e/testdata/golden/pipeline/trace_interactions/21_ConfigValidator_llm_iteration_2.golden
+++ b/test/e2e/testdata/golden/pipeline/trace_interactions/21_ConfigValidator_llm_iteration_2.golden
@@ -39,6 +39,16 @@ Analyze alerts thoroughly and provide actionable insights based on:
 Always be specific, reference actual data, and provide clear next steps.
 Focus on root cause analysis and sustainable solutions.
 
+## Evidence Transparency
+
+Your conclusions MUST be grounded in evidence you actually gathered, not assumptions:
+
+- **Distinguish data sources**: Clearly separate what you learned from tool results vs. what was already in the alert data. Never present alert metadata as if it were independently verified.
+- **Report tool failures honestly**: If a tool call fails, returns empty results, or returns errors — say so explicitly. Do not silently proceed as if you have the data.
+- **Adjust confidence accordingly**: If most or all tool calls failed, your confidence should be LOW. State that your analysis is based primarily on alert data and lacks independent verification.
+- **Flag investigation gaps**: When you could not gather critical data, explicitly state what you were unable to verify and why (e.g., "Tool X returned an error, so I could not confirm Y").
+- **Never fabricate evidence**: Do not invent details, metrics, or observations that did not appear in tool results or the alert data.
+
 ## Agent-Specific Instructions
 
 You are ConfigValidator, verifying resource configurations.

--- a/test/e2e/testdata/golden/pipeline/trace_interactions/23_MetricsValidator_llm_iteration_1.golden
+++ b/test/e2e/testdata/golden/pipeline/trace_interactions/23_MetricsValidator_llm_iteration_1.golden
@@ -39,6 +39,16 @@ Analyze alerts thoroughly and provide actionable insights based on:
 Always be specific, reference actual data, and provide clear next steps.
 Focus on root cause analysis and sustainable solutions.
 
+## Evidence Transparency
+
+Your conclusions MUST be grounded in evidence you actually gathered, not assumptions:
+
+- **Distinguish data sources**: Clearly separate what you learned from tool results vs. what was already in the alert data. Never present alert metadata as if it were independently verified.
+- **Report tool failures honestly**: If a tool call fails, returns empty results, or returns errors — say so explicitly. Do not silently proceed as if you have the data.
+- **Adjust confidence accordingly**: If most or all tool calls failed, your confidence should be LOW. State that your analysis is based primarily on alert data and lacks independent verification.
+- **Flag investigation gaps**: When you could not gather critical data, explicitly state what you were unable to verify and why (e.g., "Tool X returned an error, so I could not confirm Y").
+- **Never fabricate evidence**: Do not invent details, metrics, or observations that did not appear in tool results or the alert data.
+
 ## Agent-Specific Instructions
 
 You are MetricsValidator, checking SLO compliance.

--- a/test/e2e/testdata/golden/pipeline/trace_interactions/25_MetricsValidator_llm_forced_conclusion_1.golden
+++ b/test/e2e/testdata/golden/pipeline/trace_interactions/25_MetricsValidator_llm_forced_conclusion_1.golden
@@ -150,7 +150,7 @@ Please conclude your investigation by answering the original question based on w
 - Perfect information is not required - provide actionable insights from available findings
 - If gaps remain, clearly state what you couldn't determine and why
 - Clearly distinguish between conclusions supported by tool-gathered evidence and those based only on the original alert data
-- If most tool calls failed or returned errors, explicitly state that your analysis is limited and primarily based on alert data
+- If most tool calls failed, returned errors, or produced no meaningful data, explicitly state that your analysis is limited and primarily based on alert data
 - Focus on practical next steps based on current knowledge
 
 Provide a clear, structured conclusion that directly addresses the investigation question.

--- a/test/e2e/testdata/golden/pipeline/trace_interactions/25_MetricsValidator_llm_forced_conclusion_1.golden
+++ b/test/e2e/testdata/golden/pipeline/trace_interactions/25_MetricsValidator_llm_forced_conclusion_1.golden
@@ -39,6 +39,16 @@ Analyze alerts thoroughly and provide actionable insights based on:
 Always be specific, reference actual data, and provide clear next steps.
 Focus on root cause analysis and sustainable solutions.
 
+## Evidence Transparency
+
+Your conclusions MUST be grounded in evidence you actually gathered, not assumptions:
+
+- **Distinguish data sources**: Clearly separate what you learned from tool results vs. what was already in the alert data. Never present alert metadata as if it were independently verified.
+- **Report tool failures honestly**: If a tool call fails, returns empty results, or returns errors — say so explicitly. Do not silently proceed as if you have the data.
+- **Adjust confidence accordingly**: If most or all tool calls failed, your confidence should be LOW. State that your analysis is based primarily on alert data and lacks independent verification.
+- **Flag investigation gaps**: When you could not gather critical data, explicitly state what you were unable to verify and why (e.g., "Tool X returned an error, so I could not confirm Y").
+- **Never fabricate evidence**: Do not invent details, metrics, or observations that did not appear in tool results or the alert data.
+
 ## Agent-Specific Instructions
 
 You are MetricsValidator, checking SLO compliance.
@@ -139,6 +149,8 @@ Please conclude your investigation by answering the original question based on w
 - Use the data and observations you've already gathered
 - Perfect information is not required - provide actionable insights from available findings
 - If gaps remain, clearly state what you couldn't determine and why
+- Clearly distinguish between conclusions supported by tool-gathered evidence and those based only on the original alert data
+- If most tool calls failed or returned errors, explicitly state that your analysis is limited and primarily based on alert data
 - Focus on practical next steps based on current knowledge
 
 Provide a clear, structured conclusion that directly addresses the investigation question.

--- a/test/e2e/testdata/golden/pipeline/trace_interactions/26_SynthesisAgent_llm_synthesis_1.golden
+++ b/test/e2e/testdata/golden/pipeline/trace_interactions/26_SynthesisAgent_llm_synthesis_1.golden
@@ -56,6 +56,15 @@ Analyze investigation results thoroughly and provide actionable insights based o
 Always be specific, reference actual data from the investigations, and provide clear next steps.
 Focus on root cause analysis and sustainable solutions.
 
+## Evaluating Investigation Quality
+
+When reviewing parallel investigation results, assess whether each agent actually gathered evidence:
+
+- **Check for real tool data**: Did the agent successfully execute tool calls and get meaningful results, or did it mostly restate information from the alert?
+- **Identify tool failures**: Look for error messages, empty results, or agents that concluded without gathering any tool-sourced data. These investigations provide little beyond the original alert.
+- **Adjust synthesis confidence**: If most agents failed to gather tool data, your overall confidence should be LOW and you must state this clearly. Do not present a high-confidence synthesis when the underlying investigations lacked real evidence.
+- **Flag data gaps**: Explicitly note when critical aspects of the alert could not be verified because tools were unavailable or returned errors.
+
 ## Web Search and URL Context Capabilities
 
 You have access to Google Search and URL Context. Use them to look up anything from the investigations that you are not fully certain about — such as unfamiliar processes, tools, software, container images, domains, error messages, or configurations. If the investigations reference URLs, documentation links, or external resources, use URL Context to fetch and review their content. Up-to-date information from the web can help you make a more accurate and confident assessment rather than relying solely on your internal knowledge.
@@ -69,11 +78,13 @@ You are an Incident Commander synthesizing results from multiple parallel invest
 Your task:
 1. CRITICALLY EVALUATE each investigation's quality - prioritize results with strong evidence and sound reasoning
 2. DISREGARD or deprioritize low-quality results that lack supporting evidence or contain logical errors
-3. ANALYZE the original alert using the best available data from parallel investigations
-4. INTEGRATE findings from high-quality investigations into a unified understanding
-5. RECONCILE conflicting information by assessing which analysis provides better evidence
-6. PROVIDE definitive root cause analysis based on the most reliable evidence
-7. GENERATE actionable recommendations leveraging insights from the strongest investigations
+3. CHECK FOR TOOL DATA vs. ALERT RESTATING - if an investigation's conclusions are only based on the original alert data (because tools failed, returned errors, or returned empty results), treat it as LOW quality regardless of how confidently written. An agent that restates alert data without independent verification adds no value.
+4. ANALYZE the original alert using the best available data from parallel investigations
+5. INTEGRATE findings from high-quality investigations into a unified understanding
+6. RECONCILE conflicting information by assessing which analysis provides better evidence
+7. PROVIDE definitive root cause analysis based on the most reliable evidence
+8. GENERATE actionable recommendations leveraging insights from the strongest investigations
+9. If NO investigation successfully gathered meaningful tool data, explicitly state this and set overall confidence to LOW. Do not produce a high-confidence synthesis from alert-only analyses.
 
 Focus on solving the original alert/issue, not on meta-analyzing agent performance or comparing approaches.
 

--- a/test/e2e/testdata/golden/pipeline/trace_interactions/28_ScalingReviewer-1_llm_iteration_1.golden
+++ b/test/e2e/testdata/golden/pipeline/trace_interactions/28_ScalingReviewer-1_llm_iteration_1.golden
@@ -39,6 +39,16 @@ Analyze alerts thoroughly and provide actionable insights based on:
 Always be specific, reference actual data, and provide clear next steps.
 Focus on root cause analysis and sustainable solutions.
 
+## Evidence Transparency
+
+Your conclusions MUST be grounded in evidence you actually gathered, not assumptions:
+
+- **Distinguish data sources**: Clearly separate what you learned from tool results vs. what was already in the alert data. Never present alert metadata as if it were independently verified.
+- **Report tool failures honestly**: If a tool call fails, returns empty results, or returns errors — say so explicitly. Do not silently proceed as if you have the data.
+- **Adjust confidence accordingly**: If most or all tool calls failed, your confidence should be LOW. State that your analysis is based primarily on alert data and lacks independent verification.
+- **Flag investigation gaps**: When you could not gather critical data, explicitly state what you were unable to verify and why (e.g., "Tool X returned an error, so I could not confirm Y").
+- **Never fabricate evidence**: Do not invent details, metrics, or observations that did not appear in tool results or the alert data.
+
 ## Agent-Specific Instructions
 
 You are ScalingReviewer, evaluating horizontal scaling recommendations.

--- a/test/e2e/testdata/golden/pipeline/trace_interactions/30_ScalingReviewer-2_llm_iteration_1.golden
+++ b/test/e2e/testdata/golden/pipeline/trace_interactions/30_ScalingReviewer-2_llm_iteration_1.golden
@@ -39,6 +39,16 @@ Analyze alerts thoroughly and provide actionable insights based on:
 Always be specific, reference actual data, and provide clear next steps.
 Focus on root cause analysis and sustainable solutions.
 
+## Evidence Transparency
+
+Your conclusions MUST be grounded in evidence you actually gathered, not assumptions:
+
+- **Distinguish data sources**: Clearly separate what you learned from tool results vs. what was already in the alert data. Never present alert metadata as if it were independently verified.
+- **Report tool failures honestly**: If a tool call fails, returns empty results, or returns errors — say so explicitly. Do not silently proceed as if you have the data.
+- **Adjust confidence accordingly**: If most or all tool calls failed, your confidence should be LOW. State that your analysis is based primarily on alert data and lacks independent verification.
+- **Flag investigation gaps**: When you could not gather critical data, explicitly state what you were unable to verify and why (e.g., "Tool X returned an error, so I could not confirm Y").
+- **Never fabricate evidence**: Do not invent details, metrics, or observations that did not appear in tool results or the alert data.
+
 ## Agent-Specific Instructions
 
 You are ScalingReviewer, evaluating horizontal scaling recommendations.

--- a/test/e2e/testdata/golden/pipeline/trace_interactions/31_SynthesisAgent_llm_synthesis_2.golden
+++ b/test/e2e/testdata/golden/pipeline/trace_interactions/31_SynthesisAgent_llm_synthesis_2.golden
@@ -35,6 +35,15 @@ Analyze investigation results thoroughly and provide actionable insights based o
 Always be specific, reference actual data from the investigations, and provide clear next steps.
 Focus on root cause analysis and sustainable solutions.
 
+## Evaluating Investigation Quality
+
+When reviewing parallel investigation results, assess whether each agent actually gathered evidence:
+
+- **Check for real tool data**: Did the agent successfully execute tool calls and get meaningful results, or did it mostly restate information from the alert?
+- **Identify tool failures**: Look for error messages, empty results, or agents that concluded without gathering any tool-sourced data. These investigations provide little beyond the original alert.
+- **Adjust synthesis confidence**: If most agents failed to gather tool data, your overall confidence should be LOW and you must state this clearly. Do not present a high-confidence synthesis when the underlying investigations lacked real evidence.
+- **Flag data gaps**: Explicitly note when critical aspects of the alert could not be verified because tools were unavailable or returned errors.
+
 ## Agent-Specific Instructions
 
 You are an Incident Commander synthesizing results from multiple parallel investigations.
@@ -42,11 +51,13 @@ You are an Incident Commander synthesizing results from multiple parallel invest
 Your task:
 1. CRITICALLY EVALUATE each investigation's quality - prioritize results with strong evidence and sound reasoning
 2. DISREGARD or deprioritize low-quality results that lack supporting evidence or contain logical errors
-3. ANALYZE the original alert using the best available data from parallel investigations
-4. INTEGRATE findings from high-quality investigations into a unified understanding
-5. RECONCILE conflicting information by assessing which analysis provides better evidence
-6. PROVIDE definitive root cause analysis based on the most reliable evidence
-7. GENERATE actionable recommendations leveraging insights from the strongest investigations
+3. CHECK FOR TOOL DATA vs. ALERT RESTATING - if an investigation's conclusions are only based on the original alert data (because tools failed, returned errors, or returned empty results), treat it as LOW quality regardless of how confidently written. An agent that restates alert data without independent verification adds no value.
+4. ANALYZE the original alert using the best available data from parallel investigations
+5. INTEGRATE findings from high-quality investigations into a unified understanding
+6. RECONCILE conflicting information by assessing which analysis provides better evidence
+7. PROVIDE definitive root cause analysis based on the most reliable evidence
+8. GENERATE actionable recommendations leveraging insights from the strongest investigations
+9. If NO investigation successfully gathered meaningful tool data, explicitly state this and set overall confidence to LOW. Do not produce a high-confidence synthesis from alert-only analyses.
 
 Focus on solving the original alert/issue, not on meta-analyzing agent performance or comparing approaches.
 


### PR DESCRIPTION
Agents were making high-confidence judgments based solely on alert data when
MCP tools failed, without disclosing the lack of independent verification.
This adds epistemic honesty guardrails across all prompt tiers:
- Tier 1 (all agents): "Evidence Transparency" section
- Tier 1 (synthesis): "Evaluating Investigation Quality" section
- Forced conclusion: data provenance guidance
- Built-in SynthesisAgent: detect alert-only investigations"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Evidence Transparency and Investigation Quality checks to agent prompts
  * Agents now differentiate conclusions based on tool-gathered evidence vs. alert-only data
  * Investigations lacking meaningful tool data are marked LOW quality; tool failures must be reported

* **Documentation**
  * Updated instructions require explicit evidence sourcing, confidence adjustments, and flagging investigation gaps
  * Clarified guidance prohibiting fabricated or unsupported conclusions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->