### PR TITLE
Render exec summary tooltip as MD in list of sessions

### DIFF
--- a/web/dashboard/src/components/dashboard/SessionListItem.tsx
+++ b/web/dashboard/src/components/dashboard/SessionListItem.tsx
@@ -114,7 +114,7 @@ export function SessionListItem({ session, searchTerm }: SessionListItemProps) {
                   </Box>
                   <Divider sx={{ mb: 1.5 }} />
                   <Box sx={executiveSummaryMarkdownStyles}>
-                    <ReactMarkdown>{session.executive_summary}</ReactMarkdown>
+                    <ReactMarkdown skipHtml>{session.executive_summary}</ReactMarkdown>
                   </Box>
                 </Card>
               </Popover>

--- a/web/dashboard/src/components/dashboard/SessionListItem.tsx
+++ b/web/dashboard/src/components/dashboard/SessionListItem.tsx
@@ -32,7 +32,7 @@ import { highlightSearchTermNodes } from '../../utils/search.ts';
 import { formatTimestamp, formatDurationMs } from '../../utils/format.ts';
 import TokenUsageDisplay from '../shared/TokenUsageDisplay.tsx';
 import { sessionDetailPath } from '../../constants/routes.ts';
-import { executiveSummaryMarkdownStyles } from '../../utils/markdownComponents.ts';
+import { executiveSummaryMarkdownStyles } from '../../utils/markdownComponents.tsx';
 import type { DashboardSessionItem } from '../../types/session.ts';
 
 interface SessionListItemProps {

--- a/web/dashboard/src/components/dashboard/SessionListItem.tsx
+++ b/web/dashboard/src/components/dashboard/SessionListItem.tsx
@@ -26,11 +26,13 @@ import {
   Summarize,
 } from '@mui/icons-material';
 import { useNavigate } from 'react-router-dom';
+import ReactMarkdown from 'react-markdown';
 import { StatusBadge } from '../common/StatusBadge.tsx';
 import { highlightSearchTermNodes } from '../../utils/search.ts';
 import { formatTimestamp, formatDurationMs } from '../../utils/format.ts';
 import TokenUsageDisplay from '../shared/TokenUsageDisplay.tsx';
 import { sessionDetailPath } from '../../constants/routes.ts';
+import { executiveSummaryMarkdownStyles } from '../../utils/markdownComponents.ts';
 import type { DashboardSessionItem } from '../../types/session.ts';
 
 interface SessionListItemProps {
@@ -111,9 +113,9 @@ export function SessionListItem({ session, searchTerm }: SessionListItemProps) {
                     </Typography>
                   </Box>
                   <Divider sx={{ mb: 1.5 }} />
-                  <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap' }}>
-                    {session.executive_summary}
-                  </Typography>
+                  <Box sx={executiveSummaryMarkdownStyles}>
+                    <ReactMarkdown>{session.executive_summary}</ReactMarkdown>
+                  </Box>
                 </Card>
               </Popover>
             </>


### PR DESCRIPTION
Assisted-by: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session executive summaries now render Markdown, enabling headings, lists, links, and inline formatting directly in the session list view for richer content.

* **Style**
  * Updated summary presentation with dedicated styling for improved readability and consistent visual appearance across sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->