### PR TITLE
Enable summarization by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ For containerized and OpenShift deployment with OAuth authentication, see **[dep
 - **Flexible Alert Processing**: Accept arbitrary text payloads from any monitoring system
 - **Optional Runbook Integration**: Fetch supplemental guidance from GitHub repositories to steer agent behavior
 - **Data Masking**: Hybrid masking combining structural analysis (Kubernetes Secrets) with regex patterns to protect sensitive data
-- **Tool Result Summarization**: LLM-powered summarization of verbose MCP outputs to reduce token usage and improve reasoning
+- **Tool Result Summarization**: Enabled by default — LLM-powered summarization of verbose MCP outputs (>5K tokens) to reduce token usage and improve reasoning
 
 ### Observability & Operations
 - **SRE Dashboard**: Real-time monitoring with live LLM streaming and interactive chain timeline visualization

--- a/deploy/config/tarsy.yaml.example
+++ b/deploy/config/tarsy.yaml.example
@@ -165,10 +165,13 @@ mcp_servers:
       #     replacement: "[MASKED_CUSTOM]"
       #     description: "Custom secret pattern"
     
-    summarization:
-      enabled: true
-      # size_threshold_tokens: 10000  # Default: 10000 (omit to use default)
-      summary_max_token_limit: 1000
+    # Summarization is enabled by default for all MCP servers.
+    # Large tool results (>5000 tokens) are automatically summarized by an LLM call.
+    # To customize thresholds or disable, uncomment below:
+    # summarization:
+    #   enabled: false                  # Set to false to disable (default: true)
+    #   size_threshold_tokens: 8000     # Override default (5000 tokens)
+    #   summary_max_token_limit: 1000   # Max tokens in summary (default: 1000)
 
   # Example: ArgoCD MCP server
   argocd-server:
@@ -195,9 +198,9 @@ mcp_servers:
       pattern_groups: ["kubernetes"]
       patterns: ["certificate", "token"]
     
+    # Override default summarization threshold for ArgoCD (smaller results are useful)
     summarization:
-      enabled: true
-      size_threshold_tokens: 3000
+      size_threshold_tokens: 3000     # Summarize above 3000 tokens (default: 5000)
 
   # Example: HTTP-based MCP server
   monitoring-server:
@@ -218,9 +221,9 @@ mcp_servers:
       enabled: true
       patterns: ["email", "token"]
     
+    # Disable summarization for this server (monitoring data should be kept raw)
     summarization:
-      enabled: true
-      size_threshold_tokens: 4000
+      enabled: false
 
 # =============================================================================
 # CUSTOM AGENT DEFINITIONS

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -131,7 +131,7 @@ Agents are specialized AI-powered components that analyze alerts using domain ex
 - **Three transport types**: stdio (command-line servers), HTTP (JSON-RPC endpoints), SSE (Server-Sent Events)
 - **Per-agent-execution isolation** -- each agent execution gets its own MCP Client with independent sessions
 - **Data masking** with hybrid approach: code-based structural maskers (K8s Secrets) + regex patterns
-- **Tool result summarization** -- large MCP results are automatically summarized by an LLM call before being sent back to the investigating agent
+- **Tool result summarization** -- enabled by default for all MCP servers; large results (>5K tokens) are automatically summarized by an LLM call before being sent back to the investigating agent (can be disabled per-server)
 - **Health monitoring** -- background service checks server health, attempts recovery, surfaces warnings
 
 ### 6. LLM Multi-Provider Support

--- a/pkg/agent/controller/lifecycle_integration_test.go
+++ b/pkg/agent/controller/lifecycle_integration_test.go
@@ -210,7 +210,6 @@ func TestIteratingController_SummarizationIntegration(t *testing.T) {
 	registry := config.NewMCPServerRegistry(map[string]*config.MCPServerConfig{
 		"k8s": {
 			Summarization: &config.SummarizationConfig{
-				Enabled:              true,
 				SizeThresholdTokens:  100, // Low threshold to trigger summarization
 				SummaryMaxTokenLimit: 500,
 			},
@@ -266,7 +265,6 @@ func TestIteratingController_SummarizationFailOpen(t *testing.T) {
 	registry := config.NewMCPServerRegistry(map[string]*config.MCPServerConfig{
 		"k8s": {
 			Summarization: &config.SummarizationConfig{
-				Enabled:             true,
 				SizeThresholdTokens: 100,
 			},
 		},
@@ -470,7 +468,6 @@ func TestGoogleNativeController_SummarizationIntegration(t *testing.T) {
 	registry := config.NewMCPServerRegistry(map[string]*config.MCPServerConfig{
 		"k8s": {
 			Summarization: &config.SummarizationConfig{
-				Enabled:              true,
 				SizeThresholdTokens:  100, // Low threshold to trigger summarization
 				SummaryMaxTokenLimit: 500,
 			},
@@ -528,7 +525,6 @@ func TestGoogleNativeController_SummarizationFailOpen(t *testing.T) {
 	registry := config.NewMCPServerRegistry(map[string]*config.MCPServerConfig{
 		"k8s": {
 			Summarization: &config.SummarizationConfig{
-				Enabled:             true,
 				SizeThresholdTokens: 100,
 			},
 		},

--- a/pkg/agent/controller/summarize.go
+++ b/pkg/agent/controller/summarize.go
@@ -57,7 +57,7 @@ func maybeSummarize(
 	}
 
 	// Summarization is enabled by default; only skip if explicitly disabled
-	if serverConfig.Summarization != nil && !serverConfig.Summarization.Enabled {
+	if serverConfig.Summarization != nil && serverConfig.Summarization.SummarizationDisabled() {
 		return &SummarizationResult{Content: rawContent}, nil
 	}
 

--- a/pkg/agent/controller/summarize_test.go
+++ b/pkg/agent/controller/summarize_test.go
@@ -65,10 +65,10 @@ func TestBuildConversationContext(t *testing.T) {
 func TestMaybeSummarize(t *testing.T) {
 	ctx := t.Context()
 
-	t.Run("returns raw content when summarization disabled", func(t *testing.T) {
+	t.Run("returns raw content when below default threshold with nil config", func(t *testing.T) {
 		registry := config.NewMCPServerRegistry(map[string]*config.MCPServerConfig{
 			"test-server": {
-				Summarization: nil,
+				Summarization: nil, // nil = enabled with defaults
 			},
 		})
 		pb := prompt.NewPromptBuilder(registry)
@@ -86,7 +86,7 @@ func TestMaybeSummarize(t *testing.T) {
 		assert.False(t, result.WasSummarized)
 	})
 
-	t.Run("returns raw content when below threshold", func(t *testing.T) {
+	t.Run("returns raw content when below explicit threshold", func(t *testing.T) {
 		registry := config.NewMCPServerRegistry(map[string]*config.MCPServerConfig{
 			"test-server": {
 				Summarization: &config.SummarizationConfig{
@@ -162,6 +162,34 @@ func TestMaybeSummarize(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "content", result.Content)
 		assert.False(t, result.WasSummarized)
+	})
+
+	t.Run("triggers summarization with nil config above default threshold", func(t *testing.T) {
+		mockLLM := &mockLLMClient{
+			responses: []mockLLMResponse{
+				{chunks: []agent.Chunk{&agent.TextChunk{Content: "Summarized output"}}},
+			},
+		}
+
+		registry := config.NewMCPServerRegistry(map[string]*config.MCPServerConfig{
+			"test-server": {
+				Summarization: nil, // nil = enabled with defaults (threshold = DefaultSizeThresholdTokens)
+			},
+		})
+		pb := prompt.NewPromptBuilder(registry)
+
+		execCtx := newTestExecCtx(t, mockLLM, agent.NewStubToolExecutor(nil))
+		execCtx.PromptBuilder = pb
+
+		// DefaultSizeThresholdTokens is 5000 tokens ≈ 20000 chars
+		largeContent := strings.Repeat("event-data ", 2500) // ~27500 chars ≈ 6875 tokens > 5000
+		eventSeq := 0
+		result, err := maybeSummarize(ctx, execCtx, "test-server", "get_events",
+			largeContent, "[user]: check events", &eventSeq)
+		require.NoError(t, err)
+		assert.True(t, result.WasSummarized)
+		assert.Contains(t, result.Content, "Summarized output")
+		assert.Contains(t, result.Content, "[NOTE: The output from test-server.get_events was")
 	})
 
 	t.Run("triggers summarization above threshold", func(t *testing.T) {

--- a/pkg/agent/controller/summarize_test.go
+++ b/pkg/agent/controller/summarize_test.go
@@ -90,7 +90,7 @@ func TestMaybeSummarize(t *testing.T) {
 		registry := config.NewMCPServerRegistry(map[string]*config.MCPServerConfig{
 			"test-server": {
 				Summarization: &config.SummarizationConfig{
-					Enabled:             true,
+					Enabled:             config.BoolPtr(true),
 					SizeThresholdTokens: 5000,
 				},
 			},
@@ -114,7 +114,7 @@ func TestMaybeSummarize(t *testing.T) {
 		registry := config.NewMCPServerRegistry(map[string]*config.MCPServerConfig{
 			"test-server": {
 				Summarization: &config.SummarizationConfig{
-					Enabled:             false,
+					Enabled:             config.BoolPtr(false),
 					SizeThresholdTokens: 100,
 				},
 			},
@@ -202,7 +202,6 @@ func TestMaybeSummarize(t *testing.T) {
 		registry := config.NewMCPServerRegistry(map[string]*config.MCPServerConfig{
 			"test-server": {
 				Summarization: &config.SummarizationConfig{
-					Enabled:              true,
 					SizeThresholdTokens:  100, // Low threshold
 					SummaryMaxTokenLimit: 500,
 				},
@@ -238,7 +237,6 @@ func TestMaybeSummarize(t *testing.T) {
 		registry := config.NewMCPServerRegistry(map[string]*config.MCPServerConfig{
 			"test-server": {
 				Summarization: &config.SummarizationConfig{
-					Enabled:              true,
 					SizeThresholdTokens:  100,
 					SummaryMaxTokenLimit: 500,
 				},
@@ -297,7 +295,6 @@ func TestMaybeSummarize(t *testing.T) {
 		registry := config.NewMCPServerRegistry(map[string]*config.MCPServerConfig{
 			"test-server": {
 				Summarization: &config.SummarizationConfig{
-					Enabled:             true,
 					SizeThresholdTokens: 100,
 				},
 			},
@@ -326,7 +323,6 @@ func TestMaybeSummarize(t *testing.T) {
 		registry := config.NewMCPServerRegistry(map[string]*config.MCPServerConfig{
 			"test-server": {
 				Summarization: &config.SummarizationConfig{
-					Enabled:             true,
 					SizeThresholdTokens: 100,
 				},
 			},

--- a/pkg/config/builtin.go
+++ b/pkg/config/builtin.go
@@ -162,7 +162,7 @@ func initBuiltinMCPServers() map[string]MCPServerConfig {
 				Patterns:      []string{"certificate", "token", "email"},
 			},
 			Summarization: &SummarizationConfig{
-				Enabled:              true,
+				Enabled:              BoolPtr(true),
 				SizeThresholdTokens:  DefaultSizeThresholdTokens,
 				SummaryMaxTokenLimit: 1000,
 			},

--- a/pkg/config/builtin_test.go
+++ b/pkg/config/builtin_test.go
@@ -227,7 +227,8 @@ func TestBuiltinMCPServers(t *testing.T) {
 		assert.NotNil(t, server.DataMasking)
 		assert.True(t, server.DataMasking.Enabled)
 		assert.NotNil(t, server.Summarization)
-		assert.True(t, server.Summarization.Enabled)
+		require.NotNil(t, server.Summarization.Enabled)
+		assert.True(t, *server.Summarization.Enabled)
 	})
 }
 

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -123,7 +123,7 @@ func load(_ context.Context, configDir string) (*Config, error) {
 
 	// 5. Apply MCP server defaults (before validation)
 	for _, server := range mcpServers {
-		if server.Summarization != nil && server.Summarization.Enabled && server.Summarization.SizeThresholdTokens == 0 {
+		if server.Summarization != nil && !server.Summarization.SummarizationDisabled() && server.Summarization.SizeThresholdTokens == 0 {
 			server.Summarization.SizeThresholdTokens = DefaultSizeThresholdTokens
 		}
 	}

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -897,7 +897,6 @@ mcp_servers:
       type: "http"
       url: "https://example.com/mcp"
     summarization:
-      enabled: true
       summary_max_token_limit: 1200
 agent_chains: {}
 `
@@ -910,7 +909,8 @@ agent_chains: {}
 	server, err := cfg.MCPServerRegistry.Get("my-server")
 	require.NoError(t, err)
 	require.NotNil(t, server.Summarization)
-	assert.True(t, server.Summarization.Enabled)
+	assert.Nil(t, server.Summarization.Enabled, "Enabled should be nil when omitted from YAML")
+	assert.False(t, server.Summarization.SummarizationDisabled(), "nil Enabled means enabled by default")
 	assert.Equal(t, DefaultSizeThresholdTokens, server.Summarization.SizeThresholdTokens,
 		"size_threshold_tokens should default to %d when not specified", DefaultSizeThresholdTokens)
 	assert.Equal(t, 1200, server.Summarization.SummaryMaxTokenLimit)

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -41,7 +41,7 @@ type MaskingPattern struct {
 
 // DefaultSizeThresholdTokens is the default token count above which MCP
 // responses are summarized (when summarization is enabled).
-const DefaultSizeThresholdTokens = 10000
+const DefaultSizeThresholdTokens = 5000
 
 // SummarizationConfig defines when and how to summarize large MCP responses
 type SummarizationConfig struct {

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -43,12 +43,21 @@ type MaskingPattern struct {
 // responses are summarized (when summarization is enabled).
 const DefaultSizeThresholdTokens = 5000
 
-// SummarizationConfig defines when and how to summarize large MCP responses
+// SummarizationConfig defines when and how to summarize large MCP responses.
+// Enabled is a *bool: nil means "use default" (enabled), explicit false disables.
 type SummarizationConfig struct {
-	Enabled              bool `yaml:"enabled"`
-	SizeThresholdTokens  int  `yaml:"size_threshold_tokens,omitempty" validate:"omitempty,min=100"`
-	SummaryMaxTokenLimit int  `yaml:"summary_max_token_limit,omitempty" validate:"omitempty,min=50"`
+	Enabled              *bool `yaml:"enabled,omitempty"`
+	SizeThresholdTokens  int   `yaml:"size_threshold_tokens,omitempty" validate:"omitempty,min=100"`
+	SummaryMaxTokenLimit int   `yaml:"summary_max_token_limit,omitempty" validate:"omitempty,min=50"`
 }
+
+// SummarizationDisabled returns true only when Enabled is explicitly set to false.
+func (c *SummarizationConfig) SummarizationDisabled() bool {
+	return c.Enabled != nil && !*c.Enabled
+}
+
+// BoolPtr returns a pointer to b. Convenience for *bool struct fields.
+func BoolPtr(b bool) *bool { return &b }
 
 // StageAgentConfig represents an agent reference with stage-level overrides
 // Used in stage.agents[] array (even for single-agent stages)

--- a/pkg/config/validator.go
+++ b/pkg/config/validator.go
@@ -435,7 +435,7 @@ func (v *Validator) validateMCPServers() error {
 		}
 
 		// Validate summarization configuration
-		if server.Summarization != nil && server.Summarization.Enabled {
+		if server.Summarization != nil && !server.Summarization.SummarizationDisabled() {
 			if server.Summarization.SizeThresholdTokens < 100 {
 				return NewValidationError("mcp_server", serverID, "summarization.size_threshold_tokens", fmt.Errorf("must be at least 100"))
 			}

--- a/pkg/config/validator_test.go
+++ b/pkg/config/validator_test.go
@@ -494,8 +494,22 @@ func TestValidateMCPServers(t *testing.T) {
 						Command: "test",
 					},
 					Summarization: &SummarizationConfig{
-						Enabled:             true,
 						SizeThresholdTokens: 5000,
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid summarization with threshold-only config (no enabled field)",
+			servers: map[string]*MCPServerConfig{
+				"test-server": {
+					Transport: TransportConfig{
+						Type:    TransportTypeStdio,
+						Command: "test",
+					},
+					Summarization: &SummarizationConfig{
+						SizeThresholdTokens: 3000,
 					},
 				},
 			},
@@ -510,7 +524,6 @@ func TestValidateMCPServers(t *testing.T) {
 						Command: "test",
 					},
 					Summarization: &SummarizationConfig{
-						Enabled:             true,
 						SizeThresholdTokens: 50,
 					},
 				},


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tool result summarization is enabled by default.
  * Default token threshold for triggering summarization lowered to 5K tokens (from 10K).
  * Summarization can be customized or disabled per server.

* **Documentation**
  * Updated docs and configuration examples to reflect default-enabled summarization and threshold customization.

* **Tests**
  * Test suites updated to reflect nil-default enabled semantics and revised threshold behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->