### PR TITLE
LLM Provider Fallback - Phase 2 - Core Fallback Logic

### DIFF
--- a/deploy/config/tarsy.yaml.example
+++ b/deploy/config/tarsy.yaml.example
@@ -93,6 +93,17 @@ defaults:
   
   # Default success policy for parallel stages ("all" or "any")
   success_policy: "any"
+
+  # LLM provider fallback — ordered list of alternative providers to try when
+  # the primary provider fails (after Python-level retries are exhausted).
+  # Each entry specifies both provider and backend explicitly.
+  # Overridable per chain, stage, or agent.
+  # Validated at startup: all referenced providers must exist with valid credentials.
+  # fallback_providers:
+  #   - provider: "gemini-3.1-pro"
+  #     backend: "google-native"
+  #   - provider: "anthropic-vertex"
+  #     backend: "langchain"
   
   # Default scoring agent name (fallback when chain has no scoring config)
   scoring_agent: "ScoringAgent"
@@ -393,10 +404,15 @@ agent_chains:
           - name: "KubernetesAgent"
         replicas: 2  # Run KubernetesAgent twice
 
-  # Security incident chain
+  # Security incident chain (with chain-level fallback override)
   security-incident:
     alert_types: ["SecurityIncident", "IntrusionDetection"]
     description: "Security-focused investigation"
+    # Chain-level fallback overrides defaults.fallback_providers for all
+    # stages/agents in this chain. Can also be set per stage or per agent.
+    # fallback_providers:
+    #   - provider: "gemini-3.1-pro"
+    #     backend: "google-native"
     stages:
       - name: "triage"
         agents:

--- a/docs/proposals/llm-provider-fallback-design.md
+++ b/docs/proposals/llm-provider-fallback-design.md
@@ -32,24 +32,31 @@ Fallback operates at the **Go controller level** (`pkg/agent/controller/iteratin
 ```
 Iteration N: LLM call fails (after Python retries exhausted)
     │
-    ├─ Partial output received? → NO fallback for this call
-    │                              (treat as recoverable, retry via iteration)
-    │
     ├─ Parent context cancelled? → Return immediately (session expired)
     │
-    └─ No partial output, retryable error:
+    ├─ Loop detection error? → Not a provider issue, no fallback
+    │
+    └─ Evaluate error code against trigger rules:
          │
-         ├─ Fallback providers available? 
-         │    │
-         │    ├─ YES → Select next fallback provider
-         │    │         Record fallback timeline event
-         │    │         Update execution metadata
-         │    │         Swap provider in execCtx.Config
-         │    │         Continue iteration loop with new provider
-         │    │
-         │    └─ NO → Record failure, continue as today
+         ├─ max_retries / credentials → Immediate fallback trigger
          │
-         └─ (All fallback providers exhausted → fail execution)
+         ├─ provider_error / invalid_request / partial_stream_error
+         │    → Increment consecutive counter; trigger after 2 consecutive
+         │      failures (1 Go retry on the same provider first)
+         │
+         └─ Fallback triggered?
+              │
+              ├─ Fallback providers available?
+              │    │
+              │    ├─ YES → Select next fallback provider
+              │    │         Record fallback timeline event
+              │    │         Update execution metadata
+              │    │         Swap provider in execCtx.Config
+              │    │         Continue iteration loop with new provider
+              │    │
+              │    └─ NO → Record failure, continue as today
+              │
+              └─ NO trigger → Retry iteration with same provider
 ```
 
 **Decision (Q1):** Fallback sticks for the rest of the execution. Each new execution (stage, sub-agent) starts fresh with the primary provider via `ResolveAgentConfig`.
@@ -110,7 +117,7 @@ type FallbackState struct {
     CurrentProviderIndex    int      // -1 = primary, 0+ = fallback list index
     AttemptedProviders      []string // For observability
     FallbackReason          string   // Last error that triggered fallback
-    ConsecutiveNonRetryable int      // Counts consecutive provider_error/invalid_request (threshold: 2)
+    ConsecutiveProviderErrors int     // Counts consecutive provider_error/invalid_request/transport (threshold: 2)
     ConsecutivePartialErrors int     // Counts consecutive partial_stream_error (threshold: 2)
 }
 ```

--- a/docs/proposals/llm-provider-fallback-design.md
+++ b/docs/proposals/llm-provider-fallback-design.md
@@ -110,7 +110,7 @@ type FallbackState struct {
     CurrentProviderIndex    int      // -1 = primary, 0+ = fallback list index
     AttemptedProviders      []string // For observability
     FallbackReason          string   // Last error that triggered fallback
-    ConsecutiveNonRetryable int      // Counts consecutive provider_error/invalid_request (threshold: 1)
+    ConsecutiveNonRetryable int      // Counts consecutive provider_error/invalid_request (threshold: 2)
     ConsecutivePartialErrors int     // Counts consecutive partial_stream_error (threshold: 2)
 }
 ```

--- a/docs/proposals/llm-provider-fallback-design.md
+++ b/docs/proposals/llm-provider-fallback-design.md
@@ -201,7 +201,7 @@ Tests:
 - `pkg/config/validator_test.go` — Startup validation: missing provider, invalid backend, missing credentials
 - `pkg/agent/config_resolver_test.go` — Fallback list resolution through hierarchy
 
-### Phase 2: Core Fallback Logic (P2)
+### Phase 2: Core Fallback Logic (P2) - ✅ DONE
 
 **Goal:** When a provider fails, automatically switch to the next fallback provider based on error-code-aware trigger rules (Q7). All LLM call sites get fallback (Q6).
 

--- a/docs/proposals/llm-provider-fallback-design.md
+++ b/docs/proposals/llm-provider-fallback-design.md
@@ -154,9 +154,9 @@ Fallback triggers depend on the error code from the Python LLM service, since ea
 |---|---|---|
 | `max_retries` | Yes (3x) | Immediate |
 | `credentials` | No | Immediate (guaranteed failure) |
-| `provider_error` | No | After 1 Go retry |
-| `invalid_request` | No | After 1 Go retry |
-| `partial_stream_error` | No | After 2 consecutive partial errors |
+| `provider_error` | No | After 1 Go retry (2 consecutive failures) |
+| `invalid_request` | No | After 1 Go retry (2 consecutive failures) |
+| `partial_stream_error` | No | After 1 Go retry (2 consecutive failures) |
 
 In all cases, fallback also requires:
 - The parent context is not cancelled/expired
@@ -252,5 +252,5 @@ All decisions resolved — see [llm-provider-fallback-questions.md](llm-provider
 4. **Q4** — Validate fallback credentials at startup; fail if any are missing
 5. **Q5** — Two new nullable columns: `original_llm_provider`, `original_llm_backend`
 6. **Q6** — All controllers get fallback (iterating, forced conclusion, single-shot)
-7. **Q7** — Error-code-aware triggers: immediate for `max_retries`/`credentials`, 1 Go retry for `provider_error`/`invalid_request`, 2 consecutive for `partial_stream_error`
+7. **Q7** — Error-code-aware triggers: immediate for `max_retries`/`credentials`, 2 consecutive failures for `provider_error`/`invalid_request`/`partial_stream_error`
 8. **Q8** — Conservative defaults: 120s initial, 60s stall, 5m max

--- a/llm-service/llm/providers/google_native.py
+++ b/llm-service/llm/providers/google_native.py
@@ -290,6 +290,14 @@ class GoogleNativeProvider(LLMProvider):
             )
             return
 
+        if request.clear_cache and request.execution_id:
+            if request.execution_id in self._model_contents:
+                del self._model_contents[request.execution_id]
+                logger.info(
+                    "[%s] Cleared model content cache for execution %s (provider fallback)",
+                    request_id, request.execution_id,
+                )
+
         try:
             system_instruction, contents = self._convert_messages(
                 list(request.messages), request.execution_id

--- a/llm-service/tests/test_google_native.py
+++ b/llm-service/tests/test_google_native.py
@@ -473,6 +473,108 @@ class TestGoogleNativeProvider:
     @pytest.mark.asyncio
     @patch.dict(os.environ, {"TEST_API_KEY": "test-key-123"})
     @patch("llm.providers.google_native.genai.Client")
+    async def test_clear_cache_deletes_model_contents(self, mock_client_class, provider):
+        """Test that clear_cache=True deletes _model_contents for the execution."""
+        execution_id = "exec-fallback"
+        content = genai_types.Content(
+            role="model", parts=[genai_types.Part(text="cached")]
+        )
+        provider._cache_model_turn(execution_id, [content])
+        assert execution_id in provider._model_contents
+
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+
+        mock_chunk = MagicMock()
+        mock_chunk.candidates = [MagicMock()]
+        mock_chunk.candidates[0].content = genai_types.Content(
+            role="model", parts=[genai_types.Part(text="fresh response")]
+        )
+        mock_chunk.usage_metadata = None
+
+        async def mock_stream():
+            yield mock_chunk
+
+        mock_client.aio.models.generate_content_stream = AsyncMock(return_value=mock_stream())
+
+        request = pb.GenerateRequest(
+            session_id="sess-1",
+            execution_id=execution_id,
+            clear_cache=True,
+            llm_config=pb.LLMConfig(
+                backend="google-native",
+                model="gemini-2.5-pro",
+                api_key_env="TEST_API_KEY",
+            ),
+            messages=[pb.ConversationMessage(role="user", content="hello")],
+        )
+
+        responses = []
+        async for resp in provider.generate(request):
+            responses.append(resp)
+
+        # Cache should have been cleared before message conversion
+        # (a new cache entry may have been created by the generate call itself)
+        # The key test: the old cached content should not be there
+        if execution_id in provider._model_contents:
+            turns, _ = provider._model_contents[execution_id]
+            # Should only contain the fresh turn, not the pre-seeded one
+            assert len(turns) <= 1
+
+    @pytest.mark.asyncio
+    @patch.dict(os.environ, {"TEST_API_KEY": "test-key-123"})
+    @patch("llm.providers.google_native.genai.Client")
+    async def test_clear_cache_false_preserves_model_contents(self, mock_client_class, provider):
+        """Test that clear_cache=False (default) preserves existing cache."""
+        execution_id = "exec-no-clear"
+        content = genai_types.Content(
+            role="model", parts=[genai_types.Part(text="cached")]
+        )
+        provider._cache_model_turn(execution_id, [content])
+        assert execution_id in provider._model_contents
+
+        turns_before, _ = provider._model_contents[execution_id]
+        assert len(turns_before) == 1
+
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+
+        mock_chunk = MagicMock()
+        mock_chunk.candidates = [MagicMock()]
+        mock_chunk.candidates[0].content = genai_types.Content(
+            role="model", parts=[genai_types.Part(text="response")]
+        )
+        mock_chunk.usage_metadata = None
+
+        async def mock_stream():
+            yield mock_chunk
+
+        mock_client.aio.models.generate_content_stream = AsyncMock(return_value=mock_stream())
+
+        request = pb.GenerateRequest(
+            session_id="sess-1",
+            execution_id=execution_id,
+            clear_cache=False,
+            llm_config=pb.LLMConfig(
+                backend="google-native",
+                model="gemini-2.5-pro",
+                api_key_env="TEST_API_KEY",
+            ),
+            messages=[pb.ConversationMessage(role="user", content="hello")],
+        )
+
+        responses = []
+        async for resp in provider.generate(request):
+            responses.append(resp)
+
+        # Cache should still have the pre-seeded entry (plus possibly the new turn)
+        assert execution_id in provider._model_contents
+        turns_after, _ = provider._model_contents[execution_id]
+        assert len(turns_after) >= 1
+
+    @pytest.mark.asyncio
+    @patch.dict(os.environ, {"TEST_API_KEY": "test-key-123"})
+    @patch("llm.providers.google_native.genai.Client")
     async def test_generate_missing_api_key(self, mock_client_class, provider):
         """Test that generate yields error when API key env var is missing."""
         with patch.dict(os.environ, {}, clear=True):

--- a/llm-service/tests/test_google_native.py
+++ b/llm-service/tests/test_google_native.py
@@ -482,14 +482,20 @@ class TestGoogleNativeProvider:
         provider._cache_model_turn(execution_id, [content])
         assert execution_id in provider._model_contents
 
+        cached_turns = provider._get_cached_model_turns(execution_id)
+        assert len(cached_turns) == 1
+
         mock_client = MagicMock()
         mock_client_class.return_value = mock_client
 
-        mock_chunk = MagicMock()
-        mock_chunk.candidates = [MagicMock()]
-        mock_chunk.candidates[0].content = genai_types.Content(
+        mock_candidate = MagicMock()
+        mock_candidate.content = genai_types.Content(
             role="model", parts=[genai_types.Part(text="fresh response")]
         )
+        mock_candidate.grounding_metadata = None
+
+        mock_chunk = MagicMock()
+        mock_chunk.candidates = [mock_candidate]
         mock_chunk.usage_metadata = None
 
         async def mock_stream():
@@ -513,13 +519,15 @@ class TestGoogleNativeProvider:
         async for resp in provider.generate(request):
             responses.append(resp)
 
-        # Cache should have been cleared before message conversion
-        # (a new cache entry may have been created by the generate call itself)
-        # The key test: the old cached content should not be there
+        # After generate, any cached entry should only contain the fresh
+        # response — the pre-seeded "cached" content must have been cleared.
         if execution_id in provider._model_contents:
             turns, _ = provider._model_contents[execution_id]
-            # Should only contain the fresh turn, not the pre-seeded one
-            assert len(turns) <= 1
+            for turn in turns:
+                for content_obj in turn:
+                    for part in content_obj.parts:
+                        assert getattr(part, "text", None) != "cached", \
+                            "old cached content should have been cleared before generate"
 
     @pytest.mark.asyncio
     @patch.dict(os.environ, {"TEST_API_KEY": "test-key-123"})
@@ -539,11 +547,14 @@ class TestGoogleNativeProvider:
         mock_client = MagicMock()
         mock_client_class.return_value = mock_client
 
-        mock_chunk = MagicMock()
-        mock_chunk.candidates = [MagicMock()]
-        mock_chunk.candidates[0].content = genai_types.Content(
+        mock_candidate = MagicMock()
+        mock_candidate.content = genai_types.Content(
             role="model", parts=[genai_types.Part(text="response")]
         )
+        mock_candidate.grounding_metadata = None
+
+        mock_chunk = MagicMock()
+        mock_chunk.candidates = [mock_candidate]
         mock_chunk.usage_metadata = None
 
         async def mock_stream():

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -2,7 +2,10 @@
 // Agents investigate alerts using LLM calls and (optionally) MCP tools.
 package agent
 
-import "context"
+import (
+	"context"
+	"errors"
+)
 
 // Agent defines the interface for all TARSy agents.
 // Agents are created per-execution (not shared between sessions).
@@ -30,6 +33,28 @@ const (
 	ExecutionStatusTimedOut  ExecutionStatus = "timed_out"
 	ExecutionStatusCancelled ExecutionStatus = "cancelled"
 )
+
+// StatusFromContextErr maps a context error to the appropriate ExecutionStatus.
+// Returns ("", false) if the context is still active.
+func StatusFromContextErr(ctx context.Context) (ExecutionStatus, bool) {
+	if ctx.Err() == nil {
+		return "", false
+	}
+	return StatusFromErr(ctx.Err()), true
+}
+
+// StatusFromErr maps an error to the appropriate ExecutionStatus.
+// Returns TimedOut for DeadlineExceeded, Cancelled for context.Canceled,
+// and Failed for everything else (including nil).
+func StatusFromErr(err error) ExecutionStatus {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return ExecutionStatusTimedOut
+	}
+	if errors.Is(err, context.Canceled) {
+		return ExecutionStatusCancelled
+	}
+	return ExecutionStatusFailed
+}
 
 // ExecutionResult is returned by Agent.Execute().
 // Lightweight — all intermediate state was already written to DB during execution.

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -48,9 +48,8 @@ func TestStatusFromContextErr(t *testing.T) {
 	})
 
 	t.Run("timed out context", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(context.Background(), time.Nanosecond)
+		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
 		defer cancel()
-		time.Sleep(time.Millisecond)
 
 		status, done := StatusFromContextErr(ctx)
 		assert.True(t, done)

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -1,0 +1,59 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStatusFromErr(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected ExecutionStatus
+	}{
+		{"deadline exceeded", context.DeadlineExceeded, ExecutionStatusTimedOut},
+		{"context canceled", context.Canceled, ExecutionStatusCancelled},
+		{"generic error", fmt.Errorf("something broke"), ExecutionStatusFailed},
+		{"nil error", nil, ExecutionStatusFailed},
+		{"wrapped deadline", fmt.Errorf("call failed: %w", context.DeadlineExceeded), ExecutionStatusTimedOut},
+		{"wrapped canceled", fmt.Errorf("call failed: %w", context.Canceled), ExecutionStatusCancelled},
+		{"double wrapped deadline", fmt.Errorf("outer: %w", fmt.Errorf("inner: %w", context.DeadlineExceeded)), ExecutionStatusTimedOut},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, StatusFromErr(tt.err))
+		})
+	}
+}
+
+func TestStatusFromContextErr(t *testing.T) {
+	t.Run("active context", func(t *testing.T) {
+		status, done := StatusFromContextErr(context.Background())
+		assert.False(t, done)
+		assert.Equal(t, ExecutionStatus(""), status)
+	})
+
+	t.Run("cancelled context", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		status, done := StatusFromContextErr(ctx)
+		assert.True(t, done)
+		assert.Equal(t, ExecutionStatusCancelled, status)
+	})
+
+	t.Run("timed out context", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Nanosecond)
+		defer cancel()
+		time.Sleep(time.Millisecond)
+
+		status, done := StatusFromContextErr(ctx)
+		assert.True(t, done)
+		assert.Equal(t, ExecutionStatusTimedOut, status)
+	})
+}

--- a/pkg/agent/base_agent.go
+++ b/pkg/agent/base_agent.go
@@ -2,7 +2,6 @@ package agent
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/codeready-toolchain/tarsy/ent/agentexecution"
@@ -53,13 +52,7 @@ func (a *BaseAgent) Execute(ctx context.Context, execCtx *ExecutionContext, prev
 	// Use errors.Is on the returned error (not ctx.Err()) so that a concurrent
 	// context expiration doesn't misclassify an unrelated failure as timed-out.
 	if err != nil {
-		if errors.Is(err, context.DeadlineExceeded) {
-			return &ExecutionResult{Status: ExecutionStatusTimedOut, Error: err}, nil
-		}
-		if errors.Is(err, context.Canceled) {
-			return &ExecutionResult{Status: ExecutionStatusCancelled, Error: err}, nil
-		}
-		return &ExecutionResult{Status: ExecutionStatusFailed, Error: err}, nil
+		return &ExecutionResult{Status: StatusFromErr(err), Error: err}, nil
 	}
 
 	// 4. Defensive nil-check: ensure controller returned a valid result.

--- a/pkg/agent/config_resolver.go
+++ b/pkg/agent/config_resolver.go
@@ -108,7 +108,7 @@ func ResolveAgentConfig(
 	// Apply agent-level native tools override (provider → agent merge)
 	resolvedProvider := applyAgentNativeTools(provider, agentDef.NativeTools)
 
-	resolvedFallback := resolveFullFallbackEntries(cfg, fallbackProviders)
+	resolvedFallback := resolveFullFallbackEntries(cfg, fallbackProviders, agentDef.NativeTools)
 
 	return &ResolvedAgentConfig{
 		AgentName:                 agentConfig.Name,
@@ -233,7 +233,7 @@ func ResolveChatAgentConfig(
 	// Apply agent-level native tools override (provider → agent merge)
 	resolvedProvider := applyAgentNativeTools(provider, agentDef.NativeTools)
 
-	resolvedFallback := resolveFullFallbackEntries(cfg, fallbackProviders)
+	resolvedFallback := resolveFullFallbackEntries(cfg, fallbackProviders, agentDef.NativeTools)
 
 	return &ResolvedAgentConfig{
 		AgentName: agentName,
@@ -341,7 +341,7 @@ func ResolveScoringConfig(
 	// Apply agent-level native tools override (provider → agent merge)
 	resolvedProvider := applyAgentNativeTools(provider, agentDef.NativeTools)
 
-	resolvedFallback := resolveFullFallbackEntries(cfg, fallbackProviders)
+	resolvedFallback := resolveFullFallbackEntries(cfg, fallbackProviders, agentDef.NativeTools)
 
 	return &ResolvedAgentConfig{
 		AgentName:                 agentName,
@@ -432,9 +432,11 @@ func resolveFallbackProviders(overrides ...[]config.FallbackProviderEntry) []con
 }
 
 // resolveFullFallbackEntries looks up the full LLMProviderConfig for each
-// fallback provider entry. Entries whose provider is not found in the registry
-// are logged and skipped (startup validation should have caught these).
-func resolveFullFallbackEntries(cfg *config.Config, entries []config.FallbackProviderEntry) []ResolvedFallbackEntry {
+// fallback provider entry and applies agent-level native tool overrides so
+// that native tool configuration survives provider swaps during fallback.
+// Entries whose provider is not found in the registry are logged and skipped
+// (startup validation should have caught these).
+func resolveFullFallbackEntries(cfg *config.Config, entries []config.FallbackProviderEntry, agentNativeTools map[config.GoogleNativeTool]bool) []ResolvedFallbackEntry {
 	if len(entries) == 0 {
 		return nil
 	}
@@ -449,7 +451,7 @@ func resolveFullFallbackEntries(cfg *config.Config, entries []config.FallbackPro
 		resolved = append(resolved, ResolvedFallbackEntry{
 			ProviderName: entry.Provider,
 			Backend:      entry.Backend,
-			Config:       provider,
+			Config:       applyAgentNativeTools(provider, agentNativeTools),
 		})
 	}
 	return resolved

--- a/pkg/agent/config_resolver.go
+++ b/pkg/agent/config_resolver.go
@@ -108,21 +108,24 @@ func ResolveAgentConfig(
 	// Apply agent-level native tools override (provider → agent merge)
 	resolvedProvider := applyAgentNativeTools(provider, agentDef.NativeTools)
 
+	resolvedFallback := resolveFullFallbackEntries(cfg, fallbackProviders)
+
 	return &ResolvedAgentConfig{
-		AgentName:              agentConfig.Name,
-		Type:                   agentType,
-		LLMBackend:             backend,
-		LLMProvider:            resolvedProvider,
-		LLMProviderName:        providerName,
-		MaxIterations:          maxIter,
-		IterationTimeout:       DefaultIterationTimeout,
-		LLMCallTimeout:         DefaultLLMCallTimeout,
-		ToolCallTimeout:        DefaultToolCallTimeout,
-		MCPServers:             mcpServers,
-		CustomInstructions:     agentDef.CustomInstructions,
-		FallbackProviders:      fallbackProviders,
-		InitialResponseTimeout: DefaultInitialResponseTimeout,
-		StallTimeout:           DefaultStallTimeout,
+		AgentName:                 agentConfig.Name,
+		Type:                      agentType,
+		LLMBackend:                backend,
+		LLMProvider:               resolvedProvider,
+		LLMProviderName:           providerName,
+		MaxIterations:             maxIter,
+		IterationTimeout:          DefaultIterationTimeout,
+		LLMCallTimeout:            DefaultLLMCallTimeout,
+		ToolCallTimeout:           DefaultToolCallTimeout,
+		MCPServers:                mcpServers,
+		CustomInstructions:        agentDef.CustomInstructions,
+		FallbackProviders:         fallbackProviders,
+		ResolvedFallbackProviders: resolvedFallback,
+		InitialResponseTimeout:    DefaultInitialResponseTimeout,
+		StallTimeout:              DefaultStallTimeout,
 	}, nil
 }
 
@@ -230,23 +233,26 @@ func ResolveChatAgentConfig(
 	// Apply agent-level native tools override (provider → agent merge)
 	resolvedProvider := applyAgentNativeTools(provider, agentDef.NativeTools)
 
+	resolvedFallback := resolveFullFallbackEntries(cfg, fallbackProviders)
+
 	return &ResolvedAgentConfig{
 		AgentName: agentName,
 		// Chat always uses the iterating function-calling controller,
 		// regardless of what the agent definition's Type field says.
-		Type:                   config.AgentTypeDefault,
-		LLMBackend:             backend,
-		LLMProvider:            resolvedProvider,
-		LLMProviderName:        providerName,
-		MaxIterations:          maxIter,
-		IterationTimeout:       DefaultIterationTimeout,
-		LLMCallTimeout:         DefaultLLMCallTimeout,
-		ToolCallTimeout:        DefaultToolCallTimeout,
-		MCPServers:             mcpServers,
-		CustomInstructions:     agentDef.CustomInstructions,
-		FallbackProviders:      fallbackProviders,
-		InitialResponseTimeout: DefaultInitialResponseTimeout,
-		StallTimeout:           DefaultStallTimeout,
+		Type:                      config.AgentTypeDefault,
+		LLMBackend:                backend,
+		LLMProvider:               resolvedProvider,
+		LLMProviderName:           providerName,
+		MaxIterations:             maxIter,
+		IterationTimeout:          DefaultIterationTimeout,
+		LLMCallTimeout:            DefaultLLMCallTimeout,
+		ToolCallTimeout:           DefaultToolCallTimeout,
+		MCPServers:                mcpServers,
+		CustomInstructions:        agentDef.CustomInstructions,
+		FallbackProviders:         fallbackProviders,
+		ResolvedFallbackProviders: resolvedFallback,
+		InitialResponseTimeout:    DefaultInitialResponseTimeout,
+		StallTimeout:              DefaultStallTimeout,
 	}, nil
 }
 
@@ -335,21 +341,24 @@ func ResolveScoringConfig(
 	// Apply agent-level native tools override (provider → agent merge)
 	resolvedProvider := applyAgentNativeTools(provider, agentDef.NativeTools)
 
+	resolvedFallback := resolveFullFallbackEntries(cfg, fallbackProviders)
+
 	return &ResolvedAgentConfig{
-		AgentName:              agentName,
-		Type:                   config.AgentTypeScoring,
-		LLMBackend:             backend,
-		LLMProvider:            resolvedProvider,
-		LLMProviderName:        providerName,
-		MaxIterations:          maxIter,
-		IterationTimeout:       DefaultIterationTimeout,
-		LLMCallTimeout:         DefaultLLMCallTimeout,
-		ToolCallTimeout:        DefaultToolCallTimeout,
-		MCPServers:             mcpServers,
-		CustomInstructions:     agentDef.CustomInstructions,
-		FallbackProviders:      fallbackProviders,
-		InitialResponseTimeout: DefaultInitialResponseTimeout,
-		StallTimeout:           DefaultStallTimeout,
+		AgentName:                 agentName,
+		Type:                      config.AgentTypeScoring,
+		LLMBackend:                backend,
+		LLMProvider:               resolvedProvider,
+		LLMProviderName:           providerName,
+		MaxIterations:             maxIter,
+		IterationTimeout:          DefaultIterationTimeout,
+		LLMCallTimeout:            DefaultLLMCallTimeout,
+		ToolCallTimeout:           DefaultToolCallTimeout,
+		MCPServers:                mcpServers,
+		CustomInstructions:        agentDef.CustomInstructions,
+		FallbackProviders:         fallbackProviders,
+		ResolvedFallbackProviders: resolvedFallback,
+		InitialResponseTimeout:    DefaultInitialResponseTimeout,
+		StallTimeout:              DefaultStallTimeout,
 	}, nil
 }
 
@@ -420,6 +429,30 @@ func resolveFallbackProviders(overrides ...[]config.FallbackProviderEntry) []con
 		return make([]config.FallbackProviderEntry, 0)
 	}
 	return append([]config.FallbackProviderEntry(nil), result...)
+}
+
+// resolveFullFallbackEntries looks up the full LLMProviderConfig for each
+// fallback provider entry. Entries whose provider is not found in the registry
+// are logged and skipped (startup validation should have caught these).
+func resolveFullFallbackEntries(cfg *config.Config, entries []config.FallbackProviderEntry) []ResolvedFallbackEntry {
+	if len(entries) == 0 {
+		return nil
+	}
+	resolved := make([]ResolvedFallbackEntry, 0, len(entries))
+	for _, entry := range entries {
+		provider, err := cfg.GetLLMProvider(entry.Provider)
+		if err != nil {
+			slog.Warn("Fallback provider not found in registry (skipping)",
+				"provider", entry.Provider, "error", err)
+			continue
+		}
+		resolved = append(resolved, ResolvedFallbackEntry{
+			ProviderName: entry.Provider,
+			Backend:      entry.Backend,
+			Config:       provider,
+		})
+	}
+	return resolved
 }
 
 // resolveMaxIterations returns the last non-nil value from the given

--- a/pkg/agent/config_resolver_test.go
+++ b/pkg/agent/config_resolver_test.go
@@ -1156,6 +1156,114 @@ func TestResolveFallbackProviders(t *testing.T) {
 	})
 }
 
+func TestResolvedFallbackProviders(t *testing.T) {
+	primaryProvider := &config.LLMProviderConfig{
+		Type:    config.LLMProviderTypeGoogle,
+		Model:   "gemini-primary",
+		APIKeyEnv: "GOOGLE_API_KEY",
+	}
+	fallbackProvider1 := &config.LLMProviderConfig{
+		Type:    config.LLMProviderTypeGoogle,
+		Model:   "gemini-fallback-1",
+		APIKeyEnv: "GOOGLE_API_KEY",
+	}
+	fallbackProvider2 := &config.LLMProviderConfig{
+		Type:    config.LLMProviderTypeOpenAI,
+		Model:   "gpt-fallback-2",
+		APIKeyEnv: "OPENAI_API_KEY",
+	}
+
+	cfg := &config.Config{
+		Defaults: &config.Defaults{
+			LLMProvider: "primary",
+			FallbackProviders: []config.FallbackProviderEntry{
+				{Provider: "fb-1", Backend: config.LLMBackendNativeGemini},
+				{Provider: "fb-2", Backend: config.LLMBackendLangChain},
+			},
+		},
+		AgentRegistry: config.NewAgentRegistry(map[string]*config.AgentConfig{
+			"TestAgent":    {},
+			"ScoringAgent": {Type: config.AgentTypeScoring},
+			"ChatAgent":    {},
+		}),
+		LLMProviderRegistry: config.NewLLMProviderRegistry(map[string]*config.LLMProviderConfig{
+			"primary": primaryProvider,
+			"fb-1":    fallbackProvider1,
+			"fb-2":    fallbackProvider2,
+		}),
+	}
+
+	t.Run("ResolveAgentConfig populates ResolvedFallbackProviders", func(t *testing.T) {
+		resolved, err := ResolveAgentConfig(cfg,
+			&config.ChainConfig{},
+			config.StageConfig{},
+			config.StageAgentConfig{Name: "TestAgent"},
+		)
+		require.NoError(t, err)
+		require.Len(t, resolved.ResolvedFallbackProviders, 2)
+
+		assert.Equal(t, "fb-1", resolved.ResolvedFallbackProviders[0].ProviderName)
+		assert.Equal(t, config.LLMBackendNativeGemini, resolved.ResolvedFallbackProviders[0].Backend)
+		assert.Equal(t, "gemini-fallback-1", resolved.ResolvedFallbackProviders[0].Config.Model)
+
+		assert.Equal(t, "fb-2", resolved.ResolvedFallbackProviders[1].ProviderName)
+		assert.Equal(t, config.LLMBackendLangChain, resolved.ResolvedFallbackProviders[1].Backend)
+		assert.Equal(t, "gpt-fallback-2", resolved.ResolvedFallbackProviders[1].Config.Model)
+	})
+
+	t.Run("ResolveChatAgentConfig populates ResolvedFallbackProviders", func(t *testing.T) {
+		resolved, err := ResolveChatAgentConfig(cfg, &config.ChainConfig{}, nil)
+		require.NoError(t, err)
+		require.Len(t, resolved.ResolvedFallbackProviders, 2)
+		assert.Equal(t, "fb-1", resolved.ResolvedFallbackProviders[0].ProviderName)
+		assert.Equal(t, "fb-2", resolved.ResolvedFallbackProviders[1].ProviderName)
+	})
+
+	t.Run("ResolveScoringConfig populates ResolvedFallbackProviders", func(t *testing.T) {
+		resolved, err := ResolveScoringConfig(cfg, &config.ChainConfig{}, nil)
+		require.NoError(t, err)
+		require.Len(t, resolved.ResolvedFallbackProviders, 2)
+		assert.Equal(t, "fb-1", resolved.ResolvedFallbackProviders[0].ProviderName)
+	})
+
+	t.Run("nil FallbackProviders yields nil ResolvedFallbackProviders", func(t *testing.T) {
+		cfgNoFallback := &config.Config{
+			Defaults:            &config.Defaults{LLMProvider: "primary"},
+			AgentRegistry:       cfg.AgentRegistry,
+			LLMProviderRegistry: cfg.LLMProviderRegistry,
+		}
+		resolved, err := ResolveAgentConfig(cfgNoFallback,
+			&config.ChainConfig{},
+			config.StageConfig{},
+			config.StageAgentConfig{Name: "TestAgent"},
+		)
+		require.NoError(t, err)
+		assert.Nil(t, resolved.ResolvedFallbackProviders)
+	})
+
+	t.Run("missing provider in registry is skipped", func(t *testing.T) {
+		cfgMissing := &config.Config{
+			Defaults: &config.Defaults{
+				LLMProvider: "primary",
+				FallbackProviders: []config.FallbackProviderEntry{
+					{Provider: "nonexistent", Backend: config.LLMBackendLangChain},
+					{Provider: "fb-1", Backend: config.LLMBackendNativeGemini},
+				},
+			},
+			AgentRegistry:       cfg.AgentRegistry,
+			LLMProviderRegistry: cfg.LLMProviderRegistry,
+		}
+		resolved, err := ResolveAgentConfig(cfgMissing,
+			&config.ChainConfig{},
+			config.StageConfig{},
+			config.StageAgentConfig{Name: "TestAgent"},
+		)
+		require.NoError(t, err)
+		require.Len(t, resolved.ResolvedFallbackProviders, 1, "nonexistent provider should be skipped")
+		assert.Equal(t, "fb-1", resolved.ResolvedFallbackProviders[0].ProviderName)
+	})
+}
+
 func TestResolveAdaptiveTimeoutDefaults(t *testing.T) {
 	googleProvider := &config.LLMProviderConfig{
 		Type:                config.LLMProviderTypeGoogle,

--- a/pkg/agent/config_resolver_test.go
+++ b/pkg/agent/config_resolver_test.go
@@ -1158,18 +1158,18 @@ func TestResolveFallbackProviders(t *testing.T) {
 
 func TestResolvedFallbackProviders(t *testing.T) {
 	primaryProvider := &config.LLMProviderConfig{
-		Type:    config.LLMProviderTypeGoogle,
-		Model:   "gemini-primary",
+		Type:      config.LLMProviderTypeGoogle,
+		Model:     "gemini-primary",
 		APIKeyEnv: "GOOGLE_API_KEY",
 	}
 	fallbackProvider1 := &config.LLMProviderConfig{
-		Type:    config.LLMProviderTypeGoogle,
-		Model:   "gemini-fallback-1",
+		Type:      config.LLMProviderTypeGoogle,
+		Model:     "gemini-fallback-1",
 		APIKeyEnv: "GOOGLE_API_KEY",
 	}
 	fallbackProvider2 := &config.LLMProviderConfig{
-		Type:    config.LLMProviderTypeOpenAI,
-		Model:   "gpt-fallback-2",
+		Type:      config.LLMProviderTypeOpenAI,
+		Model:     "gpt-fallback-2",
 		APIKeyEnv: "OPENAI_API_KEY",
 	}
 

--- a/pkg/agent/config_resolver_test.go
+++ b/pkg/agent/config_resolver_test.go
@@ -1241,6 +1241,56 @@ func TestResolvedFallbackProviders(t *testing.T) {
 		assert.Nil(t, resolved.ResolvedFallbackProviders)
 	})
 
+	t.Run("agent native tool overrides applied to fallback entries", func(t *testing.T) {
+		// Provider fb-1 has google_search enabled in its registry config
+		fbWithNativeTools := &config.LLMProviderConfig{
+			Type:      config.LLMProviderTypeGoogle,
+			Model:     "gemini-fb-native",
+			APIKeyEnv: "GOOGLE_API_KEY",
+			NativeTools: map[config.GoogleNativeTool]bool{
+				config.GoogleNativeToolGoogleSearch: true,
+			},
+		}
+		cfgNative := &config.Config{
+			Defaults: &config.Defaults{
+				LLMProvider: "primary",
+				FallbackProviders: []config.FallbackProviderEntry{
+					{Provider: "fb-native", Backend: config.LLMBackendNativeGemini},
+				},
+			},
+			AgentRegistry: config.NewAgentRegistry(map[string]*config.AgentConfig{
+				"NativeAgent": {
+					NativeTools: map[config.GoogleNativeTool]bool{
+						config.GoogleNativeToolCodeExecution: true,
+						config.GoogleNativeToolGoogleSearch:  false, // override: disable search
+					},
+				},
+			}),
+			LLMProviderRegistry: config.NewLLMProviderRegistry(map[string]*config.LLMProviderConfig{
+				"primary":   primaryProvider,
+				"fb-native": fbWithNativeTools,
+			}),
+		}
+
+		resolved, err := ResolveAgentConfig(cfgNative,
+			&config.ChainConfig{},
+			config.StageConfig{},
+			config.StageAgentConfig{Name: "NativeAgent"},
+		)
+		require.NoError(t, err)
+		require.Len(t, resolved.ResolvedFallbackProviders, 1)
+
+		fbConfig := resolved.ResolvedFallbackProviders[0].Config
+		assert.False(t, fbConfig.NativeTools[config.GoogleNativeToolGoogleSearch],
+			"agent override should disable google_search on fallback")
+		assert.True(t, fbConfig.NativeTools[config.GoogleNativeToolCodeExecution],
+			"agent override should enable code_execution on fallback")
+
+		// Primary provider should also have the same overrides
+		assert.False(t, resolved.LLMProvider.NativeTools[config.GoogleNativeToolGoogleSearch])
+		assert.True(t, resolved.LLMProvider.NativeTools[config.GoogleNativeToolCodeExecution])
+	})
+
 	t.Run("missing provider in registry is skipped", func(t *testing.T) {
 		cfgMissing := &config.Config{
 			Defaults: &config.Defaults{

--- a/pkg/agent/context.go
+++ b/pkg/agent/context.go
@@ -73,6 +73,14 @@ type ServiceBundle struct {
 	Stage       *services.StageService
 }
 
+// ResolvedFallbackEntry is a pre-resolved fallback provider with its full config.
+// Built during config resolution so the controller never needs registry access.
+type ResolvedFallbackEntry struct {
+	ProviderName string
+	Backend      config.LLMBackend
+	Config       *config.LLMProviderConfig
+}
+
 // ResolvedAgentConfig is the fully-resolved configuration for an agent execution.
 // All hierarchy levels (defaults → chain → stage → agent) have been applied.
 type ResolvedAgentConfig struct {
@@ -90,6 +98,8 @@ type ResolvedAgentConfig struct {
 
 	// Fallback providers to try when the primary provider fails (ordered by preference)
 	FallbackProviders []config.FallbackProviderEntry
+	// Pre-resolved fallback provider configs (parallel to FallbackProviders)
+	ResolvedFallbackProviders []ResolvedFallbackEntry
 
 	// Adaptive timeout: max wait for the first streaming chunk (default: 120s)
 	InitialResponseTimeout time.Duration

--- a/pkg/agent/controller/fallback.go
+++ b/pkg/agent/controller/fallback.go
@@ -15,7 +15,7 @@ import (
 
 // Thresholds: fallback triggers when the consecutive error count reaches this value.
 const (
-	nonRetryableThreshold  = 2 // provider_error / invalid_request: fallback after 2 consecutive errors
+	providerErrorThreshold = 2 // provider_error / invalid_request / transport: fallback after 2 consecutive errors
 	partialStreamThreshold = 2 // partial_stream_error: fallback after 2 consecutive errors
 )
 
@@ -27,7 +27,7 @@ type FallbackState struct {
 	CurrentProviderIndex     int // -1 = primary, 0+ = index into ResolvedFallbackProviders
 	AttemptedProviders       []string
 	FallbackReason           string
-	ConsecutiveNonRetryable  int // counts consecutive provider_error / invalid_request
+	ConsecutiveProviderErrors int // counts consecutive provider_error / invalid_request / transport failures
 	ConsecutivePartialErrors int // counts consecutive partial_stream_error
 	ClearCacheNeeded         bool
 }
@@ -57,9 +57,9 @@ func (s *FallbackState) shouldFallback(err error, fallbackProviders []agent.Reso
 	if !errors.As(err, &poe) {
 		// Not an LLM error (e.g. gRPC transport failure) — no error code to
 		// inspect. Treat like a provider_error for fallback purposes.
-		s.ConsecutiveNonRetryable++
+		s.ConsecutiveProviderErrors++
 		s.ConsecutivePartialErrors = 0
-		return s.ConsecutiveNonRetryable >= nonRetryableThreshold
+		return s.ConsecutiveProviderErrors >= providerErrorThreshold
 	}
 
 	if poe.IsLoop {
@@ -76,26 +76,26 @@ func (s *FallbackState) shouldFallback(err error, fallbackProviders []agent.Reso
 		return true
 
 	case LLMErrorProviderError, LLMErrorInvalidRequest:
-		s.ConsecutiveNonRetryable++
+		s.ConsecutiveProviderErrors++
 		s.ConsecutivePartialErrors = 0
-		return s.ConsecutiveNonRetryable >= nonRetryableThreshold
+		return s.ConsecutiveProviderErrors >= providerErrorThreshold
 
 	case LLMErrorPartialStreamError:
 		s.ConsecutivePartialErrors++
-		s.ConsecutiveNonRetryable = 0
+		s.ConsecutiveProviderErrors = 0
 		return s.ConsecutivePartialErrors >= partialStreamThreshold
 
 	default:
 		// Unknown code — treat conservatively like provider_error
-		s.ConsecutiveNonRetryable++
+		s.ConsecutiveProviderErrors++
 		s.ConsecutivePartialErrors = 0
-		return s.ConsecutiveNonRetryable >= nonRetryableThreshold
+		return s.ConsecutiveProviderErrors >= providerErrorThreshold
 	}
 }
 
 // resetCounters resets consecutive error counters after a successful fallback switch.
 func (s *FallbackState) resetCounters() {
-	s.ConsecutiveNonRetryable = 0
+	s.ConsecutiveProviderErrors = 0
 	s.ConsecutivePartialErrors = 0
 }
 

--- a/pkg/agent/controller/fallback.go
+++ b/pkg/agent/controller/fallback.go
@@ -15,8 +15,8 @@ import (
 
 // Thresholds for consecutive error counters before fallback triggers.
 const (
-	nonRetryableThreshold    = 1 // provider_error / invalid_request: fallback after 1 Go retry
-	partialStreamThreshold   = 2 // partial_stream_error: fallback after 2 consecutive occurrences
+	nonRetryableThreshold  = 1 // provider_error / invalid_request: fallback after 1 Go retry
+	partialStreamThreshold = 2 // partial_stream_error: fallback after 2 consecutive occurrences
 )
 
 // FallbackState tracks fallback progress within a single execution.
@@ -24,7 +24,7 @@ const (
 type FallbackState struct {
 	OriginalProvider         string
 	OriginalBackend          config.LLMBackend
-	CurrentProviderIndex     int      // -1 = primary, 0+ = index into ResolvedFallbackProviders
+	CurrentProviderIndex     int // -1 = primary, 0+ = index into ResolvedFallbackProviders
 	AttemptedProviders       []string
 	FallbackReason           string
 	ConsecutiveNonRetryable  int // counts consecutive provider_error / invalid_request

--- a/pkg/agent/controller/fallback.go
+++ b/pkg/agent/controller/fallback.go
@@ -63,7 +63,11 @@ func (s *FallbackState) shouldFallback(err error, fallbackProviders []agent.Reso
 	}
 
 	if poe.IsLoop {
-		return false // loop detection is not a provider issue
+		// Loop detection is not a provider issue — break any consecutive streak
+		// so a subsequent provider error doesn't inherit the pre-loop count.
+		s.ConsecutiveProviderErrors = 0
+		s.ConsecutivePartialErrors = 0
+		return false
 	}
 
 	switch poe.Code {

--- a/pkg/agent/controller/fallback.go
+++ b/pkg/agent/controller/fallback.go
@@ -13,10 +13,10 @@ import (
 
 // Error code constants are defined in streaming.go as LLMErrorCode values.
 
-// Thresholds for consecutive error counters before fallback triggers.
+// Thresholds: fallback triggers when the consecutive error count reaches this value.
 const (
-	nonRetryableThreshold  = 1 // provider_error / invalid_request: fallback after 1 Go retry
-	partialStreamThreshold = 2 // partial_stream_error: fallback after 2 consecutive occurrences
+	nonRetryableThreshold  = 2 // provider_error / invalid_request: fallback after 2 consecutive errors
+	partialStreamThreshold = 2 // partial_stream_error: fallback after 2 consecutive errors
 )
 
 // FallbackState tracks fallback progress within a single execution.
@@ -59,7 +59,7 @@ func (s *FallbackState) shouldFallback(err error, fallbackProviders []agent.Reso
 		// inspect. Treat like a provider_error for fallback purposes.
 		s.ConsecutiveNonRetryable++
 		s.ConsecutivePartialErrors = 0
-		return s.ConsecutiveNonRetryable > nonRetryableThreshold
+		return s.ConsecutiveNonRetryable >= nonRetryableThreshold
 	}
 
 	if poe.IsLoop {
@@ -78,7 +78,7 @@ func (s *FallbackState) shouldFallback(err error, fallbackProviders []agent.Reso
 	case LLMErrorProviderError, LLMErrorInvalidRequest:
 		s.ConsecutiveNonRetryable++
 		s.ConsecutivePartialErrors = 0
-		return s.ConsecutiveNonRetryable > nonRetryableThreshold
+		return s.ConsecutiveNonRetryable >= nonRetryableThreshold
 
 	case LLMErrorPartialStreamError:
 		s.ConsecutivePartialErrors++
@@ -89,7 +89,7 @@ func (s *FallbackState) shouldFallback(err error, fallbackProviders []agent.Reso
 		// Unknown code — treat conservatively like provider_error
 		s.ConsecutiveNonRetryable++
 		s.ConsecutivePartialErrors = 0
-		return s.ConsecutiveNonRetryable > nonRetryableThreshold
+		return s.ConsecutiveNonRetryable >= nonRetryableThreshold
 	}
 }
 
@@ -128,6 +128,8 @@ func tryFallback(
 		return false
 	}
 
+	// Defensive: shouldFallback already rejects exhausted lists, but guard
+	// the slice access in case the two checks ever diverge.
 	nextIdx := state.CurrentProviderIndex + 1
 	if nextIdx >= len(execCtx.Config.ResolvedFallbackProviders) {
 		return false

--- a/pkg/agent/controller/fallback.go
+++ b/pkg/agent/controller/fallback.go
@@ -22,14 +22,14 @@ const (
 // FallbackState tracks fallback progress within a single execution.
 // Initialized once at the start of Run() and carried through all iterations.
 type FallbackState struct {
-	OriginalProvider         string
-	OriginalBackend          config.LLMBackend
-	CurrentProviderIndex     int // -1 = primary, 0+ = index into ResolvedFallbackProviders
-	AttemptedProviders       []string
-	FallbackReason           string
+	OriginalProvider          string
+	OriginalBackend           config.LLMBackend
+	CurrentProviderIndex      int // -1 = primary, 0+ = index into ResolvedFallbackProviders
+	AttemptedProviders        []string
+	FallbackReason            string
 	ConsecutiveProviderErrors int // counts consecutive provider_error / invalid_request / transport failures
-	ConsecutivePartialErrors int // counts consecutive partial_stream_error
-	ClearCacheNeeded         bool
+	ConsecutivePartialErrors  int // counts consecutive partial_stream_error
+	ClearCacheNeeded          bool
 }
 
 // NewFallbackState creates a FallbackState initialized from the current provider.
@@ -140,6 +140,18 @@ func tryFallback(
 	prevProvider := execCtx.Config.LLMProviderName
 	prevBackend := execCtx.Config.LLMBackend
 
+	// Check for native tools that will be lost on backend switch.
+	droppedTools := nativeToolsDroppedOnFallback(execCtx.Config.LLMProvider, entry.Backend)
+	if len(droppedTools) > 0 {
+		slog.Warn("Fallback provider does not support native tools; capabilities will be reduced",
+			"session_id", execCtx.SessionID,
+			"execution_id", execCtx.ExecutionID,
+			"dropped_tools", droppedTools,
+			"from_backend", prevBackend,
+			"to_backend", entry.Backend,
+		)
+	}
+
 	// Swap provider in the execution config
 	execCtx.Config.LLMProvider = entry.Config
 	execCtx.Config.LLMProviderName = entry.ProviderName
@@ -170,6 +182,9 @@ func tryFallback(
 		"reason":            state.FallbackReason,
 		"attempt":           nextIdx + 1,
 	}
+	if len(droppedTools) > 0 {
+		meta["native_tools_dropped"] = droppedTools
+	}
 	createTimelineEvent(ctx, execCtx, timelineevent.EventTypeProviderFallback,
 		fmt.Sprintf("Provider fallback: %s → %s", prevProvider, entry.ProviderName),
 		meta, eventSeq)
@@ -187,6 +202,22 @@ func tryFallback(
 	}
 
 	return true
+}
+
+// nativeToolsDroppedOnFallback returns the list of enabled native tool names
+// that will be silently lost when switching to a backend that doesn't support
+// them (anything other than google-native). Returns nil when no tools are lost.
+func nativeToolsDroppedOnFallback(current *config.LLMProviderConfig, targetBackend config.LLMBackend) []string {
+	if targetBackend == config.LLMBackendNativeGemini {
+		return nil
+	}
+	var dropped []string
+	for tool, enabled := range current.NativeTools {
+		if enabled {
+			dropped = append(dropped, string(tool))
+		}
+	}
+	return dropped
 }
 
 // consumeClearCache returns the current ClearCacheNeeded value and resets it.

--- a/pkg/agent/controller/fallback.go
+++ b/pkg/agent/controller/fallback.go
@@ -1,0 +1,198 @@
+package controller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/codeready-toolchain/tarsy/ent/timelineevent"
+	"github.com/codeready-toolchain/tarsy/pkg/agent"
+	"github.com/codeready-toolchain/tarsy/pkg/config"
+)
+
+// Error code constants are defined in streaming.go as LLMErrorCode values.
+
+// Thresholds for consecutive error counters before fallback triggers.
+const (
+	nonRetryableThreshold    = 1 // provider_error / invalid_request: fallback after 1 Go retry
+	partialStreamThreshold   = 2 // partial_stream_error: fallback after 2 consecutive occurrences
+)
+
+// FallbackState tracks fallback progress within a single execution.
+// Initialized once at the start of Run() and carried through all iterations.
+type FallbackState struct {
+	OriginalProvider         string
+	OriginalBackend          config.LLMBackend
+	CurrentProviderIndex     int      // -1 = primary, 0+ = index into ResolvedFallbackProviders
+	AttemptedProviders       []string
+	FallbackReason           string
+	ConsecutiveNonRetryable  int // counts consecutive provider_error / invalid_request
+	ConsecutivePartialErrors int // counts consecutive partial_stream_error
+	ClearCacheNeeded         bool
+}
+
+// NewFallbackState creates a FallbackState initialized from the current provider.
+func NewFallbackState(execCtx *agent.ExecutionContext) *FallbackState {
+	return &FallbackState{
+		OriginalProvider:     execCtx.Config.LLMProviderName,
+		OriginalBackend:      execCtx.Config.LLMBackend,
+		CurrentProviderIndex: -1,
+		AttemptedProviders:   []string{execCtx.Config.LLMProviderName},
+	}
+}
+
+// shouldFallback inspects the error, updates internal counters, and returns
+// whether a fallback switch should happen NOW. It does NOT advance the provider
+// index — that happens in applyFallback.
+func (s *FallbackState) shouldFallback(err error, fallbackProviders []agent.ResolvedFallbackEntry) bool {
+	if len(fallbackProviders) == 0 {
+		return false
+	}
+	if s.CurrentProviderIndex+1 >= len(fallbackProviders) {
+		return false // all fallback providers exhausted
+	}
+
+	var poe *PartialOutputError
+	if !errors.As(err, &poe) {
+		// Not an LLM error (e.g. gRPC transport failure) — no error code to
+		// inspect. Treat like a provider_error for fallback purposes.
+		s.ConsecutiveNonRetryable++
+		s.ConsecutivePartialErrors = 0
+		return s.ConsecutiveNonRetryable > nonRetryableThreshold
+	}
+
+	if poe.IsLoop {
+		return false // loop detection is not a provider issue
+	}
+
+	switch poe.Code {
+	case LLMErrorMaxRetries:
+		// Python already retried 3x — fallback immediately
+		return true
+
+	case LLMErrorCredentials:
+		// Guaranteed failure — fallback immediately
+		return true
+
+	case LLMErrorProviderError, LLMErrorInvalidRequest:
+		s.ConsecutiveNonRetryable++
+		s.ConsecutivePartialErrors = 0
+		return s.ConsecutiveNonRetryable > nonRetryableThreshold
+
+	case LLMErrorPartialStreamError:
+		s.ConsecutivePartialErrors++
+		s.ConsecutiveNonRetryable = 0
+		return s.ConsecutivePartialErrors >= partialStreamThreshold
+
+	default:
+		// Unknown code — treat conservatively like provider_error
+		s.ConsecutiveNonRetryable++
+		s.ConsecutivePartialErrors = 0
+		return s.ConsecutiveNonRetryable > nonRetryableThreshold
+	}
+}
+
+// resetCounters resets consecutive error counters after a successful fallback switch.
+func (s *FallbackState) resetCounters() {
+	s.ConsecutiveNonRetryable = 0
+	s.ConsecutivePartialErrors = 0
+}
+
+// HasFallbackOccurred returns true if the provider has been switched from the primary.
+func (s *FallbackState) HasFallbackOccurred() bool {
+	return s.CurrentProviderIndex >= 0
+}
+
+// tryFallback checks whether fallback should trigger for the given error and,
+// if so, performs the full provider swap: updates execCtx, records a timeline
+// event, and updates the execution record. Returns true if the caller should
+// retry the LLM call with the new provider.
+//
+// Returns false (and does nothing) when:
+//   - fallback should not trigger (error code / counters)
+//   - all fallback providers are exhausted
+//   - the parent context is done
+func tryFallback(
+	ctx context.Context,
+	execCtx *agent.ExecutionContext,
+	state *FallbackState,
+	err error,
+	eventSeq *int,
+) bool {
+	if ctx.Err() != nil {
+		return false
+	}
+
+	if !state.shouldFallback(err, execCtx.Config.ResolvedFallbackProviders) {
+		return false
+	}
+
+	nextIdx := state.CurrentProviderIndex + 1
+	if nextIdx >= len(execCtx.Config.ResolvedFallbackProviders) {
+		return false
+	}
+
+	entry := execCtx.Config.ResolvedFallbackProviders[nextIdx]
+
+	prevProvider := execCtx.Config.LLMProviderName
+	prevBackend := execCtx.Config.LLMBackend
+
+	// Swap provider in the execution config
+	execCtx.Config.LLMProvider = entry.Config
+	execCtx.Config.LLMProviderName = entry.ProviderName
+	execCtx.Config.LLMBackend = entry.Backend
+
+	state.CurrentProviderIndex = nextIdx
+	state.FallbackReason = err.Error()
+	state.AttemptedProviders = append(state.AttemptedProviders, entry.ProviderName)
+	state.ClearCacheNeeded = true
+	state.resetCounters()
+
+	slog.Info("Falling back to next LLM provider",
+		"session_id", execCtx.SessionID,
+		"execution_id", execCtx.ExecutionID,
+		"from_provider", prevProvider,
+		"from_backend", prevBackend,
+		"to_provider", entry.ProviderName,
+		"to_backend", entry.Backend,
+		"reason", state.FallbackReason,
+	)
+
+	// Record provider_fallback timeline event
+	meta := map[string]interface{}{
+		"original_provider": prevProvider,
+		"original_backend":  string(prevBackend),
+		"fallback_provider": entry.ProviderName,
+		"fallback_backend":  string(entry.Backend),
+		"reason":            state.FallbackReason,
+		"attempt":           nextIdx + 1,
+	}
+	createTimelineEvent(ctx, execCtx, timelineevent.EventTypeProviderFallback,
+		fmt.Sprintf("Provider fallback: %s → %s", prevProvider, entry.ProviderName),
+		meta, eventSeq)
+
+	// Update execution record (best-effort — don't block on DB failure)
+	if execCtx.Services != nil && execCtx.Services.Stage != nil {
+		if updateErr := execCtx.Services.Stage.UpdateExecutionProviderFallback(
+			ctx, execCtx.ExecutionID,
+			state.OriginalProvider, string(state.OriginalBackend),
+			entry.ProviderName, string(entry.Backend),
+		); updateErr != nil {
+			slog.Warn("Failed to update execution fallback record",
+				"execution_id", execCtx.ExecutionID, "error", updateErr)
+		}
+	}
+
+	return true
+}
+
+// consumeClearCache returns the current ClearCacheNeeded value and resets it.
+// Call this when building the GenerateInput for the next LLM call.
+func (s *FallbackState) consumeClearCache() bool {
+	if s.ClearCacheNeeded {
+		s.ClearCacheNeeded = false
+		return true
+	}
+	return false
+}

--- a/pkg/agent/controller/fallback_test.go
+++ b/pkg/agent/controller/fallback_test.go
@@ -139,17 +139,17 @@ func TestShouldFallback_ConsecutiveCounterReset(t *testing.T) {
 
 	// One provider_error — counter at 1
 	state.shouldFallback(makePartialError(LLMErrorProviderError), providers)
-	assert.Equal(t, 1, state.ConsecutiveNonRetryable)
+	assert.Equal(t, 1, state.ConsecutiveProviderErrors)
 
-	// Partial stream error resets the non-retryable counter
+	// Partial stream error resets the provider error counter
 	state.shouldFallback(makePartialError(LLMErrorPartialStreamError), providers)
-	assert.Equal(t, 0, state.ConsecutiveNonRetryable)
+	assert.Equal(t, 0, state.ConsecutiveProviderErrors)
 	assert.Equal(t, 1, state.ConsecutivePartialErrors)
 
 	// Provider error resets the partial counter
 	state.shouldFallback(makePartialError(LLMErrorProviderError), providers)
 	assert.Equal(t, 0, state.ConsecutivePartialErrors)
-	assert.Equal(t, 1, state.ConsecutiveNonRetryable)
+	assert.Equal(t, 1, state.ConsecutiveProviderErrors)
 }
 
 func TestShouldFallback_NonPartialError_TreatedAsProviderError(t *testing.T) {
@@ -188,16 +188,16 @@ func TestShouldFallback_MixedErrors_BreaksConsecutiveCount(t *testing.T) {
 	// provider_error → partial_stream_error → provider_error: none should trigger
 	// because consecutive counts reset when the error type changes.
 	state.shouldFallback(makePartialError(LLMErrorProviderError), providers)
-	assert.Equal(t, 1, state.ConsecutiveNonRetryable)
+	assert.Equal(t, 1, state.ConsecutiveProviderErrors)
 
 	state.shouldFallback(makePartialError(LLMErrorPartialStreamError), providers)
-	assert.Equal(t, 0, state.ConsecutiveNonRetryable, "provider_error count reset by partial")
+	assert.Equal(t, 0, state.ConsecutiveProviderErrors, "provider_error count reset by partial")
 	assert.Equal(t, 1, state.ConsecutivePartialErrors)
 
 	result := state.shouldFallback(makePartialError(LLMErrorProviderError), providers)
 	assert.False(t, result, "alternating errors should never reach threshold")
 	assert.Equal(t, 0, state.ConsecutivePartialErrors, "partial count reset by provider_error")
-	assert.Equal(t, 1, state.ConsecutiveNonRetryable)
+	assert.Equal(t, 1, state.ConsecutiveProviderErrors)
 }
 
 // ────────────────────────────────────────────────────────────
@@ -224,11 +224,11 @@ func TestFallbackState_HasFallbackOccurred(t *testing.T) {
 
 func TestFallbackState_ResetCounters(t *testing.T) {
 	state := newTestFallbackState()
-	state.ConsecutiveNonRetryable = 3
+	state.ConsecutiveProviderErrors = 3
 	state.ConsecutivePartialErrors = 2
 
 	state.resetCounters()
-	assert.Equal(t, 0, state.ConsecutiveNonRetryable)
+	assert.Equal(t, 0, state.ConsecutiveProviderErrors)
 	assert.Equal(t, 0, state.ConsecutivePartialErrors)
 }
 
@@ -248,7 +248,7 @@ func TestTryFallback_SwapsProviderAndRecordsEvents(t *testing.T) {
 
 	state := NewFallbackState(execCtx)
 	// Simulate immediate-fallback error
-	state.ConsecutiveNonRetryable = nonRetryableThreshold + 1
+	state.ConsecutiveProviderErrors = providerErrorThreshold + 1
 
 	eventSeq := 0
 	err := makePartialError(LLMErrorMaxRetries)
@@ -265,7 +265,7 @@ func TestTryFallback_SwapsProviderAndRecordsEvents(t *testing.T) {
 	assert.Equal(t, 0, state.CurrentProviderIndex)
 	assert.True(t, state.ClearCacheNeeded)
 	assert.Contains(t, state.AttemptedProviders, "fallback-1")
-	assert.Equal(t, 0, state.ConsecutiveNonRetryable, "counters should be reset")
+	assert.Equal(t, 0, state.ConsecutiveProviderErrors, "counters should be reset")
 
 	// Verify timeline event was created (eventSeq should have incremented)
 	assert.Equal(t, 1, eventSeq, "a timeline event should have been created")

--- a/pkg/agent/controller/fallback_test.go
+++ b/pkg/agent/controller/fallback_test.go
@@ -1,0 +1,348 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/codeready-toolchain/tarsy/pkg/agent"
+	"github.com/codeready-toolchain/tarsy/pkg/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func fallbackProviders() []agent.ResolvedFallbackEntry {
+	return []agent.ResolvedFallbackEntry{
+		{
+			ProviderName: "fallback-1",
+			Backend:      config.LLMBackendNativeGemini,
+			Config:       &config.LLMProviderConfig{Model: "fallback-model-1"},
+		},
+		{
+			ProviderName: "fallback-2",
+			Backend:      config.LLMBackendLangChain,
+			Config:       &config.LLMProviderConfig{Model: "fallback-model-2"},
+		},
+	}
+}
+
+func newTestFallbackState() *FallbackState {
+	return &FallbackState{
+		OriginalProvider:     "primary-provider",
+		OriginalBackend:      config.LLMBackendLangChain,
+		CurrentProviderIndex: -1,
+		AttemptedProviders:   []string{"primary-provider"},
+	}
+}
+
+func makePartialError(code LLMErrorCode) error {
+	return &PartialOutputError{
+		Cause:     fmt.Errorf("test error (code: %s)", code),
+		Code:      code,
+		Retryable: false,
+	}
+}
+
+// ────────────────────────────────────────────────────────────
+// shouldFallback tests
+// ────────────────────────────────────────────────────────────
+
+func TestShouldFallback_MaxRetries_Immediate(t *testing.T) {
+	state := newTestFallbackState()
+	providers := fallbackProviders()
+
+	result := state.shouldFallback(makePartialError(LLMErrorMaxRetries), providers)
+	assert.True(t, result, "max_retries should trigger immediate fallback")
+}
+
+func TestShouldFallback_Credentials_Immediate(t *testing.T) {
+	state := newTestFallbackState()
+	providers := fallbackProviders()
+
+	result := state.shouldFallback(makePartialError(LLMErrorCredentials), providers)
+	assert.True(t, result, "credentials should trigger immediate fallback")
+}
+
+func TestShouldFallback_ProviderError_AfterOneRetry(t *testing.T) {
+	state := newTestFallbackState()
+	providers := fallbackProviders()
+
+	// First occurrence — should NOT trigger fallback (let Go retry)
+	result := state.shouldFallback(makePartialError(LLMErrorProviderError), providers)
+	assert.False(t, result, "first provider_error should not trigger fallback")
+
+	// Second consecutive — should trigger
+	result = state.shouldFallback(makePartialError(LLMErrorProviderError), providers)
+	assert.True(t, result, "second consecutive provider_error should trigger fallback")
+}
+
+func TestShouldFallback_InvalidRequest_AfterOneRetry(t *testing.T) {
+	state := newTestFallbackState()
+	providers := fallbackProviders()
+
+	result := state.shouldFallback(makePartialError(LLMErrorInvalidRequest), providers)
+	assert.False(t, result, "first invalid_request should not trigger fallback")
+
+	result = state.shouldFallback(makePartialError(LLMErrorInvalidRequest), providers)
+	assert.True(t, result, "second consecutive invalid_request should trigger fallback")
+}
+
+func TestShouldFallback_PartialStreamError_AfterTwo(t *testing.T) {
+	state := newTestFallbackState()
+	providers := fallbackProviders()
+
+	result := state.shouldFallback(makePartialError(LLMErrorPartialStreamError), providers)
+	assert.False(t, result, "first partial_stream_error should not trigger")
+
+	result = state.shouldFallback(makePartialError(LLMErrorPartialStreamError), providers)
+	assert.True(t, result, "second consecutive partial_stream_error should trigger")
+}
+
+func TestShouldFallback_LoopError_NeverTriggers(t *testing.T) {
+	state := newTestFallbackState()
+	providers := fallbackProviders()
+
+	loopErr := &PartialOutputError{
+		Cause:  fmt.Errorf("loop detected"),
+		IsLoop: true,
+		Code:   LLMErrorPartialStreamError,
+	}
+
+	for i := 0; i < 5; i++ {
+		result := state.shouldFallback(loopErr, providers)
+		assert.False(t, result, "loop error should never trigger fallback")
+	}
+}
+
+func TestShouldFallback_EmptyFallbackList(t *testing.T) {
+	state := newTestFallbackState()
+
+	result := state.shouldFallback(makePartialError(LLMErrorMaxRetries), nil)
+	assert.False(t, result, "should not trigger with empty fallback list")
+
+	result = state.shouldFallback(makePartialError(LLMErrorMaxRetries), []agent.ResolvedFallbackEntry{})
+	assert.False(t, result, "should not trigger with empty fallback list")
+}
+
+func TestShouldFallback_AllProvidersExhausted(t *testing.T) {
+	state := newTestFallbackState()
+	state.CurrentProviderIndex = 1 // already at last index
+	providers := fallbackProviders()
+
+	result := state.shouldFallback(makePartialError(LLMErrorMaxRetries), providers)
+	assert.False(t, result, "should not trigger when all providers exhausted")
+}
+
+func TestShouldFallback_ConsecutiveCounterReset(t *testing.T) {
+	state := newTestFallbackState()
+	providers := fallbackProviders()
+
+	// One provider_error — counter at 1
+	state.shouldFallback(makePartialError(LLMErrorProviderError), providers)
+	assert.Equal(t, 1, state.ConsecutiveNonRetryable)
+
+	// Partial stream error resets the non-retryable counter
+	state.shouldFallback(makePartialError(LLMErrorPartialStreamError), providers)
+	assert.Equal(t, 0, state.ConsecutiveNonRetryable)
+	assert.Equal(t, 1, state.ConsecutivePartialErrors)
+
+	// Provider error resets the partial counter
+	state.shouldFallback(makePartialError(LLMErrorProviderError), providers)
+	assert.Equal(t, 0, state.ConsecutivePartialErrors)
+	assert.Equal(t, 1, state.ConsecutiveNonRetryable)
+}
+
+func TestShouldFallback_NonPartialError_TreatedAsProviderError(t *testing.T) {
+	state := newTestFallbackState()
+	providers := fallbackProviders()
+
+	plainErr := fmt.Errorf("gRPC transport failure")
+
+	result := state.shouldFallback(plainErr, providers)
+	assert.False(t, result, "first non-POE error should not trigger")
+
+	result = state.shouldFallback(plainErr, providers)
+	assert.True(t, result, "second consecutive non-POE error should trigger")
+}
+
+// ────────────────────────────────────────────────────────────
+// FallbackState lifecycle tests
+// ────────────────────────────────────────────────────────────
+
+func TestFallbackState_ConsumesClearCache(t *testing.T) {
+	state := newTestFallbackState()
+
+	assert.False(t, state.consumeClearCache(), "initially no clear cache needed")
+
+	state.ClearCacheNeeded = true
+	assert.True(t, state.consumeClearCache(), "should return true and consume")
+	assert.False(t, state.consumeClearCache(), "should be false after consumption")
+}
+
+func TestFallbackState_HasFallbackOccurred(t *testing.T) {
+	state := newTestFallbackState()
+	assert.False(t, state.HasFallbackOccurred())
+
+	state.CurrentProviderIndex = 0
+	assert.True(t, state.HasFallbackOccurred())
+}
+
+func TestFallbackState_ResetCounters(t *testing.T) {
+	state := newTestFallbackState()
+	state.ConsecutiveNonRetryable = 3
+	state.ConsecutivePartialErrors = 2
+
+	state.resetCounters()
+	assert.Equal(t, 0, state.ConsecutiveNonRetryable)
+	assert.Equal(t, 0, state.ConsecutivePartialErrors)
+}
+
+// ────────────────────────────────────────────────────────────
+// tryFallback integration tests (with real DB)
+// ────────────────────────────────────────────────────────────
+
+func TestTryFallback_SwapsProviderAndRecordsEvents(t *testing.T) {
+	llm := &mockLLMClient{
+		responses: []mockLLMResponse{
+			{chunks: []agent.Chunk{&agent.TextChunk{Content: "hello"}}},
+		},
+	}
+	execCtx := newTestExecCtx(t, llm, &mockToolExecutor{})
+	execCtx.Config.LLMProviderName = "primary"
+	execCtx.Config.ResolvedFallbackProviders = fallbackProviders()
+
+	state := NewFallbackState(execCtx)
+	// Simulate immediate-fallback error
+	state.ConsecutiveNonRetryable = nonRetryableThreshold + 1
+
+	eventSeq := 0
+	err := makePartialError(LLMErrorMaxRetries)
+
+	result := tryFallback(context.Background(), execCtx, state, err, &eventSeq)
+	require.True(t, result, "tryFallback should succeed")
+
+	// Verify provider was swapped
+	assert.Equal(t, "fallback-1", execCtx.Config.LLMProviderName)
+	assert.Equal(t, config.LLMBackendNativeGemini, execCtx.Config.LLMBackend)
+	assert.Equal(t, "fallback-model-1", execCtx.Config.LLMProvider.Model)
+
+	// Verify state updated
+	assert.Equal(t, 0, state.CurrentProviderIndex)
+	assert.True(t, state.ClearCacheNeeded)
+	assert.Contains(t, state.AttemptedProviders, "fallback-1")
+	assert.Equal(t, 0, state.ConsecutiveNonRetryable, "counters should be reset")
+
+	// Verify timeline event was created (eventSeq should have incremented)
+	assert.Equal(t, 1, eventSeq, "a timeline event should have been created")
+}
+
+func TestTryFallback_ExhaustsFallbackList(t *testing.T) {
+	llm := &mockLLMClient{
+		responses: []mockLLMResponse{
+			{chunks: []agent.Chunk{&agent.TextChunk{Content: "hello"}}},
+		},
+	}
+	execCtx := newTestExecCtx(t, llm, &mockToolExecutor{})
+	execCtx.Config.LLMProviderName = "primary"
+	execCtx.Config.ResolvedFallbackProviders = fallbackProviders()
+
+	state := NewFallbackState(execCtx)
+	eventSeq := 0
+
+	// First fallback: success
+	result := tryFallback(context.Background(), execCtx, state,
+		makePartialError(LLMErrorMaxRetries), &eventSeq)
+	require.True(t, result)
+
+	// Second fallback: success
+	result = tryFallback(context.Background(), execCtx, state,
+		makePartialError(LLMErrorMaxRetries), &eventSeq)
+	require.True(t, result)
+	assert.Equal(t, "fallback-2", execCtx.Config.LLMProviderName)
+
+	// Third fallback: exhausted
+	result = tryFallback(context.Background(), execCtx, state,
+		makePartialError(LLMErrorMaxRetries), &eventSeq)
+	assert.False(t, result, "should fail when all providers exhausted")
+}
+
+func TestTryFallback_CancelledContext(t *testing.T) {
+	llm := &mockLLMClient{
+		responses: []mockLLMResponse{
+			{chunks: []agent.Chunk{&agent.TextChunk{Content: "hello"}}},
+		},
+	}
+	execCtx := newTestExecCtx(t, llm, &mockToolExecutor{})
+	execCtx.Config.ResolvedFallbackProviders = fallbackProviders()
+
+	state := NewFallbackState(execCtx)
+	eventSeq := 0
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	result := tryFallback(ctx, execCtx, state,
+		makePartialError(LLMErrorMaxRetries), &eventSeq)
+	assert.False(t, result, "should not fallback with cancelled context")
+}
+
+func TestTryFallback_UpdatesExecutionRecord(t *testing.T) {
+	llm := &mockLLMClient{
+		responses: []mockLLMResponse{
+			{chunks: []agent.Chunk{&agent.TextChunk{Content: "hello"}}},
+		},
+	}
+	execCtx := newTestExecCtx(t, llm, &mockToolExecutor{})
+	execCtx.Config.LLMProviderName = "primary"
+	execCtx.Config.ResolvedFallbackProviders = fallbackProviders()
+
+	state := NewFallbackState(execCtx)
+	eventSeq := 0
+
+	result := tryFallback(context.Background(), execCtx, state,
+		makePartialError(LLMErrorMaxRetries), &eventSeq)
+	require.True(t, result)
+
+	// Verify execution record was updated
+	exec, err := execCtx.Services.Stage.GetAgentExecutionByID(
+		context.Background(), execCtx.ExecutionID)
+	require.NoError(t, err)
+
+	require.NotNil(t, exec.OriginalLlmProvider, "original_llm_provider should be set")
+	assert.Equal(t, "primary", *exec.OriginalLlmProvider)
+	require.NotNil(t, exec.OriginalLlmBackend, "original_llm_backend should be set")
+	assert.Equal(t, string(config.LLMBackendLangChain), *exec.OriginalLlmBackend)
+	assert.Equal(t, "fallback-1", *exec.LlmProvider)
+	assert.Equal(t, string(config.LLMBackendNativeGemini), exec.LlmBackend)
+}
+
+func TestTryFallback_PreservesOriginalOnSecondFallback(t *testing.T) {
+	llm := &mockLLMClient{
+		responses: []mockLLMResponse{
+			{chunks: []agent.Chunk{&agent.TextChunk{Content: "hello"}}},
+		},
+	}
+	execCtx := newTestExecCtx(t, llm, &mockToolExecutor{})
+	execCtx.Config.LLMProviderName = "primary"
+	execCtx.Config.ResolvedFallbackProviders = fallbackProviders()
+
+	state := NewFallbackState(execCtx)
+	eventSeq := 0
+
+	// First fallback
+	tryFallback(context.Background(), execCtx, state,
+		makePartialError(LLMErrorMaxRetries), &eventSeq)
+
+	// Second fallback
+	tryFallback(context.Background(), execCtx, state,
+		makePartialError(LLMErrorMaxRetries), &eventSeq)
+
+	// Verify original is still "primary" (not "fallback-1")
+	exec, err := execCtx.Services.Stage.GetAgentExecutionByID(
+		context.Background(), execCtx.ExecutionID)
+	require.NoError(t, err)
+
+	require.NotNil(t, exec.OriginalLlmProvider)
+	assert.Equal(t, "primary", *exec.OriginalLlmProvider, "original should be preserved across multiple fallbacks")
+	assert.Equal(t, "fallback-2", *exec.LlmProvider, "current should be updated to latest fallback")
+}

--- a/pkg/agent/controller/fallback_test.go
+++ b/pkg/agent/controller/fallback_test.go
@@ -381,3 +381,71 @@ func TestTryFallback_PreservesOriginalOnSecondFallback(t *testing.T) {
 	assert.Equal(t, "primary", *exec.OriginalLlmProvider, "original should be preserved across multiple fallbacks")
 	assert.Equal(t, "fallback-2", *exec.LlmProvider, "current should be updated to latest fallback")
 }
+
+func TestNativeToolsDroppedOnFallback(t *testing.T) {
+	t.Run("no drop when target is google-native", func(t *testing.T) {
+		provider := &config.LLMProviderConfig{
+			NativeTools: map[config.GoogleNativeTool]bool{
+				config.GoogleNativeToolGoogleSearch: true,
+			},
+		}
+		dropped := nativeToolsDroppedOnFallback(provider, config.LLMBackendNativeGemini)
+		assert.Nil(t, dropped)
+	})
+
+	t.Run("drops enabled tools when target is langchain", func(t *testing.T) {
+		provider := &config.LLMProviderConfig{
+			NativeTools: map[config.GoogleNativeTool]bool{
+				config.GoogleNativeToolGoogleSearch:  true,
+				config.GoogleNativeToolCodeExecution: false, // disabled — not dropped
+				config.GoogleNativeToolURLContext:    true,
+			},
+		}
+		dropped := nativeToolsDroppedOnFallback(provider, config.LLMBackendLangChain)
+		assert.Len(t, dropped, 2)
+		assert.Contains(t, dropped, "google_search")
+		assert.Contains(t, dropped, "url_context")
+	})
+
+	t.Run("no drop when no native tools configured", func(t *testing.T) {
+		provider := &config.LLMProviderConfig{}
+		dropped := nativeToolsDroppedOnFallback(provider, config.LLMBackendLangChain)
+		assert.Nil(t, dropped)
+	})
+}
+
+func TestTryFallback_NativeToolsDroppedMetadata(t *testing.T) {
+	llm := &mockLLMClient{
+		responses: []mockLLMResponse{
+			{chunks: []agent.Chunk{&agent.TextChunk{Content: "hello"}}},
+		},
+	}
+	execCtx := newTestExecCtx(t, llm, &mockToolExecutor{})
+	execCtx.Config.LLMProviderName = "primary"
+	execCtx.Config.LLMProvider.NativeTools = map[config.GoogleNativeTool]bool{
+		config.GoogleNativeToolGoogleSearch: true,
+		config.GoogleNativeToolURLContext:   true,
+	}
+	// Fallback directly to langchain backend
+	execCtx.Config.ResolvedFallbackProviders = []agent.ResolvedFallbackEntry{
+		{
+			ProviderName: "langchain-fb",
+			Backend:      config.LLMBackendLangChain,
+			Config:       &config.LLMProviderConfig{Model: "gpt-fallback"},
+		},
+	}
+
+	state := NewFallbackState(execCtx)
+	eventSeq := 0
+
+	result := tryFallback(context.Background(), execCtx, state,
+		makePartialError(LLMErrorMaxRetries), &eventSeq)
+	require.True(t, result)
+
+	// Verify the timeline event was created (contains native_tools_dropped metadata)
+	assert.Equal(t, 1, eventSeq)
+
+	// Verify the provider was swapped to langchain
+	assert.Equal(t, "langchain-fb", execCtx.Config.LLMProviderName)
+	assert.Equal(t, config.LLMBackendLangChain, execCtx.Config.LLMBackend)
+}

--- a/pkg/agent/controller/fallback_test.go
+++ b/pkg/agent/controller/fallback_test.go
@@ -114,6 +114,31 @@ func TestShouldFallback_LoopError_NeverTriggers(t *testing.T) {
 	}
 }
 
+func TestShouldFallback_LoopError_BreaksConsecutiveStreak(t *testing.T) {
+	state := newTestFallbackState()
+	providers := fallbackProviders()
+
+	loopErr := &PartialOutputError{
+		Cause:  fmt.Errorf("loop detected"),
+		IsLoop: true,
+		Code:   LLMErrorPartialStreamError,
+	}
+
+	// provider_error → count=1
+	state.shouldFallback(makePartialError(LLMErrorProviderError), providers)
+	assert.Equal(t, 1, state.ConsecutiveProviderErrors)
+
+	// loop error resets the streak
+	state.shouldFallback(loopErr, providers)
+	assert.Equal(t, 0, state.ConsecutiveProviderErrors, "loop should reset provider streak")
+	assert.Equal(t, 0, state.ConsecutivePartialErrors, "loop should reset partial streak")
+
+	// Next provider_error starts from 0 again — no fallback
+	result := state.shouldFallback(makePartialError(LLMErrorProviderError), providers)
+	assert.False(t, result, "provider_error after loop should not trigger (streak was reset)")
+	assert.Equal(t, 1, state.ConsecutiveProviderErrors)
+}
+
 func TestShouldFallback_EmptyFallbackList(t *testing.T) {
 	state := newTestFallbackState()
 

--- a/pkg/agent/controller/fallback_test.go
+++ b/pkg/agent/controller/fallback_test.go
@@ -165,6 +165,41 @@ func TestShouldFallback_NonPartialError_TreatedAsProviderError(t *testing.T) {
 	assert.True(t, result, "second consecutive non-POE error should trigger")
 }
 
+func TestShouldFallback_UnknownCode_TreatedAsProviderError(t *testing.T) {
+	state := newTestFallbackState()
+	providers := fallbackProviders()
+
+	unknownErr := &PartialOutputError{
+		Cause: fmt.Errorf("something new"),
+		Code:  LLMErrorCode("new_error_code"),
+	}
+
+	result := state.shouldFallback(unknownErr, providers)
+	assert.False(t, result, "first unknown code should not trigger")
+
+	result = state.shouldFallback(unknownErr, providers)
+	assert.True(t, result, "second consecutive unknown code should trigger")
+}
+
+func TestShouldFallback_MixedErrors_BreaksConsecutiveCount(t *testing.T) {
+	state := newTestFallbackState()
+	providers := fallbackProviders()
+
+	// provider_error → partial_stream_error → provider_error: none should trigger
+	// because consecutive counts reset when the error type changes.
+	state.shouldFallback(makePartialError(LLMErrorProviderError), providers)
+	assert.Equal(t, 1, state.ConsecutiveNonRetryable)
+
+	state.shouldFallback(makePartialError(LLMErrorPartialStreamError), providers)
+	assert.Equal(t, 0, state.ConsecutiveNonRetryable, "provider_error count reset by partial")
+	assert.Equal(t, 1, state.ConsecutivePartialErrors)
+
+	result := state.shouldFallback(makePartialError(LLMErrorProviderError), providers)
+	assert.False(t, result, "alternating errors should never reach threshold")
+	assert.Equal(t, 0, state.ConsecutivePartialErrors, "partial count reset by provider_error")
+	assert.Equal(t, 1, state.ConsecutiveNonRetryable)
+}
+
 // ────────────────────────────────────────────────────────────
 // FallbackState lifecycle tests
 // ────────────────────────────────────────────────────────────

--- a/pkg/agent/controller/iterating.go
+++ b/pkg/agent/controller/iterating.go
@@ -32,6 +32,7 @@ func (c *IteratingController) Run(
 	maxIter := execCtx.Config.MaxIterations
 	totalUsage := agent.TokenUsage{}
 	state := &agent.IterationState{MaxIterations: maxIter}
+	fbState := NewFallbackState(execCtx)
 	msgSeq := 0
 
 	// Initialize eventSeq from DB to avoid collisions with events created
@@ -103,6 +104,7 @@ func (c *IteratingController) Run(
 			Config:      execCtx.Config.LLMProvider,
 			Tools:       tools, // Tools bound for native calling
 			Backend:     execCtx.Config.LLMBackend,
+			ClearCache:  fbState.consumeClearCache(),
 		}, &eventSeq)
 		llmCancel()
 
@@ -121,6 +123,11 @@ func (c *IteratingController) Run(
 					Error:      fmt.Errorf("execution interrupted: %w", err),
 					TokensUsed: totalUsage,
 				}, nil
+			}
+
+			// Try fallback to a different provider before exhausting retries
+			if tryFallback(ctx, execCtx, fbState, err, &eventSeq) {
+				continue
 			}
 
 			var poe *PartialOutputError
@@ -256,7 +263,7 @@ func (c *IteratingController) Run(
 	}
 
 	// Max iterations — force conclusion (call LLM WITHOUT tools)
-	return c.forceConclusion(ctx, execCtx, messages, &totalUsage, state, &msgSeq, &eventSeq)
+	return c.forceConclusion(ctx, execCtx, messages, &totalUsage, state, fbState, &msgSeq, &eventSeq)
 }
 
 // forceConclusion forces the LLM to produce a final answer by calling without tools.
@@ -266,6 +273,7 @@ func (c *IteratingController) forceConclusion(
 	messages []agent.ConversationMessage,
 	totalUsage *agent.TokenUsage,
 	state *agent.IterationState,
+	fbState *FallbackState,
 	msgSeq *int,
 	eventSeq *int,
 ) (*agent.ExecutionResult, error) {
@@ -289,23 +297,33 @@ func (c *IteratingController) forceConclusion(
 
 	// Call LLM WITHOUT tools with streaming — forces text-only response.
 	// Apply LLM call timeout (the parent ctx is the session context here).
-	llmCtx, llmCancel := context.WithTimeout(ctx, execCtx.Config.LLMCallTimeout)
-	streamed, err := callLLMWithStreaming(llmCtx, execCtx, execCtx.LLMClient, &agent.GenerateInput{
-		SessionID:   execCtx.SessionID,
-		ExecutionID: execCtx.ExecutionID,
-		Messages:    messages,
-		Config:      execCtx.Config.LLMProvider,
-		Tools:       nil, // No tools — force conclusion
-		Backend:     execCtx.Config.LLMBackend,
-	}, eventSeq, forcedMeta)
-	llmCancel()
-	if err != nil {
-		createTimelineEvent(ctx, execCtx, timelineevent.EventTypeError, err.Error(), nil, eventSeq)
-		return &agent.ExecutionResult{
-			Status:     agent.ExecutionStatusFailed,
-			Error:      fmt.Errorf("forced conclusion LLM call failed: %w", err),
-			TokensUsed: *totalUsage,
-		}, nil
+	// On failure, attempt fallback to another provider before giving up.
+	var streamed *StreamedResponse
+	var err error
+	for {
+		llmCtx, llmCancel := context.WithTimeout(ctx, execCtx.Config.LLMCallTimeout)
+		streamed, err = callLLMWithStreaming(llmCtx, execCtx, execCtx.LLMClient, &agent.GenerateInput{
+			SessionID:   execCtx.SessionID,
+			ExecutionID: execCtx.ExecutionID,
+			Messages:    messages,
+			Config:      execCtx.Config.LLMProvider,
+			Tools:       nil, // No tools — force conclusion
+			Backend:     execCtx.Config.LLMBackend,
+			ClearCache:  fbState.consumeClearCache(),
+		}, eventSeq, forcedMeta)
+		llmCancel()
+		if err == nil {
+			break
+		}
+		if !tryFallback(ctx, execCtx, fbState, err, eventSeq) {
+			createTimelineEvent(ctx, execCtx, timelineevent.EventTypeError, err.Error(), nil, eventSeq)
+			return &agent.ExecutionResult{
+				Status:     agent.ExecutionStatusFailed,
+				Error:      fmt.Errorf("forced conclusion LLM call failed: %w", err),
+				TokensUsed: *totalUsage,
+			}, nil
+		}
+		startTime = time.Now()
 	}
 	resp := streamed.LLMResponse
 

--- a/pkg/agent/controller/iterating.go
+++ b/pkg/agent/controller/iterating.go
@@ -113,11 +113,7 @@ func (c *IteratingController) Run(
 
 			// If the parent context is cancelled/expired, return immediately
 			// instead of burning through retry iterations with the same error.
-			if ctx.Err() != nil {
-				status := agent.ExecutionStatusCancelled
-				if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-					status = agent.ExecutionStatusTimedOut
-				}
+			if status, done := agent.StatusFromContextErr(ctx); done {
 				return &agent.ExecutionResult{
 					Status:     status,
 					Error:      fmt.Errorf("execution interrupted: %w", err),
@@ -223,14 +219,8 @@ func (c *IteratingController) Run(
 				msg, waitErr := collector.WaitForResult(ctx)
 				if waitErr != nil {
 					iterCancel()
-					status := agent.ExecutionStatusFailed
-					if errors.Is(waitErr, context.DeadlineExceeded) {
-						status = agent.ExecutionStatusTimedOut
-					} else if errors.Is(waitErr, context.Canceled) {
-						status = agent.ExecutionStatusCancelled
-					}
 					return &agent.ExecutionResult{
-						Status:     status,
+						Status:     agent.StatusFromErr(waitErr),
 						Error:      fmt.Errorf("sub-agent wait interrupted: %w", waitErr),
 						TokensUsed: totalUsage,
 					}, nil
@@ -301,6 +291,13 @@ func (c *IteratingController) forceConclusion(
 	var streamed *StreamedResponse
 	var err error
 	for {
+		if status, done := agent.StatusFromContextErr(ctx); done {
+			return &agent.ExecutionResult{
+				Status:     status,
+				Error:      fmt.Errorf("forced conclusion interrupted: %w", ctx.Err()),
+				TokensUsed: *totalUsage,
+			}, nil
+		}
 		llmCtx, llmCancel := context.WithTimeout(ctx, execCtx.Config.LLMCallTimeout)
 		streamed, err = callLLMWithStreaming(llmCtx, execCtx, execCtx.LLMClient, &agent.GenerateInput{
 			SessionID:   execCtx.SessionID,

--- a/pkg/agent/controller/iterating_test.go
+++ b/pkg/agent/controller/iterating_test.go
@@ -1007,11 +1007,7 @@ func TestIteratingController_FallbackOnMaxRetries(t *testing.T) {
 	execCtx := newTestExecCtx(t, llm, executor)
 	execCtx.Config.LLMProviderName = "primary-provider"
 	execCtx.Config.ResolvedFallbackProviders = []agent.ResolvedFallbackEntry{
-		{
-			ProviderName: "fallback-provider",
-			Backend:      config.LLMBackendNativeGemini,
-			Config:       &config.LLMProviderConfig{Model: "fallback-model"},
-		},
+		makeFallbackEntry("fallback-provider", config.LLMBackendNativeGemini, "fallback-model"),
 	}
 
 	ctrl := NewIteratingController()
@@ -1050,11 +1046,7 @@ func TestIteratingController_FallbackOnCredentials_Immediate(t *testing.T) {
 	execCtx := newTestExecCtx(t, llm, executor)
 	execCtx.Config.LLMProviderName = "bad-creds-provider"
 	execCtx.Config.ResolvedFallbackProviders = []agent.ResolvedFallbackEntry{
-		{
-			ProviderName: "good-provider",
-			Backend:      config.LLMBackendNativeGemini,
-			Config:       &config.LLMProviderConfig{Model: "good-model"},
-		},
+		makeFallbackEntry("good-provider", config.LLMBackendNativeGemini, "good-model"),
 	}
 
 	ctrl := NewIteratingController()
@@ -1090,11 +1082,7 @@ func TestIteratingController_FallbackProviderError_RequiresOneRetry(t *testing.T
 	execCtx := newTestExecCtx(t, llm, executor)
 	execCtx.Config.LLMProviderName = "primary"
 	execCtx.Config.ResolvedFallbackProviders = []agent.ResolvedFallbackEntry{
-		{
-			ProviderName: "fallback",
-			Backend:      config.LLMBackendLangChain,
-			Config:       &config.LLMProviderConfig{Model: "fallback-model"},
-		},
+		makeFallbackEntry("fallback", config.LLMBackendLangChain, "fallback-model"),
 	}
 
 	ctrl := NewIteratingController()
@@ -1143,11 +1131,7 @@ func TestIteratingController_FallbackInForcedConclusion(t *testing.T) {
 	execCtx.Config.MaxIterations = 1
 	execCtx.Config.LLMProviderName = "primary"
 	execCtx.Config.ResolvedFallbackProviders = []agent.ResolvedFallbackEntry{
-		{
-			ProviderName: "fallback",
-			Backend:      config.LLMBackendNativeGemini,
-			Config:       &config.LLMProviderConfig{Model: "fallback-model"},
-		},
+		makeFallbackEntry("fallback", config.LLMBackendNativeGemini, "fallback-model"),
 	}
 
 	ctrl := NewIteratingController()
@@ -1203,11 +1187,7 @@ func TestIteratingController_FallbackSetsTimelineEvent(t *testing.T) {
 	execCtx := newTestExecCtx(t, llm, executor)
 	execCtx.Config.LLMProviderName = "primary"
 	execCtx.Config.ResolvedFallbackProviders = []agent.ResolvedFallbackEntry{
-		{
-			ProviderName: "fallback",
-			Backend:      config.LLMBackendLangChain,
-			Config:       &config.LLMProviderConfig{Model: "fallback-model"},
-		},
+		makeFallbackEntry("fallback", config.LLMBackendLangChain, "fallback-model"),
 	}
 
 	ctrl := NewIteratingController()

--- a/pkg/agent/controller/iterating_test.go
+++ b/pkg/agent/controller/iterating_test.go
@@ -1031,6 +1031,40 @@ func TestIteratingController_FallbackOnMaxRetries(t *testing.T) {
 	require.Equal(t, config.LLMBackendNativeGemini, execCtx.Config.LLMBackend)
 }
 
+func TestIteratingController_FallbackOnCredentials_Immediate(t *testing.T) {
+	// credentials errors trigger immediate fallback (no Go retry needed)
+	llm := &mockLLMClient{
+		capture: true,
+		responses: []mockLLMResponse{
+			{chunks: []agent.Chunk{
+				&agent.ErrorChunk{Message: "API key invalid", Code: "credentials", Retryable: false},
+			}},
+			{chunks: []agent.Chunk{
+				&agent.TextChunk{Content: "Success with fallback."},
+				&agent.UsageChunk{InputTokens: 5, OutputTokens: 10, TotalTokens: 15},
+			}},
+		},
+	}
+
+	executor := &mockToolExecutor{tools: []agent.ToolDefinition{}}
+	execCtx := newTestExecCtx(t, llm, executor)
+	execCtx.Config.LLMProviderName = "bad-creds-provider"
+	execCtx.Config.ResolvedFallbackProviders = []agent.ResolvedFallbackEntry{
+		{
+			ProviderName: "good-provider",
+			Backend:      config.LLMBackendNativeGemini,
+			Config:       &config.LLMProviderConfig{Model: "good-model"},
+		},
+	}
+
+	ctrl := NewIteratingController()
+	result, err := ctrl.Run(context.Background(), execCtx, "")
+	require.NoError(t, err)
+	require.Equal(t, agent.ExecutionStatusCompleted, result.Status)
+	require.Equal(t, 2, llm.callCount, "credentials should trigger immediate fallback, no extra retry")
+	require.Equal(t, "good-model", llm.capturedInputs[1].Config.Model)
+}
+
 func TestIteratingController_FallbackProviderError_RequiresOneRetry(t *testing.T) {
 	// provider_error requires 1 Go retry before fallback.
 	// Call 1: provider_error → no fallback (first occurrence)

--- a/pkg/agent/controller/iterating_test.go
+++ b/pkg/agent/controller/iterating_test.go
@@ -986,3 +986,213 @@ func TestIteratingController_NilCollectorSkipsDrainWait(t *testing.T) {
 	require.Equal(t, "Everything is fine.", result.FinalAnalysis)
 	require.Equal(t, 1, llm.callCount)
 }
+
+func TestIteratingController_FallbackOnMaxRetries(t *testing.T) {
+	// First call: max_retries error → immediate fallback
+	// Second call (with fallback provider): success
+	llm := &mockLLMClient{
+		capture: true,
+		responses: []mockLLMResponse{
+			{chunks: []agent.Chunk{
+				&agent.ErrorChunk{Message: "all retries exhausted", Code: "max_retries", Retryable: false},
+			}},
+			{chunks: []agent.Chunk{
+				&agent.TextChunk{Content: "Analysis complete with fallback provider."},
+				&agent.UsageChunk{InputTokens: 10, OutputTokens: 20, TotalTokens: 30},
+			}},
+		},
+	}
+
+	executor := &mockToolExecutor{tools: []agent.ToolDefinition{}}
+	execCtx := newTestExecCtx(t, llm, executor)
+	execCtx.Config.LLMProviderName = "primary-provider"
+	execCtx.Config.ResolvedFallbackProviders = []agent.ResolvedFallbackEntry{
+		{
+			ProviderName: "fallback-provider",
+			Backend:      config.LLMBackendNativeGemini,
+			Config:       &config.LLMProviderConfig{Model: "fallback-model"},
+		},
+	}
+
+	ctrl := NewIteratingController()
+	result, err := ctrl.Run(context.Background(), execCtx, "")
+	require.NoError(t, err)
+	require.Equal(t, agent.ExecutionStatusCompleted, result.Status)
+	require.Equal(t, "Analysis complete with fallback provider.", result.FinalAnalysis)
+	require.Equal(t, 2, llm.callCount, "should have made 2 LLM calls")
+
+	// Verify the second call used the fallback provider config
+	require.Len(t, llm.capturedInputs, 2)
+	require.Equal(t, "fallback-model", llm.capturedInputs[1].Config.Model)
+	require.True(t, llm.capturedInputs[1].ClearCache, "second call should have ClearCache set")
+
+	// Verify provider was swapped in execCtx
+	require.Equal(t, "fallback-provider", execCtx.Config.LLMProviderName)
+	require.Equal(t, config.LLMBackendNativeGemini, execCtx.Config.LLMBackend)
+}
+
+func TestIteratingController_FallbackProviderError_RequiresOneRetry(t *testing.T) {
+	// provider_error requires 1 Go retry before fallback.
+	// Call 1: provider_error → no fallback (first occurrence)
+	// Call 2: provider_error → fallback triggered (second consecutive)
+	// Call 3: success with fallback provider
+	llm := &mockLLMClient{
+		capture: true,
+		responses: []mockLLMResponse{
+			{chunks: []agent.Chunk{
+				&agent.ErrorChunk{Message: "provider down", Code: "provider_error", Retryable: false},
+			}},
+			{chunks: []agent.Chunk{
+				&agent.ErrorChunk{Message: "provider still down", Code: "provider_error", Retryable: false},
+			}},
+			{chunks: []agent.Chunk{
+				&agent.TextChunk{Content: "Recovered via fallback."},
+				&agent.UsageChunk{InputTokens: 10, OutputTokens: 20, TotalTokens: 30},
+			}},
+		},
+	}
+
+	executor := &mockToolExecutor{tools: []agent.ToolDefinition{}}
+	execCtx := newTestExecCtx(t, llm, executor)
+	execCtx.Config.LLMProviderName = "primary"
+	execCtx.Config.ResolvedFallbackProviders = []agent.ResolvedFallbackEntry{
+		{
+			ProviderName: "fallback",
+			Backend:      config.LLMBackendLangChain,
+			Config:       &config.LLMProviderConfig{Model: "fallback-model"},
+		},
+	}
+
+	ctrl := NewIteratingController()
+	result, err := ctrl.Run(context.Background(), execCtx, "")
+	require.NoError(t, err)
+	require.Equal(t, agent.ExecutionStatusCompleted, result.Status)
+	require.Equal(t, 3, llm.callCount)
+
+	// First two calls with primary, third with fallback
+	require.Equal(t, "test-model", llm.capturedInputs[0].Config.Model)
+	require.Equal(t, "test-model", llm.capturedInputs[1].Config.Model)
+	require.Equal(t, "fallback-model", llm.capturedInputs[2].Config.Model)
+}
+
+func TestIteratingController_FallbackInForcedConclusion(t *testing.T) {
+	// Use maxIter=1, first call returns a tool call (consuming the iteration),
+	// then forced conclusion fails with max_retries → fallback → success.
+	llm := &mockLLMClient{
+		capture: true,
+		responses: []mockLLMResponse{
+			// Iteration 1: tool call
+			{chunks: []agent.Chunk{
+				&agent.ToolCallChunk{CallID: "call-1", Name: "test.tool", Arguments: "{}"},
+			}},
+			// Forced conclusion: max_retries error → fallback
+			{chunks: []agent.Chunk{
+				&agent.ErrorChunk{Message: "retries exhausted", Code: "max_retries", Retryable: false},
+			}},
+			// Forced conclusion retry with fallback: success
+			{chunks: []agent.Chunk{
+				&agent.TextChunk{Content: "Forced conclusion via fallback."},
+				&agent.UsageChunk{InputTokens: 10, OutputTokens: 20, TotalTokens: 30},
+			}},
+		},
+	}
+
+	tools := []agent.ToolDefinition{{Name: "test.tool", Description: "A test tool"}}
+	executor := &mockToolExecutor{
+		tools: tools,
+		results: map[string]*agent.ToolResult{
+			"test.tool": {Content: "tool result"},
+		},
+	}
+
+	execCtx := newTestExecCtx(t, llm, executor)
+	execCtx.Config.MaxIterations = 1
+	execCtx.Config.LLMProviderName = "primary"
+	execCtx.Config.ResolvedFallbackProviders = []agent.ResolvedFallbackEntry{
+		{
+			ProviderName: "fallback",
+			Backend:      config.LLMBackendNativeGemini,
+			Config:       &config.LLMProviderConfig{Model: "fallback-model"},
+		},
+	}
+
+	ctrl := NewIteratingController()
+	result, err := ctrl.Run(context.Background(), execCtx, "")
+	require.NoError(t, err)
+	require.Equal(t, agent.ExecutionStatusCompleted, result.Status)
+	require.Equal(t, "Forced conclusion via fallback.", result.FinalAnalysis)
+	require.Equal(t, 3, llm.callCount)
+
+	// Third call should use fallback provider with ClearCache
+	require.Equal(t, "fallback-model", llm.capturedInputs[2].Config.Model)
+	require.True(t, llm.capturedInputs[2].ClearCache)
+}
+
+func TestIteratingController_NoFallbackWithEmptyList(t *testing.T) {
+	// When no fallback providers are configured, errors go through normal retry path
+	llm := &mockLLMClient{
+		responses: []mockLLMResponse{
+			{chunks: []agent.Chunk{
+				&agent.ErrorChunk{Message: "retries exhausted", Code: "max_retries", Retryable: false},
+			}},
+			{chunks: []agent.Chunk{
+				&agent.TextChunk{Content: "Recovered on retry."},
+				&agent.UsageChunk{InputTokens: 10, OutputTokens: 20, TotalTokens: 30},
+			}},
+		},
+	}
+
+	executor := &mockToolExecutor{tools: []agent.ToolDefinition{}}
+	execCtx := newTestExecCtx(t, llm, executor)
+	// No fallback providers (default)
+
+	ctrl := NewIteratingController()
+	result, err := ctrl.Run(context.Background(), execCtx, "")
+	require.NoError(t, err)
+	require.Equal(t, agent.ExecutionStatusCompleted, result.Status)
+	require.Equal(t, 2, llm.callCount, "should have retried with same provider")
+}
+
+func TestIteratingController_FallbackSetsTimelineEvent(t *testing.T) {
+	llm := &mockLLMClient{
+		responses: []mockLLMResponse{
+			{chunks: []agent.Chunk{
+				&agent.ErrorChunk{Message: "retries exhausted", Code: "max_retries", Retryable: false},
+			}},
+			{chunks: []agent.Chunk{
+				&agent.TextChunk{Content: "Success."},
+			}},
+		},
+	}
+
+	executor := &mockToolExecutor{tools: []agent.ToolDefinition{}}
+	execCtx := newTestExecCtx(t, llm, executor)
+	execCtx.Config.LLMProviderName = "primary"
+	execCtx.Config.ResolvedFallbackProviders = []agent.ResolvedFallbackEntry{
+		{
+			ProviderName: "fallback",
+			Backend:      config.LLMBackendLangChain,
+			Config:       &config.LLMProviderConfig{Model: "fallback-model"},
+		},
+	}
+
+	ctrl := NewIteratingController()
+	result, err := ctrl.Run(context.Background(), execCtx, "")
+	require.NoError(t, err)
+	require.Equal(t, agent.ExecutionStatusCompleted, result.Status)
+
+	// Verify provider_fallback timeline event was created
+	events, listErr := execCtx.Services.Timeline.GetSessionTimeline(
+		context.Background(), execCtx.SessionID)
+	require.NoError(t, listErr)
+
+	var foundFallbackEvent bool
+	for _, evt := range events {
+		if evt.EventType == timelineevent.EventTypeProviderFallback {
+			foundFallbackEvent = true
+			require.Contains(t, evt.Content, "primary")
+			require.Contains(t, evt.Content, "fallback")
+		}
+	}
+	require.True(t, foundFallbackEvent, "should have a provider_fallback timeline event")
+}

--- a/pkg/agent/controller/single_shot.go
+++ b/pkg/agent/controller/single_shot.go
@@ -72,6 +72,13 @@ func (c *SingleShotController) Run(
 	var streamed *StreamedResponse
 	var err error
 	for {
+		if status, done := agent.StatusFromContextErr(ctx); done {
+			return &agent.ExecutionResult{
+				Status:     status,
+				Error:      fmt.Errorf("%s interrupted: %w", c.cfg.InteractionLabel, ctx.Err()),
+				TokensUsed: agent.TokenUsage{},
+			}, nil
+		}
 		streamed, err = callLLMWithStreaming(ctx, execCtx, execCtx.LLMClient, &agent.GenerateInput{
 			SessionID:   execCtx.SessionID,
 			ExecutionID: execCtx.ExecutionID,

--- a/pkg/agent/controller/single_shot.go
+++ b/pkg/agent/controller/single_shot.go
@@ -55,6 +55,7 @@ func (c *SingleShotController) Run(
 	startTime := time.Now()
 	msgSeq := 0
 	eventSeq := 0
+	fbState := NewFallbackState(execCtx)
 
 	// 1. Build messages via config-provided builder
 	if c.cfg.BuildMessages == nil {
@@ -67,18 +68,27 @@ func (c *SingleShotController) Run(
 		return nil, err
 	}
 
-	// 3. Single LLM call with streaming (no tools)
-	streamed, err := callLLMWithStreaming(ctx, execCtx, execCtx.LLMClient, &agent.GenerateInput{
-		SessionID:   execCtx.SessionID,
-		ExecutionID: execCtx.ExecutionID,
-		Messages:    messages,
-		Config:      execCtx.Config.LLMProvider,
-		Tools:       nil, // No MCP tools; native tools (Google Search) may still activate
-		Backend:     execCtx.Config.LLMBackend,
-	}, &eventSeq)
-	if err != nil {
-		createTimelineEvent(ctx, execCtx, timelineevent.EventTypeError, err.Error(), nil, &eventSeq)
-		return nil, fmt.Errorf("%s LLM call failed: %w", c.cfg.InteractionLabel, err)
+	// 3. Single LLM call with streaming (no tools), with fallback retry
+	var streamed *StreamedResponse
+	var err error
+	for {
+		streamed, err = callLLMWithStreaming(ctx, execCtx, execCtx.LLMClient, &agent.GenerateInput{
+			SessionID:   execCtx.SessionID,
+			ExecutionID: execCtx.ExecutionID,
+			Messages:    messages,
+			Config:      execCtx.Config.LLMProvider,
+			Tools:       nil, // No MCP tools; native tools (Google Search) may still activate
+			Backend:     execCtx.Config.LLMBackend,
+			ClearCache:  fbState.consumeClearCache(),
+		}, &eventSeq)
+		if err == nil {
+			break
+		}
+		if !tryFallback(ctx, execCtx, fbState, err, &eventSeq) {
+			createTimelineEvent(ctx, execCtx, timelineevent.EventTypeError, err.Error(), nil, &eventSeq)
+			return nil, fmt.Errorf("%s LLM call failed: %w", c.cfg.InteractionLabel, err)
+		}
+		startTime = time.Now()
 	}
 	resp := streamed.LLMResponse
 

--- a/pkg/agent/controller/single_shot_test.go
+++ b/pkg/agent/controller/single_shot_test.go
@@ -201,3 +201,58 @@ func TestSynthesisController_WithCodeExecution(t *testing.T) {
 	}
 	require.True(t, foundCodeExec, "code_execution event should be created in synthesis")
 }
+
+func TestSingleShotController_FallbackOnError(t *testing.T) {
+	// First call fails with max_retries → fallback → second call succeeds
+	llm := &mockLLMClient{
+		capture: true,
+		responses: []mockLLMResponse{
+			{chunks: []agent.Chunk{
+				&agent.ErrorChunk{Message: "retries exhausted", Code: "max_retries", Retryable: false},
+			}},
+			{chunks: []agent.Chunk{
+				&agent.TextChunk{Content: "Synthesis via fallback."},
+				&agent.UsageChunk{InputTokens: 10, OutputTokens: 20, TotalTokens: 30},
+			}},
+		},
+	}
+
+	execCtx := newTestExecCtx(t, llm, &mockToolExecutor{})
+	execCtx.Config.LLMProviderName = "primary"
+	execCtx.Config.ResolvedFallbackProviders = []agent.ResolvedFallbackEntry{
+		{
+			ProviderName: "fallback",
+			Backend:      config.LLMBackendNativeGemini,
+			Config:       &config.LLMProviderConfig{Model: "fallback-model"},
+		},
+	}
+
+	ctrl := NewSynthesisController(execCtx.PromptBuilder)
+	result, err := ctrl.Run(context.Background(), execCtx, "Agent 1 analysis text.")
+	require.NoError(t, err)
+	require.Equal(t, agent.ExecutionStatusCompleted, result.Status)
+	require.Equal(t, "Synthesis via fallback.", result.FinalAnalysis)
+	require.Equal(t, 2, llm.callCount)
+
+	// Verify fallback provider was used in second call
+	require.Equal(t, "fallback-model", llm.capturedInputs[1].Config.Model)
+	require.True(t, llm.capturedInputs[1].ClearCache)
+}
+
+func TestSingleShotController_NoFallback_ReturnsError(t *testing.T) {
+	// No fallback providers → error returned directly
+	llm := &mockLLMClient{
+		responses: []mockLLMResponse{
+			{chunks: []agent.Chunk{
+				&agent.ErrorChunk{Message: "retries exhausted", Code: "max_retries", Retryable: false},
+			}},
+		},
+	}
+
+	execCtx := newTestExecCtx(t, llm, &mockToolExecutor{})
+
+	ctrl := NewSynthesisController(execCtx.PromptBuilder)
+	_, err := ctrl.Run(context.Background(), execCtx, "Agent 1 analysis text.")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "synthesis LLM call failed")
+}

--- a/pkg/agent/controller/streaming.go
+++ b/pkg/agent/controller/streaming.go
@@ -15,13 +15,28 @@ import (
 	"github.com/codeready-toolchain/tarsy/pkg/models"
 )
 
+// LLMErrorCode identifies the category of error returned by the LLM service.
+// Codes originate as strings in the Python gRPC service and are converted at
+// the Go boundary when populating PartialOutputError.
+type LLMErrorCode string
+
+const (
+	LLMErrorMaxRetries         LLMErrorCode = "max_retries"          // Python already retried 3x
+	LLMErrorCredentials        LLMErrorCode = "credentials"          // missing or invalid API key
+	LLMErrorProviderError      LLMErrorCode = "provider_error"       // upstream provider failure
+	LLMErrorInvalidRequest     LLMErrorCode = "invalid_request"      // malformed request
+	LLMErrorPartialStreamError LLMErrorCode = "partial_stream_error" // error mid-stream after partial output
+)
+
 // PartialOutputError wraps an LLM error that occurred after partial output
 // was produced. Callers can inspect PartialText to include it in retry context.
 type PartialOutputError struct {
 	Cause           error
 	PartialText     string
 	PartialThinking string
-	IsLoop          bool // true when caused by degenerate loop detection
+	IsLoop          bool         // true when caused by degenerate loop detection
+	Code            LLMErrorCode // error code from LLM service
+	Retryable       bool         // whether the LLM service considers the error retryable
 }
 
 func (e *PartialOutputError) Error() string { return e.Cause.Error() }
@@ -189,6 +204,8 @@ func collectStreamWithCallback(
 					c.Message, c.Code, c.Retryable),
 				PartialText:     textBuf.String(),
 				PartialThinking: thinkingBuf.String(),
+				Code:            LLMErrorCode(c.Code),
+				Retryable:       c.Retryable,
 			}
 		}
 	}

--- a/pkg/agent/controller/streaming_test.go
+++ b/pkg/agent/controller/streaming_test.go
@@ -298,11 +298,13 @@ func TestCollectStreamWithCallback_ErrorChunk(t *testing.T) {
 	assert.Contains(t, err.Error(), "rate limit exceeded")
 	assert.Equal(t, 1, callbackCount) // Only the first text chunk callback fired
 
-	// Should be a PartialOutputError with partial text preserved
+	// Should be a PartialOutputError with partial text and error code preserved
 	var poe *PartialOutputError
 	require.ErrorAs(t, err, &poe)
 	assert.Equal(t, "partial ", poe.PartialText)
 	assert.False(t, poe.IsLoop)
+	assert.Equal(t, LLMErrorCode("429"), poe.Code)
+	assert.True(t, poe.Retryable)
 }
 
 func TestCollectStreamWithCallback_ToolCalls(t *testing.T) {
@@ -463,6 +465,8 @@ func TestCollectStreamWithCallback_ErrorPreservesPartialOutput(t *testing.T) {
 	assert.Equal(t, "Let me think...", poe.PartialThinking)
 	assert.False(t, poe.IsLoop)
 	assert.Contains(t, poe.Error(), "stream interrupted")
+	assert.Equal(t, LLMErrorPartialStreamError, poe.Code)
+	assert.False(t, poe.Retryable)
 }
 
 // ============================================================================

--- a/pkg/agent/controller/test_helpers_test.go
+++ b/pkg/agent/controller/test_helpers_test.go
@@ -245,3 +245,12 @@ func newTestServiceBundle(t *testing.T, entClient *ent.Client) *agent.ServiceBun
 		Stage:       services.NewStageService(entClient),
 	}
 }
+
+// makeFallbackEntry builds a ResolvedFallbackEntry for test setup.
+func makeFallbackEntry(providerName string, backend config.LLMBackend, model string) agent.ResolvedFallbackEntry {
+	return agent.ResolvedFallbackEntry{
+		ProviderName: providerName,
+		Backend:      backend,
+		Config:       &config.LLMProviderConfig{Model: model},
+	}
+}

--- a/pkg/agent/llm_client.go
+++ b/pkg/agent/llm_client.go
@@ -26,6 +26,7 @@ type GenerateInput struct {
 	Config      *config.LLMProviderConfig
 	Tools       []ToolDefinition  // nil = no tools
 	Backend     config.LLMBackend // see config.LLMBackendNativeGemini, config.LLMBackendLangChain
+	ClearCache  bool              // signal to clear provider content cache (e.g. on fallback provider switch)
 }
 
 // Conversation message roles.

--- a/pkg/agent/llm_grpc.go
+++ b/pkg/agent/llm_grpc.go
@@ -85,6 +85,7 @@ func toProtoRequest(input *GenerateInput) *llmv1.GenerateRequest {
 		ExecutionId: input.ExecutionID,
 		Messages:    toProtoMessages(input.Messages),
 		Tools:       toProtoTools(input.Tools),
+		ClearCache:  input.ClearCache,
 	}
 	if input.Config != nil {
 		req.LlmConfig = toProtoLLMConfig(input.Config)

--- a/pkg/agent/llm_grpc_test.go
+++ b/pkg/agent/llm_grpc_test.go
@@ -277,6 +277,33 @@ func TestIntSliceFromInt32(t *testing.T) {
 	})
 }
 
+func TestToProtoRequest_ClearCache(t *testing.T) {
+	t.Run("ClearCache false by default", func(t *testing.T) {
+		input := &GenerateInput{
+			SessionID:   "session-1",
+			ExecutionID: "exec-1",
+			Messages:    []ConversationMessage{{Role: "user", Content: "hello"}},
+			Config:      &config.LLMProviderConfig{Model: "test-model", Type: config.LLMProviderTypeGoogle},
+			Backend:     config.LLMBackendNativeGemini,
+		}
+		req := toProtoRequest(input)
+		assert.False(t, req.ClearCache)
+	})
+
+	t.Run("ClearCache propagated when true", func(t *testing.T) {
+		input := &GenerateInput{
+			SessionID:   "session-1",
+			ExecutionID: "exec-1",
+			Messages:    []ConversationMessage{{Role: "user", Content: "hello"}},
+			Config:      &config.LLMProviderConfig{Model: "test-model", Type: config.LLMProviderTypeGoogle},
+			Backend:     config.LLMBackendNativeGemini,
+			ClearCache:  true,
+		}
+		req := toProtoRequest(input)
+		assert.True(t, req.ClearCache)
+	})
+}
+
 func TestToProtoTools(t *testing.T) {
 	t.Run("nil tools returns nil", func(t *testing.T) {
 		assert.Nil(t, toProtoTools(nil))

--- a/pkg/agent/orchestrator/runner.go
+++ b/pkg/agent/orchestrator/runner.go
@@ -289,12 +289,7 @@ func (r *SubAgentRunner) runSubAgent(
 
 	result, err := agentInstance.Execute(ctx, execCtx, "")
 	if err != nil {
-		status := agent.ExecutionStatusFailed
-		if ctx.Err() == context.DeadlineExceeded {
-			status = agent.ExecutionStatusTimedOut
-		} else if ctx.Err() != nil {
-			status = agent.ExecutionStatusCancelled
-		}
+		status := agent.StatusFromErr(ctx.Err())
 		logger.Error("Sub-agent execution error", "error", err, "resolved_status", status)
 		r.completeSubAgent(exec, status, "", err.Error())
 		return

--- a/pkg/agent/scoring_agent.go
+++ b/pkg/agent/scoring_agent.go
@@ -2,7 +2,6 @@ package agent
 
 import (
 	"context"
-	"errors"
 	"fmt"
 )
 
@@ -31,13 +30,7 @@ func (a *ScoringAgent) Execute(ctx context.Context, execCtx *ExecutionContext, p
 	result, err := a.controller.Run(ctx, execCtx, prevStageContext)
 
 	if err != nil {
-		if errors.Is(err, context.DeadlineExceeded) {
-			return &ExecutionResult{Status: ExecutionStatusTimedOut, Error: err}, nil
-		}
-		if errors.Is(err, context.Canceled) {
-			return &ExecutionResult{Status: ExecutionStatusCancelled, Error: err}, nil
-		}
-		return &ExecutionResult{Status: ExecutionStatusFailed, Error: err}, nil
+		return &ExecutionResult{Status: StatusFromErr(err), Error: err}, nil
 	}
 
 	if result == nil {

--- a/pkg/queue/chat_executor.go
+++ b/pkg/queue/chat_executor.go
@@ -369,35 +369,24 @@ func (e *ChatMessageExecutor) execute(parentCtx context.Context, input ChatExecu
 	result, execErr := agentInstance.Execute(execCtx, agentExecCtx, "") // no prevStageContext for chat
 
 	// 11. Determine terminal status
-	terminalStatus := events.StageStatusFailed
 	agentStatus := agent.ExecutionStatusFailed
 	errMsg := ""
 	if execErr != nil {
 		errMsg = execErr.Error()
-		// Check if the error was due to cancellation/timeout
-		if execCtx.Err() == context.DeadlineExceeded {
-			agentStatus = agent.ExecutionStatusTimedOut
-			terminalStatus = events.StageStatusTimedOut
-		} else if execCtx.Err() != nil {
-			agentStatus = agent.ExecutionStatusCancelled
-			terminalStatus = events.StageStatusCancelled
+		if execCtx.Err() != nil {
+			agentStatus = agent.StatusFromErr(execCtx.Err())
 		}
 	} else if result != nil {
-		// Check if context was cancelled during execution even though agent returned OK
-		if execCtx.Err() == context.DeadlineExceeded {
-			agentStatus = agent.ExecutionStatusTimedOut
-			terminalStatus = events.StageStatusTimedOut
-		} else if execCtx.Err() != nil {
-			agentStatus = agent.ExecutionStatusCancelled
-			terminalStatus = events.StageStatusCancelled
+		if execCtx.Err() != nil {
+			agentStatus = agent.StatusFromErr(execCtx.Err())
 		} else {
 			agentStatus = result.Status
-			terminalStatus = mapChatAgentStatus(result.Status)
 		}
 		if result.Error != nil {
 			errMsg = result.Error.Error()
 		}
 	}
+	terminalStatus := mapChatAgentStatus(agentStatus)
 
 	// 12. Update AgentExecution terminal status (use background context — execCtx may be cancelled)
 	entStatus := mapAgentStatusToEntStatus(agentStatus)

--- a/pkg/queue/executor.go
+++ b/pkg/queue/executor.go
@@ -647,12 +647,7 @@ func (e *RealSessionExecutor) executeAgent(
 		// When the context is cancelled (e.g. user cancel), the agent may fail with
 		// an unrelated error (e.g. "failed to store assistant message") because it
 		// tried to operate on a cancelled context. Override to the correct status.
-		errStatus := agent.ExecutionStatusFailed
-		if ctx.Err() == context.DeadlineExceeded {
-			errStatus = agent.ExecutionStatusTimedOut
-		} else if ctx.Err() != nil {
-			errStatus = agent.ExecutionStatusCancelled
-		}
+		errStatus := agent.StatusFromErr(ctx.Err())
 		entErrStatus := mapAgentStatusToEntStatus(errStatus)
 		logger.Error("Agent execution error", "error", err, "resolved_status", errStatus)
 		if updateErr := input.stageService.UpdateAgentExecutionStatus(context.Background(), exec.ID, entErrStatus, err.Error()); updateErr != nil {
@@ -676,13 +671,8 @@ func (e *RealSessionExecutor) executeAgent(
 	if result != nil && ctx.Err() != nil &&
 		result.Status != agent.ExecutionStatusCancelled &&
 		result.Status != agent.ExecutionStatusTimedOut {
-		if ctx.Err() == context.DeadlineExceeded {
-			result.Status = agent.ExecutionStatusTimedOut
-			result.Error = ctx.Err()
-		} else {
-			result.Status = agent.ExecutionStatusCancelled
-			result.Error = ctx.Err()
-		}
+		result.Status = agent.StatusFromErr(ctx.Err())
+		result.Error = ctx.Err()
 	}
 
 	// Update AgentExecution status (use background context — ctx may be cancelled)

--- a/pkg/queue/executor_synthesis.go
+++ b/pkg/queue/executor_synthesis.go
@@ -229,43 +229,105 @@ func (e *RealSessionExecutor) generateExecutiveSummary(
 		{Role: agent.RoleUser, Content: userPrompt},
 	}
 
-	// Single LLM call — no tools, consume full response from stream
-	llmInput := &agent.GenerateInput{
-		SessionID: session.ID,
-		Messages:  messages,
-		Config:    provider,
-		Backend:   backend,
+	// Resolve fallback providers for executive summary (defaults → chain)
+	var fallbackEntries []agent.ResolvedFallbackEntry
+	var rawFallback []config.FallbackProviderEntry
+	if e.cfg.Defaults != nil && e.cfg.Defaults.FallbackProviders != nil {
+		rawFallback = e.cfg.Defaults.FallbackProviders
 	}
-
-	// Derive a cancellable context so the producer goroutine in Generate
-	// is always cleaned up when we return (e.g. on ErrorChunk early exit).
-	llmCtx, llmCancel := context.WithCancel(ctx)
-	defer llmCancel()
-
-	ch, err := e.llmClient.Generate(llmCtx, llmInput)
-	if err != nil {
-		return "", fmt.Errorf("executive summary LLM call failed: %w", err)
+	if chain.FallbackProviders != nil {
+		rawFallback = chain.FallbackProviders
 	}
-
-	// Collect full text response and token usage.
-	var sb strings.Builder
-	var usage agent.TokenUsage
-	for chunk := range ch {
-		switch c := chunk.(type) {
-		case *agent.TextChunk:
-			sb.WriteString(c.Content)
-		case *agent.UsageChunk:
-			usage.InputTokens += c.InputTokens
-			usage.OutputTokens += c.OutputTokens
-			usage.TotalTokens += c.TotalTokens
-		case *agent.ErrorChunk:
-			return "", fmt.Errorf("executive summary LLM error: %s", c.Message)
+	for _, entry := range rawFallback {
+		fbProvider, fbErr := e.cfg.GetLLMProvider(entry.Provider)
+		if fbErr != nil {
+			logger.Warn("Executive summary fallback provider not found, skipping",
+				"provider", entry.Provider, "error", fbErr)
+			continue
 		}
+		fallbackEntries = append(fallbackEntries, agent.ResolvedFallbackEntry{
+			ProviderName: entry.Provider,
+			Backend:      entry.Backend,
+			Config:       fbProvider,
+		})
 	}
 
-	summary := sb.String()
-	if summary == "" {
-		return "", fmt.Errorf("executive summary LLM returned empty response")
+	// Single LLM call — no tools, consume full response from stream.
+	// Retry with fallback providers on failure.
+	var summary string
+	var usage agent.TokenUsage
+	fallbackIdx := -1 // -1 = primary, 0+ = fallback index
+	clearCache := false
+	for {
+		llmInput := &agent.GenerateInput{
+			SessionID:  session.ID,
+			Messages:   messages,
+			Config:     provider,
+			Backend:    backend,
+			ClearCache: clearCache,
+		}
+
+		llmCtx, llmCancel := context.WithCancel(ctx)
+		ch, err := e.llmClient.Generate(llmCtx, llmInput)
+		if err != nil {
+			llmCancel()
+			// Try fallback
+			if nextIdx := fallbackIdx + 1; nextIdx < len(fallbackEntries) {
+				entry := fallbackEntries[nextIdx]
+				logger.Info("Executive summary falling back to next provider",
+					"from_provider", providerName, "to_provider", entry.ProviderName,
+					"reason", err.Error())
+				provider = entry.Config
+				providerName = entry.ProviderName
+				backend = entry.Backend
+				fallbackIdx = nextIdx
+				clearCache = true
+				startTime = time.Now()
+				continue
+			}
+			return "", fmt.Errorf("executive summary LLM call failed: %w", err)
+		}
+
+		var sb strings.Builder
+		usage = agent.TokenUsage{}
+		var chunkErr error
+		for chunk := range ch {
+			switch c := chunk.(type) {
+			case *agent.TextChunk:
+				sb.WriteString(c.Content)
+			case *agent.UsageChunk:
+				usage.InputTokens += c.InputTokens
+				usage.OutputTokens += c.OutputTokens
+				usage.TotalTokens += c.TotalTokens
+			case *agent.ErrorChunk:
+				chunkErr = fmt.Errorf("executive summary LLM error: %s (code: %s)", c.Message, c.Code)
+			}
+		}
+		llmCancel()
+
+		if chunkErr != nil {
+			// Try fallback
+			if nextIdx := fallbackIdx + 1; nextIdx < len(fallbackEntries) {
+				entry := fallbackEntries[nextIdx]
+				logger.Info("Executive summary falling back to next provider",
+					"from_provider", providerName, "to_provider", entry.ProviderName,
+					"reason", chunkErr.Error())
+				provider = entry.Config
+				providerName = entry.ProviderName
+				backend = entry.Backend
+				fallbackIdx = nextIdx
+				clearCache = true
+				startTime = time.Now()
+				continue
+			}
+			return "", chunkErr
+		}
+
+		summary = sb.String()
+		if summary == "" {
+			return "", fmt.Errorf("executive summary LLM returned empty response")
+		}
+		break
 	}
 
 	durationMs := int(time.Since(startTime).Milliseconds())

--- a/pkg/queue/executor_synthesis.go
+++ b/pkg/queue/executor_synthesis.go
@@ -271,6 +271,7 @@ func (e *RealSessionExecutor) generateExecutiveSummary(
 			Backend:    backend,
 			ClearCache: clearCache,
 		}
+		clearCache = false // consume once per provider switch
 
 		llmCtx, llmCancel := context.WithCancel(ctx)
 		ch, err := e.llmClient.Generate(llmCtx, llmInput)
@@ -292,7 +293,6 @@ func (e *RealSessionExecutor) generateExecutiveSummary(
 				fallbackIdx = nextIdx
 				clearCache = true
 				retriedCurrentProvider = false
-				startTime = time.Now()
 				continue
 			}
 			return "", fmt.Errorf("executive summary LLM call failed: %w", err)
@@ -335,7 +335,6 @@ func (e *RealSessionExecutor) generateExecutiveSummary(
 				fallbackIdx = nextIdx
 				clearCache = true
 				retriedCurrentProvider = false
-				startTime = time.Now()
 				continue
 			}
 			return "", chunkErr

--- a/pkg/queue/executor_synthesis.go
+++ b/pkg/queue/executor_synthesis.go
@@ -259,6 +259,9 @@ func (e *RealSessionExecutor) generateExecutiveSummary(
 	fallbackIdx := -1 // -1 = primary, 0+ = fallback index
 	clearCache := false
 	for {
+		if ctx.Err() != nil {
+			return "", fmt.Errorf("executive summary interrupted: %w", ctx.Err())
+		}
 		llmInput := &agent.GenerateInput{
 			SessionID:  session.ID,
 			Messages:   messages,

--- a/pkg/queue/executor_synthesis.go
+++ b/pkg/queue/executor_synthesis.go
@@ -12,6 +12,7 @@ import (
 	"github.com/codeready-toolchain/tarsy/ent/timelineevent"
 	"github.com/codeready-toolchain/tarsy/pkg/agent"
 	agentctx "github.com/codeready-toolchain/tarsy/pkg/agent/context"
+	"github.com/codeready-toolchain/tarsy/pkg/agent/controller"
 	"github.com/codeready-toolchain/tarsy/pkg/config"
 	"github.com/codeready-toolchain/tarsy/pkg/events"
 	"github.com/codeready-toolchain/tarsy/pkg/models"
@@ -253,11 +254,12 @@ func (e *RealSessionExecutor) generateExecutiveSummary(
 	}
 
 	// Single LLM call — no tools, consume full response from stream.
-	// Retry with fallback providers on failure.
+	// Retry once on the same provider for transient errors, then fall back.
 	var summary string
 	var usage agent.TokenUsage
 	fallbackIdx := -1 // -1 = primary, 0+ = fallback index
 	clearCache := false
+	retriedCurrentProvider := false
 	for {
 		if ctx.Err() != nil {
 			return "", fmt.Errorf("executive summary interrupted: %w", ctx.Err())
@@ -274,7 +276,11 @@ func (e *RealSessionExecutor) generateExecutiveSummary(
 		ch, err := e.llmClient.Generate(llmCtx, llmInput)
 		if err != nil {
 			llmCancel()
-			// Try fallback
+			// Transport errors are transient — retry once before fallback
+			if !retriedCurrentProvider {
+				retriedCurrentProvider = true
+				continue
+			}
 			if nextIdx := fallbackIdx + 1; nextIdx < len(fallbackEntries) {
 				entry := fallbackEntries[nextIdx]
 				logger.Info("Executive summary falling back to next provider",
@@ -285,6 +291,7 @@ func (e *RealSessionExecutor) generateExecutiveSummary(
 				backend = entry.Backend
 				fallbackIdx = nextIdx
 				clearCache = true
+				retriedCurrentProvider = false
 				startTime = time.Now()
 				continue
 			}
@@ -292,8 +299,8 @@ func (e *RealSessionExecutor) generateExecutiveSummary(
 		}
 
 		var sb strings.Builder
-		usage = agent.TokenUsage{}
 		var chunkErr error
+		var chunkErrCode string
 		for chunk := range ch {
 			switch c := chunk.(type) {
 			case *agent.TextChunk:
@@ -304,12 +311,19 @@ func (e *RealSessionExecutor) generateExecutiveSummary(
 				usage.TotalTokens += c.TotalTokens
 			case *agent.ErrorChunk:
 				chunkErr = fmt.Errorf("executive summary LLM error: %s (code: %s)", c.Message, c.Code)
+				chunkErrCode = string(c.Code)
 			}
 		}
 		llmCancel()
 
 		if chunkErr != nil {
-			// Try fallback
+			// credentials/max_retries: fallback immediately (no retry).
+			// Other codes: retry once on the same provider before fallback.
+			immediatefallback := chunkErrCode == string(controller.LLMErrorCredentials) || chunkErrCode == string(controller.LLMErrorMaxRetries)
+			if !immediatefallback && !retriedCurrentProvider {
+				retriedCurrentProvider = true
+				continue
+			}
 			if nextIdx := fallbackIdx + 1; nextIdx < len(fallbackEntries) {
 				entry := fallbackEntries[nextIdx]
 				logger.Info("Executive summary falling back to next provider",
@@ -320,6 +334,7 @@ func (e *RealSessionExecutor) generateExecutiveSummary(
 				backend = entry.Backend
 				fallbackIdx = nextIdx
 				clearCache = true
+				retriedCurrentProvider = false
 				startTime = time.Now()
 				continue
 			}

--- a/pkg/queue/executor_synthesis.go
+++ b/pkg/queue/executor_synthesis.go
@@ -258,7 +258,7 @@ func (e *RealSessionExecutor) generateExecutiveSummary(
 	emitFallbackEvent := func(fromProvider string, toEntry agent.ResolvedFallbackEntry, reason string) {
 		_, evtErr := timelineService.CreateTimelineEvent(ctx, models.CreateTimelineEventRequest{
 			SessionID:      session.ID,
-			SequenceNumber: executiveSummarySeqNum,
+			SequenceNumber: executiveSummarySeqNum - 1,
 			EventType:      timelineevent.EventTypeProviderFallback,
 			Status:         timelineevent.StatusCompleted,
 			Content:        fmt.Sprintf("Provider fallback: %s → %s", fromProvider, toEntry.ProviderName),

--- a/pkg/queue/executor_synthesis.go
+++ b/pkg/queue/executor_synthesis.go
@@ -255,6 +255,25 @@ func (e *RealSessionExecutor) generateExecutiveSummary(
 
 	// Single LLM call — no tools, consume full response from stream.
 	// Retry once on the same provider for transient errors, then fall back.
+	emitFallbackEvent := func(fromProvider string, toEntry agent.ResolvedFallbackEntry, reason string) {
+		_, evtErr := timelineService.CreateTimelineEvent(ctx, models.CreateTimelineEventRequest{
+			SessionID:      session.ID,
+			SequenceNumber: executiveSummarySeqNum,
+			EventType:      timelineevent.EventTypeProviderFallback,
+			Status:         timelineevent.StatusCompleted,
+			Content:        fmt.Sprintf("Provider fallback: %s → %s", fromProvider, toEntry.ProviderName),
+			Metadata: map[string]any{
+				"original_provider": fromProvider,
+				"fallback_provider": toEntry.ProviderName,
+				"fallback_backend":  string(toEntry.Backend),
+				"reason":            reason,
+			},
+		})
+		if evtErr != nil {
+			logger.Warn("Failed to create provider_fallback timeline event", "error", evtErr)
+		}
+	}
+
 	var summary string
 	var usage agent.TokenUsage
 	fallbackIdx := -1 // -1 = primary, 0+ = fallback index
@@ -287,6 +306,7 @@ func (e *RealSessionExecutor) generateExecutiveSummary(
 				logger.Info("Executive summary falling back to next provider",
 					"from_provider", providerName, "to_provider", entry.ProviderName,
 					"reason", err.Error())
+				emitFallbackEvent(providerName, entry, err.Error())
 				provider = entry.Config
 				providerName = entry.ProviderName
 				backend = entry.Backend
@@ -329,6 +349,7 @@ func (e *RealSessionExecutor) generateExecutiveSummary(
 				logger.Info("Executive summary falling back to next provider",
 					"from_provider", providerName, "to_provider", entry.ProviderName,
 					"reason", chunkErr.Error())
+				emitFallbackEvent(providerName, entry, chunkErr.Error())
 				provider = entry.Config
 				providerName = entry.ProviderName
 				backend = entry.Backend

--- a/pkg/services/stage_service.go
+++ b/pkg/services/stage_service.go
@@ -191,6 +191,47 @@ func (s *StageService) UpdateAgentExecutionStatus(ctx context.Context, execution
 	return nil
 }
 
+// UpdateExecutionProviderFallback records a provider fallback on an execution.
+// Sets original_llm_provider/original_llm_backend (only on first fallback) and
+// updates llm_provider/llm_backend to the new fallback values.
+func (s *StageService) UpdateExecutionProviderFallback(
+	ctx context.Context,
+	executionID string,
+	originalProvider, originalBackend string,
+	newProvider, newBackend string,
+) error {
+	writeCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	exec, err := s.client.AgentExecution.Get(writeCtx, executionID)
+	if err != nil {
+		if ent.IsNotFound(err) {
+			return ErrNotFound
+		}
+		return fmt.Errorf("failed to get agent execution for fallback update: %w", err)
+	}
+
+	update := s.client.AgentExecution.UpdateOneID(executionID).
+		SetLlmProvider(newProvider).
+		SetLlmBackend(newBackend)
+
+	// Only set originals on the first fallback (preserve the true primary)
+	if exec.OriginalLlmProvider == nil {
+		update = update.
+			SetOriginalLlmProvider(originalProvider).
+			SetOriginalLlmBackend(originalBackend)
+	}
+
+	if err := update.Exec(writeCtx); err != nil {
+		if ent.IsNotFound(err) {
+			return ErrNotFound
+		}
+		return fmt.Errorf("failed to update execution fallback: %w", err)
+	}
+
+	return nil
+}
+
 // UpdateStageStatus aggregates stage status from all agent executions
 func (s *StageService) UpdateStageStatus(ctx context.Context, stageID string) error {
 	// Use timeout context derived from incoming context

--- a/test/e2e/failure_resilience_test.go
+++ b/test/e2e/failure_resilience_test.go
@@ -81,6 +81,10 @@ func TestE2E_FailureResilience(t *testing.T) {
 	})
 
 	// ── Executive summary — LLM error (fail-open) ──
+	// Two entries: first attempt fails, retry also fails (retry-before-fallback).
+	llm.AddSequential(LLMScriptEntry{
+		Error: fmt.Errorf("executive summary model overloaded"),
+	})
 	llm.AddSequential(LLMScriptEntry{
 		Error: fmt.Errorf("executive summary model overloaded"),
 	})
@@ -165,8 +169,8 @@ func TestE2E_FailureResilience(t *testing.T) {
 	}
 
 	// ── LLM call count ──
-	// Analyzer (1 error + 1 forced conclusion) + Investigator (2) + Synthesis (1) + Summarizer (1) + Exec summary (1 error) = 7
-	assert.Equal(t, 7, llm.CallCount())
+	// Analyzer (1 error + 1 forced conclusion) + Investigator (2) + Synthesis (1) + Summarizer (1) + Exec summary (1 error + 1 retry) = 8
+	assert.Equal(t, 8, llm.CallCount())
 
 	// ── Timeline API assertions ──
 	apiTimeline := app.GetTimeline(t, sessionID)

--- a/test/e2e/fallback_test.go
+++ b/test/e2e/fallback_test.go
@@ -70,15 +70,7 @@ func TestE2E_FallbackOnMaxRetries(t *testing.T) {
 		}),
 	)
 
-	ctx := context.Background()
-	ws, err := WSConnect(ctx, app.WSURL)
-	require.NoError(t, err)
-	defer ws.Close()
-
-	resp := app.SubmitAlert(t, "test-fallback", "API server alert triggered")
-	sessionID := resp["session_id"].(string)
-	require.NotEmpty(t, sessionID)
-	require.NoError(t, ws.Subscribe("session:"+sessionID))
+	ws, sessionID := submitAndSubscribe(t, app, "test-fallback", "API server alert triggered")
 
 	app.WaitForSessionStatus(t, sessionID, "completed")
 
@@ -120,21 +112,14 @@ func TestE2E_FallbackOnMaxRetries(t *testing.T) {
 	// ── LLM call count: 1 error + 1 tool call + 1 final + 1 exec summary = 4 ──
 	assert.Equal(t, 4, llm.CallCount())
 
-	// ── WS: provider_fallback event delivered ──
+	// ── WS: provider_fallback event delivered (use WaitForEvent to avoid race) ──
 	ws.WaitForEvent(t, func(e WSEvent) bool {
-		return e.Type == "session.status" && e.Parsed["status"] == "completed"
-	}, 5*time.Second, "waiting for session.status=completed")
-
-	var hasFallbackWSEvent bool
-	for _, e := range ws.Events() {
-		if e.Type == "timeline_event.created" {
-			if et, _ := e.Parsed["event_type"].(string); et == "provider_fallback" {
-				hasFallbackWSEvent = true
-				break
-			}
+		if e.Type != "timeline_event.created" {
+			return false
 		}
-	}
-	assert.True(t, hasFallbackWSEvent, "WS should include provider_fallback timeline event")
+		et, _ := e.Parsed["event_type"].(string)
+		return et == string(timelineevent.EventTypeProviderFallback)
+	}, 5*time.Second, "waiting for provider_fallback WS event")
 }
 
 // ────────────────────────────────────────────────────────────
@@ -183,15 +168,7 @@ func TestE2E_FallbackCascade(t *testing.T) {
 		}),
 	)
 
-	ctx := context.Background()
-	ws, err := WSConnect(ctx, app.WSURL)
-	require.NoError(t, err)
-	defer ws.Close()
-
-	resp := app.SubmitAlert(t, "test-cascade", "Monitoring alert fired")
-	sessionID := resp["session_id"].(string)
-	require.NotEmpty(t, sessionID)
-	require.NoError(t, ws.Subscribe("session:"+sessionID))
+	_, sessionID := submitAndSubscribe(t, app, "test-cascade", "Monitoring alert fired")
 
 	app.WaitForSessionStatus(t, sessionID, "completed")
 
@@ -200,15 +177,16 @@ func TestE2E_FallbackCascade(t *testing.T) {
 	assert.Equal(t, "completed", session["status"])
 	assert.NotEmpty(t, session["executive_summary"])
 
-	// ── Two provider_fallback timeline events ──
+	// ── Two provider_fallback timeline events (order-independent lookup) ──
 	timeline := app.QueryTimeline(t, sessionID)
 	fallbackEvents := filterTimelineByType(timeline, timelineevent.EventTypeProviderFallback)
 	require.Len(t, fallbackEvents, 2, "should have two provider_fallback events (primary→fb-1, fb-1→fb-2)")
 
-	assert.Equal(t, "primary-provider", fallbackEvents[0].Metadata["original_provider"])
-	assert.Equal(t, "fallback-1", fallbackEvents[0].Metadata["fallback_provider"])
-	assert.Equal(t, "fallback-1", fallbackEvents[1].Metadata["original_provider"])
-	assert.Equal(t, "fallback-2", fallbackEvents[1].Metadata["fallback_provider"])
+	ev1 := findFallbackTransition(fallbackEvents, "primary-provider", "fallback-1")
+	require.NotNil(t, ev1, "should have primary-provider → fallback-1 transition")
+
+	ev2 := findFallbackTransition(fallbackEvents, "fallback-1", "fallback-2")
+	require.NotNil(t, ev2, "should have fallback-1 → fallback-2 transition")
 
 	// ── Execution record: original provider preserved, current is fallback-2 ──
 	execs := app.QueryExecutions(t, sessionID)
@@ -270,15 +248,7 @@ func TestE2E_FallbackAllExhausted(t *testing.T) {
 		WithLLMClient(llm),
 	)
 
-	ctx := context.Background()
-	ws, err := WSConnect(ctx, app.WSURL)
-	require.NoError(t, err)
-	defer ws.Close()
-
-	resp := app.SubmitAlert(t, "test-exhausted", "Critical outage — all providers down")
-	sessionID := resp["session_id"].(string)
-	require.NotEmpty(t, sessionID)
-	require.NoError(t, ws.Subscribe("session:"+sessionID))
+	_, sessionID := submitAndSubscribe(t, app, "test-exhausted", "Critical outage — all providers down")
 
 	app.WaitForSessionStatus(t, sessionID, "failed")
 
@@ -370,15 +340,7 @@ func TestE2E_FallbackParallelAgents(t *testing.T) {
 		}),
 	)
 
-	ctx := context.Background()
-	ws, err := WSConnect(ctx, app.WSURL)
-	require.NoError(t, err)
-	defer ws.Close()
-
-	resp := app.SubmitAlert(t, "test-parallel-fallback", "Parallel investigation triggered")
-	sessionID := resp["session_id"].(string)
-	require.NotEmpty(t, sessionID)
-	require.NoError(t, ws.Subscribe("session:"+sessionID))
+	_, sessionID := submitAndSubscribe(t, app, "test-parallel-fallback", "Parallel investigation triggered")
 
 	app.WaitForSessionStatus(t, sessionID, "completed")
 
@@ -419,6 +381,12 @@ func TestE2E_FallbackParallelAgents(t *testing.T) {
 //   - Session completes with executive_summary populated
 //   - Agent execution has NO original_llm_provider (no agent-level fallback)
 //   - Executive summary was generated despite primary failure
+//   - LLM call count proves the exec summary required a retry/fallback
+//
+// NOTE: The executive summary uses a standalone LLM call path
+// (executor_synthesis.go), not the agent controller. It does not create
+// provider_fallback timeline events or execution records, so we verify
+// the fallback indirectly via call count and successful summary output.
 // ────────────────────────────────────────────────────────────
 
 func TestE2E_FallbackExecutiveSummary(t *testing.T) {
@@ -444,6 +412,9 @@ func TestE2E_FallbackExecutiveSummary(t *testing.T) {
 		Error: fmt.Errorf("executive summary provider overloaded"),
 	})
 	llm.AddSequential(LLMScriptEntry{
+		Error: fmt.Errorf("executive summary provider still overloaded"),
+	})
+	llm.AddSequential(LLMScriptEntry{
 		Text: "System operating normally. CPU 45%, memory 62%. No action required.",
 	})
 
@@ -457,15 +428,7 @@ func TestE2E_FallbackExecutiveSummary(t *testing.T) {
 		}),
 	)
 
-	ctx := context.Background()
-	ws, err := WSConnect(ctx, app.WSURL)
-	require.NoError(t, err)
-	defer ws.Close()
-
-	resp := app.SubmitAlert(t, "test-exec-fallback", "Routine health check")
-	sessionID := resp["session_id"].(string)
-	require.NotEmpty(t, sessionID)
-	require.NoError(t, ws.Subscribe("session:"+sessionID))
+	_, sessionID := submitAndSubscribe(t, app, "test-exec-fallback", "Routine health check")
 
 	app.WaitForSessionStatus(t, sessionID, "completed")
 
@@ -482,13 +445,35 @@ func TestE2E_FallbackExecutiveSummary(t *testing.T) {
 	assert.Equal(t, "completed", string(investigator.Status))
 	assert.Nil(t, investigator.OriginalLlmProvider, "Investigator should not have fallback (succeeded on primary)")
 
-	// ── LLM calls: Investigator (2) + exec summary (1 error + 1 success) = 4 ──
-	assert.Equal(t, 4, llm.CallCount())
+	// ── No agent-level provider_fallback events (exec summary path doesn't create them) ──
+	timeline := app.QueryTimeline(t, sessionID)
+	fallbackEvents := filterTimelineByType(timeline, timelineevent.EventTypeProviderFallback)
+	assert.Empty(t, fallbackEvents, "no agent-level fallback should have occurred")
+
+	// ── LLM calls: Investigator (2) + exec summary (1 retry + 1 fallback success) = 5 ──
+	// The extra call proves the exec summary path retried before falling back.
+	assert.Equal(t, 5, llm.CallCount())
 }
 
 // ────────────────────────────────────────────────────────────
 // Helpers
 // ────────────────────────────────────────────────────────────
+
+// submitAndSubscribe creates a WS connection, submits an alert, subscribes to
+// the session, and returns the WS client and session ID. Registers ws.Close
+// via t.Cleanup so callers don't need defer.
+func submitAndSubscribe(t *testing.T, app *TestApp, alertType, alertPayload string) (*WSClient, string) {
+	t.Helper()
+	ws, err := WSConnect(context.Background(), app.WSURL)
+	require.NoError(t, err)
+	t.Cleanup(func() { ws.Close() })
+
+	resp := app.SubmitAlert(t, alertType, alertPayload)
+	sessionID := resp["session_id"].(string)
+	require.NotEmpty(t, sessionID)
+	require.NoError(t, ws.Subscribe("session:"+sessionID))
+	return ws, sessionID
+}
 
 // findExecution returns the first execution matching agentName, or nil.
 func findExecution(execs []*ent.AgentExecution, agentName string) *ent.AgentExecution {
@@ -509,4 +494,14 @@ func filterTimelineByType(events []*ent.TimelineEvent, eventType timelineevent.E
 		}
 	}
 	return result
+}
+
+// findFallbackTransition locates a provider_fallback event by its from→to transition.
+func findFallbackTransition(events []*ent.TimelineEvent, fromProvider, toProvider string) *ent.TimelineEvent {
+	for _, e := range events {
+		if e.Metadata["original_provider"] == fromProvider && e.Metadata["fallback_provider"] == toProvider {
+			return e
+		}
+	}
+	return nil
 }

--- a/test/e2e/fallback_test.go
+++ b/test/e2e/fallback_test.go
@@ -1,0 +1,512 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/codeready-toolchain/tarsy/ent"
+	"github.com/codeready-toolchain/tarsy/ent/timelineevent"
+	"github.com/codeready-toolchain/tarsy/pkg/agent"
+	"github.com/codeready-toolchain/tarsy/test/e2e/testdata/configs"
+)
+
+// ────────────────────────────────────────────────────────────
+// TestE2E_FallbackOnMaxRetries — Primary provider fails with max_retries,
+// system falls back to fallback-1, agent completes investigation normally.
+//
+// Verifies:
+//   - Session completes successfully after fallback
+//   - Execution record: original_llm_provider/backend preserved
+//   - provider_fallback timeline event with correct metadata
+//   - ClearCache flag set on the post-fallback LLM call
+//   - Executive summary generated successfully
+// ────────────────────────────────────────────────────────────
+
+func TestE2E_FallbackOnMaxRetries(t *testing.T) {
+	llm := NewScriptedLLMClient()
+
+	// Iteration 1: primary provider fails with max_retries → immediate fallback
+	llm.AddRouted("Investigator", LLMScriptEntry{
+		Chunks: []agent.Chunk{
+			&agent.ErrorChunk{
+				Message:   "rate limit exceeded after 3 retries",
+				Code:      "max_retries",
+				Retryable: true,
+			},
+		},
+	})
+	// Iteration 1 (retried with fallback-1): tool call
+	llm.AddRouted("Investigator", LLMScriptEntry{
+		Chunks: []agent.Chunk{
+			&agent.ThinkingChunk{Content: "Let me check the system status."},
+			&agent.TextChunk{Content: "Checking system health after fallback."},
+			&agent.ToolCallChunk{CallID: "call-1", Name: "test-mcp__check_status", Arguments: `{"component":"api"}`},
+			&agent.UsageChunk{InputTokens: 50, OutputTokens: 20, TotalTokens: 70},
+		},
+	})
+	// Iteration 2: final answer
+	llm.AddRouted("Investigator", LLMScriptEntry{
+		Chunks: []agent.Chunk{
+			&agent.TextChunk{Content: "Investigation complete: API server is healthy. The initial provider failure was transient."},
+			&agent.UsageChunk{InputTokens: 80, OutputTokens: 30, TotalTokens: 110},
+		},
+	})
+	// Executive summary
+	llm.AddSequential(LLMScriptEntry{Text: "Alert investigated successfully. API server confirmed healthy after provider fallback."})
+
+	app := NewTestApp(t,
+		WithConfig(configs.Load(t, "fallback")),
+		WithLLMClient(llm),
+		WithMCPServers(map[string]map[string]mcpsdk.ToolHandler{
+			"test-mcp": {
+				"check_status": StaticToolHandler(`{"status":"healthy","uptime":"72h"}`),
+			},
+		}),
+	)
+
+	ctx := context.Background()
+	ws, err := WSConnect(ctx, app.WSURL)
+	require.NoError(t, err)
+	defer ws.Close()
+
+	resp := app.SubmitAlert(t, "test-fallback", "API server alert triggered")
+	sessionID := resp["session_id"].(string)
+	require.NotEmpty(t, sessionID)
+	require.NoError(t, ws.Subscribe("session:"+sessionID))
+
+	app.WaitForSessionStatus(t, sessionID, "completed")
+
+	// ── Session assertions ──
+	session := app.GetSession(t, sessionID)
+	assert.Equal(t, "completed", session["status"])
+	assert.NotEmpty(t, session["executive_summary"], "executive summary should be populated")
+
+	// ── Execution record: original provider preserved ──
+	execs := app.QueryExecutions(t, sessionID)
+	investigator := findExecution(execs, "Investigator")
+	require.NotNil(t, investigator, "Investigator execution should exist")
+	assert.Equal(t, "completed", string(investigator.Status))
+	require.NotNil(t, investigator.OriginalLlmProvider, "original_llm_provider should be set after fallback")
+	assert.Equal(t, "primary-provider", *investigator.OriginalLlmProvider)
+	require.NotNil(t, investigator.OriginalLlmBackend)
+	assert.Equal(t, "google-native", *investigator.OriginalLlmBackend)
+	require.NotNil(t, investigator.LlmProvider)
+	assert.Equal(t, "fallback-1", *investigator.LlmProvider)
+
+	// ── Timeline: provider_fallback event with metadata ──
+	timeline := app.QueryTimeline(t, sessionID)
+	fallbackEvents := filterTimelineByType(timeline, timelineevent.EventTypeProviderFallback)
+	require.Len(t, fallbackEvents, 1, "should have exactly one provider_fallback event")
+	assert.Equal(t, "primary-provider", fallbackEvents[0].Metadata["original_provider"])
+	assert.Equal(t, "fallback-1", fallbackEvents[0].Metadata["fallback_provider"])
+	assert.Equal(t, "google-native", fallbackEvents[0].Metadata["original_backend"])
+	assert.Equal(t, "google-native", fallbackEvents[0].Metadata["fallback_backend"])
+
+	// ── ClearCache: set on the first call after fallback ──
+	inputs := llm.CapturedInputs()
+	require.GreaterOrEqual(t, len(inputs), 2)
+	assert.False(t, inputs[0].ClearCache, "first call (primary) should not have ClearCache")
+	assert.True(t, inputs[1].ClearCache, "call after fallback should have ClearCache=true")
+	if len(inputs) > 2 {
+		assert.False(t, inputs[2].ClearCache, "subsequent calls should not have ClearCache")
+	}
+
+	// ── LLM call count: 1 error + 1 tool call + 1 final + 1 exec summary = 4 ──
+	assert.Equal(t, 4, llm.CallCount())
+
+	// ── WS: provider_fallback event delivered ──
+	ws.WaitForEvent(t, func(e WSEvent) bool {
+		return e.Type == "session.status" && e.Parsed["status"] == "completed"
+	}, 5*time.Second, "waiting for session.status=completed")
+
+	var hasFallbackWSEvent bool
+	for _, e := range ws.Events() {
+		if e.Type == "timeline_event.created" {
+			if et, _ := e.Parsed["event_type"].(string); et == "provider_fallback" {
+				hasFallbackWSEvent = true
+				break
+			}
+		}
+	}
+	assert.True(t, hasFallbackWSEvent, "WS should include provider_fallback timeline event")
+}
+
+// ────────────────────────────────────────────────────────────
+// TestE2E_FallbackCascade — Primary provider and first fallback both fail
+// with credentials errors; second fallback succeeds.
+//
+// Verifies:
+//   - Two provider_fallback timeline events
+//   - Execution record tracks the original (primary) provider
+//   - Session completes via the second fallback provider
+// ────────────────────────────────────────────────────────────
+
+func TestE2E_FallbackCascade(t *testing.T) {
+	llm := NewScriptedLLMClient()
+
+	// Primary: credentials error → immediate fallback to fallback-1
+	llm.AddRouted("Investigator", LLMScriptEntry{
+		Chunks: []agent.Chunk{
+			&agent.ErrorChunk{Message: "invalid API key", Code: "credentials"},
+		},
+	})
+	// fallback-1: credentials error → immediate fallback to fallback-2
+	llm.AddRouted("Investigator", LLMScriptEntry{
+		Chunks: []agent.Chunk{
+			&agent.ErrorChunk{Message: "invalid API key for fallback", Code: "credentials"},
+		},
+	})
+	// fallback-2: succeeds with final answer (no tool calls)
+	llm.AddRouted("Investigator", LLMScriptEntry{
+		Chunks: []agent.Chunk{
+			&agent.ThinkingChunk{Content: "Third provider working, analyzing alert."},
+			&agent.TextChunk{Content: "Investigation complete: alert was a false positive triggered by a monitoring misconfiguration."},
+			&agent.UsageChunk{InputTokens: 60, OutputTokens: 25, TotalTokens: 85},
+		},
+	})
+	// Executive summary
+	llm.AddSequential(LLMScriptEntry{Text: "False positive alert caused by monitoring misconfiguration."})
+
+	app := NewTestApp(t,
+		WithConfig(configs.Load(t, "fallback")),
+		WithLLMClient(llm),
+		WithMCPServers(map[string]map[string]mcpsdk.ToolHandler{
+			"test-mcp": {
+				"check_status": StaticToolHandler(`{"status":"healthy"}`),
+			},
+		}),
+	)
+
+	ctx := context.Background()
+	ws, err := WSConnect(ctx, app.WSURL)
+	require.NoError(t, err)
+	defer ws.Close()
+
+	resp := app.SubmitAlert(t, "test-cascade", "Monitoring alert fired")
+	sessionID := resp["session_id"].(string)
+	require.NotEmpty(t, sessionID)
+	require.NoError(t, ws.Subscribe("session:"+sessionID))
+
+	app.WaitForSessionStatus(t, sessionID, "completed")
+
+	// ── Session completes ──
+	session := app.GetSession(t, sessionID)
+	assert.Equal(t, "completed", session["status"])
+	assert.NotEmpty(t, session["executive_summary"])
+
+	// ── Two provider_fallback timeline events ──
+	timeline := app.QueryTimeline(t, sessionID)
+	fallbackEvents := filterTimelineByType(timeline, timelineevent.EventTypeProviderFallback)
+	require.Len(t, fallbackEvents, 2, "should have two provider_fallback events (primary→fb-1, fb-1→fb-2)")
+
+	assert.Equal(t, "primary-provider", fallbackEvents[0].Metadata["original_provider"])
+	assert.Equal(t, "fallback-1", fallbackEvents[0].Metadata["fallback_provider"])
+	assert.Equal(t, "fallback-1", fallbackEvents[1].Metadata["original_provider"])
+	assert.Equal(t, "fallback-2", fallbackEvents[1].Metadata["fallback_provider"])
+
+	// ── Execution record: original provider preserved, current is fallback-2 ──
+	execs := app.QueryExecutions(t, sessionID)
+	investigator := findExecution(execs, "Investigator")
+	require.NotNil(t, investigator)
+	require.NotNil(t, investigator.OriginalLlmProvider)
+	assert.Equal(t, "primary-provider", *investigator.OriginalLlmProvider, "original provider should be the primary")
+	require.NotNil(t, investigator.LlmProvider)
+	assert.Equal(t, "fallback-2", *investigator.LlmProvider, "current provider should be the last fallback")
+
+	// ── LLM call count: 2 errors + 1 success + 1 exec summary = 4 ──
+	assert.Equal(t, 4, llm.CallCount())
+}
+
+// ────────────────────────────────────────────────────────────
+// TestE2E_FallbackAllExhausted — All providers (primary + 2 fallbacks) fail
+// with max_retries. Session fails gracefully after exhausting every option.
+//
+// Uses LimitedAgent (max_iterations=3) so fallback providers are attempted
+// across iterations: primary (iter 0), fallback-1 (iter 1), fallback-2 (iter 2),
+// then force conclusion with fallback-2 also fails.
+//
+// Verifies:
+//   - Session/stage/execution all marked as failed
+//   - Two provider_fallback events recorded
+//   - Error timeline events present
+// ────────────────────────────────────────────────────────────
+
+func TestE2E_FallbackAllExhausted(t *testing.T) {
+	llm := NewScriptedLLMClient()
+
+	// iter 0: primary fails → fallback to fb-1
+	llm.AddRouted("LimitedAgent", LLMScriptEntry{
+		Chunks: []agent.Chunk{
+			&agent.ErrorChunk{Message: "service unavailable", Code: "max_retries", Retryable: true},
+		},
+	})
+	// iter 1: fb-1 fails → fallback to fb-2
+	llm.AddRouted("LimitedAgent", LLMScriptEntry{
+		Chunks: []agent.Chunk{
+			&agent.ErrorChunk{Message: "service unavailable", Code: "max_retries", Retryable: true},
+		},
+	})
+	// iter 2: fb-2 fails → all exhausted, treated as recoverable partial
+	llm.AddRouted("LimitedAgent", LLMScriptEntry{
+		Chunks: []agent.Chunk{
+			&agent.ErrorChunk{Message: "service unavailable", Code: "max_retries", Retryable: true},
+		},
+	})
+	// force conclusion: fb-2 fails again → exhausted → execution fails
+	llm.AddRouted("LimitedAgent", LLMScriptEntry{
+		Chunks: []agent.Chunk{
+			&agent.ErrorChunk{Message: "service unavailable", Code: "max_retries", Retryable: true},
+		},
+	})
+
+	app := NewTestApp(t,
+		WithConfig(configs.Load(t, "fallback")),
+		WithLLMClient(llm),
+	)
+
+	ctx := context.Background()
+	ws, err := WSConnect(ctx, app.WSURL)
+	require.NoError(t, err)
+	defer ws.Close()
+
+	resp := app.SubmitAlert(t, "test-exhausted", "Critical outage — all providers down")
+	sessionID := resp["session_id"].(string)
+	require.NotEmpty(t, sessionID)
+	require.NoError(t, ws.Subscribe("session:"+sessionID))
+
+	app.WaitForSessionStatus(t, sessionID, "failed")
+
+	// ── Session failed ──
+	session := app.GetSession(t, sessionID)
+	assert.Equal(t, "failed", session["status"])
+
+	// ── Execution failed with error ──
+	execs := app.QueryExecutions(t, sessionID)
+	limited := findExecution(execs, "LimitedAgent")
+	require.NotNil(t, limited)
+	assert.Equal(t, "failed", string(limited.Status))
+	require.NotNil(t, limited.ErrorMessage, "failed execution should have error_message")
+
+	// ── Two provider_fallback events (primary→fb-1, fb-1→fb-2) ──
+	timeline := app.QueryTimeline(t, sessionID)
+	fallbackEvents := filterTimelineByType(timeline, timelineevent.EventTypeProviderFallback)
+	assert.Len(t, fallbackEvents, 2, "should have two fallback events before exhaustion")
+
+	// ── Error events present ──
+	errorEvents := filterTimelineByType(timeline, timelineevent.EventTypeError)
+	assert.NotEmpty(t, errorEvents, "should have error timeline events")
+
+	// ── LLM calls: 3 main loop + 1 force conclusion = 4 ──
+	assert.Equal(t, 4, llm.CallCount())
+}
+
+// ────────────────────────────────────────────────────────────
+// TestE2E_FallbackParallelAgents — Parallel stage with two agents:
+// AlphaChecker's primary provider fails → falls back to fallback-1.
+// BetaChecker succeeds normally on the primary provider.
+// Stage completes with synthesis.
+//
+// Verifies:
+//   - Stage completes despite one agent needing fallback
+//   - AlphaChecker execution has original_llm_provider set
+//   - BetaChecker execution does NOT have original_llm_provider set
+//   - Exactly one provider_fallback timeline event (from AlphaChecker)
+// ────────────────────────────────────────────────────────────
+
+func TestE2E_FallbackParallelAgents(t *testing.T) {
+	llm := NewScriptedLLMClient()
+
+	// AlphaChecker: primary fails, then succeeds on fallback-1
+	llm.AddRouted("AlphaChecker", LLMScriptEntry{
+		Chunks: []agent.Chunk{
+			&agent.ErrorChunk{Message: "quota exceeded", Code: "max_retries", Retryable: true},
+		},
+	})
+	llm.AddRouted("AlphaChecker", LLMScriptEntry{
+		Chunks: []agent.Chunk{
+			&agent.TextChunk{Content: "System health check passed: all services are responding normally."},
+			&agent.UsageChunk{InputTokens: 40, OutputTokens: 15, TotalTokens: 55},
+		},
+	})
+
+	// BetaChecker: succeeds normally with tool call + final answer
+	llm.AddRouted("BetaChecker", LLMScriptEntry{
+		Chunks: []agent.Chunk{
+			&agent.TextChunk{Content: "Checking logs for anomalies."},
+			&agent.ToolCallChunk{CallID: "call-1", Name: "test-mcp__check_logs", Arguments: `{"service":"api"}`},
+			&agent.UsageChunk{InputTokens: 45, OutputTokens: 18, TotalTokens: 63},
+		},
+	})
+	llm.AddRouted("BetaChecker", LLMScriptEntry{
+		Chunks: []agent.Chunk{
+			&agent.TextChunk{Content: "Log analysis complete: no anomalies detected in the last 24 hours."},
+			&agent.UsageChunk{InputTokens: 70, OutputTokens: 25, TotalTokens: 95},
+		},
+	})
+
+	// Synthesis (sequential dispatch)
+	llm.AddSequential(LLMScriptEntry{
+		Chunks: []agent.Chunk{
+			&agent.TextChunk{Content: "Combined analysis: both health check and log analysis confirm system stability."},
+			&agent.UsageChunk{InputTokens: 60, OutputTokens: 20, TotalTokens: 80},
+		},
+	})
+	// Executive summary (sequential dispatch, generated for all chains)
+	llm.AddSequential(LLMScriptEntry{Text: "Parallel investigation confirms system stability."})
+
+	app := NewTestApp(t,
+		WithConfig(configs.Load(t, "fallback")),
+		WithLLMClient(llm),
+		WithMCPServers(map[string]map[string]mcpsdk.ToolHandler{
+			"test-mcp": {
+				"check_logs": StaticToolHandler(`{"anomalies":0,"last_error":null}`),
+			},
+		}),
+	)
+
+	ctx := context.Background()
+	ws, err := WSConnect(ctx, app.WSURL)
+	require.NoError(t, err)
+	defer ws.Close()
+
+	resp := app.SubmitAlert(t, "test-parallel-fallback", "Parallel investigation triggered")
+	sessionID := resp["session_id"].(string)
+	require.NotEmpty(t, sessionID)
+	require.NoError(t, ws.Subscribe("session:"+sessionID))
+
+	app.WaitForSessionStatus(t, sessionID, "completed")
+
+	// ── Stage completes ──
+	stages := app.QueryStages(t, sessionID)
+	require.NotEmpty(t, stages)
+	assert.Equal(t, "completed", string(stages[0].Status))
+
+	// ── Execution assertions: selective fallback ──
+	execs := app.QueryExecutions(t, sessionID)
+
+	alpha := findExecution(execs, "AlphaChecker")
+	require.NotNil(t, alpha, "AlphaChecker execution should exist")
+	assert.Equal(t, "completed", string(alpha.Status))
+	require.NotNil(t, alpha.OriginalLlmProvider, "AlphaChecker should have original_llm_provider (fallback occurred)")
+	assert.Equal(t, "primary-provider", *alpha.OriginalLlmProvider)
+
+	beta := findExecution(execs, "BetaChecker")
+	require.NotNil(t, beta, "BetaChecker execution should exist")
+	assert.Equal(t, "completed", string(beta.Status))
+	assert.Nil(t, beta.OriginalLlmProvider, "BetaChecker should NOT have original_llm_provider (no fallback)")
+
+	// ── Exactly one provider_fallback event ──
+	timeline := app.QueryTimeline(t, sessionID)
+	fallbackEvents := filterTimelineByType(timeline, timelineevent.EventTypeProviderFallback)
+	assert.Len(t, fallbackEvents, 1, "only AlphaChecker should trigger fallback")
+
+	// ── LLM calls: Alpha (1 err + 1 ok) + Beta (2 ok) + Synthesis (1) + Exec summary (1) = 6 ──
+	assert.Equal(t, 6, llm.CallCount())
+}
+
+// ────────────────────────────────────────────────────────────
+// TestE2E_FallbackExecutiveSummary — Agent chain completes normally, but
+// the executive summary's primary provider fails. The system falls back
+// to a secondary provider and produces the executive summary.
+//
+// Verifies:
+//   - Session completes with executive_summary populated
+//   - Agent execution has NO original_llm_provider (no agent-level fallback)
+//   - Executive summary was generated despite primary failure
+// ────────────────────────────────────────────────────────────
+
+func TestE2E_FallbackExecutiveSummary(t *testing.T) {
+	llm := NewScriptedLLMClient()
+
+	// Investigator: normal tool call + final answer
+	llm.AddRouted("Investigator", LLMScriptEntry{
+		Chunks: []agent.Chunk{
+			&agent.TextChunk{Content: "Checking system metrics."},
+			&agent.ToolCallChunk{CallID: "call-1", Name: "test-mcp__get_metrics", Arguments: `{"service":"api"}`},
+			&agent.UsageChunk{InputTokens: 50, OutputTokens: 20, TotalTokens: 70},
+		},
+	})
+	llm.AddRouted("Investigator", LLMScriptEntry{
+		Chunks: []agent.Chunk{
+			&agent.TextChunk{Content: "Metrics show normal operation. CPU at 45%, memory at 62%. No anomalies detected."},
+			&agent.UsageChunk{InputTokens: 80, OutputTokens: 30, TotalTokens: 110},
+		},
+	})
+
+	// Executive summary: primary fails, fallback succeeds
+	llm.AddSequential(LLMScriptEntry{
+		Error: fmt.Errorf("executive summary provider overloaded"),
+	})
+	llm.AddSequential(LLMScriptEntry{
+		Text: "System operating normally. CPU 45%, memory 62%. No action required.",
+	})
+
+	app := NewTestApp(t,
+		WithConfig(configs.Load(t, "fallback")),
+		WithLLMClient(llm),
+		WithMCPServers(map[string]map[string]mcpsdk.ToolHandler{
+			"test-mcp": {
+				"get_metrics": StaticToolHandler(`{"cpu":45,"memory":62,"errors":0}`),
+			},
+		}),
+	)
+
+	ctx := context.Background()
+	ws, err := WSConnect(ctx, app.WSURL)
+	require.NoError(t, err)
+	defer ws.Close()
+
+	resp := app.SubmitAlert(t, "test-exec-fallback", "Routine health check")
+	sessionID := resp["session_id"].(string)
+	require.NotEmpty(t, sessionID)
+	require.NoError(t, ws.Subscribe("session:"+sessionID))
+
+	app.WaitForSessionStatus(t, sessionID, "completed")
+
+	// ── Session completes with executive summary ──
+	session := app.GetSession(t, sessionID)
+	assert.Equal(t, "completed", session["status"])
+	assert.NotEmpty(t, session["executive_summary"], "executive summary should be populated via fallback")
+	assert.Empty(t, session["executive_summary_error"], "no error since fallback succeeded")
+
+	// ── Agent execution: no fallback at the agent level ──
+	execs := app.QueryExecutions(t, sessionID)
+	investigator := findExecution(execs, "Investigator")
+	require.NotNil(t, investigator)
+	assert.Equal(t, "completed", string(investigator.Status))
+	assert.Nil(t, investigator.OriginalLlmProvider, "Investigator should not have fallback (succeeded on primary)")
+
+	// ── LLM calls: Investigator (2) + exec summary (1 error + 1 success) = 4 ──
+	assert.Equal(t, 4, llm.CallCount())
+}
+
+// ────────────────────────────────────────────────────────────
+// Helpers
+// ────────────────────────────────────────────────────────────
+
+// findExecution returns the first execution matching agentName, or nil.
+func findExecution(execs []*ent.AgentExecution, agentName string) *ent.AgentExecution {
+	for _, e := range execs {
+		if e.AgentName == agentName {
+			return e
+		}
+	}
+	return nil
+}
+
+// filterTimelineByType returns timeline events matching the given event type.
+func filterTimelineByType(events []*ent.TimelineEvent, eventType timelineevent.EventType) []*ent.TimelineEvent {
+	var result []*ent.TimelineEvent
+	for _, e := range events {
+		if e.EventType == eventType {
+			result = append(result, e)
+		}
+	}
+	return result
+}

--- a/test/e2e/fallback_test.go
+++ b/test/e2e/fallback_test.go
@@ -445,10 +445,12 @@ func TestE2E_FallbackExecutiveSummary(t *testing.T) {
 	assert.Equal(t, "completed", string(investigator.Status))
 	assert.Nil(t, investigator.OriginalLlmProvider, "Investigator should not have fallback (succeeded on primary)")
 
-	// ── No agent-level provider_fallback events (exec summary path doesn't create them) ──
+	// ── Executive summary creates a provider_fallback timeline event ──
 	timeline := app.QueryTimeline(t, sessionID)
 	fallbackEvents := filterTimelineByType(timeline, timelineevent.EventTypeProviderFallback)
-	assert.Empty(t, fallbackEvents, "no agent-level fallback should have occurred")
+	require.Len(t, fallbackEvents, 1, "exactly one provider_fallback event from exec summary")
+	assert.Equal(t, "primary-provider", fallbackEvents[0].Metadata["original_provider"])
+	assert.Equal(t, "fallback-1", fallbackEvents[0].Metadata["fallback_provider"])
 
 	// ── LLM calls: Investigator (2) + exec summary (1 fail + 1 retry + 1 fallback) = 5 ──
 	inputs := llm.CapturedInputs()

--- a/test/e2e/fallback_test.go
+++ b/test/e2e/fallback_test.go
@@ -381,12 +381,12 @@ func TestE2E_FallbackParallelAgents(t *testing.T) {
 //   - Session completes with executive_summary populated
 //   - Agent execution has NO original_llm_provider (no agent-level fallback)
 //   - Executive summary was generated despite primary failure
-//   - LLM call count proves the exec summary required a retry/fallback
+//   - ClearCache=true and different model on the fallback call prove provider switch
 //
 // NOTE: The executive summary uses a standalone LLM call path
 // (executor_synthesis.go), not the agent controller. It does not create
 // provider_fallback timeline events or execution records, so we verify
-// the fallback indirectly via call count and successful summary output.
+// the fallback via CapturedInputs() (ClearCache flag + model change).
 // ────────────────────────────────────────────────────────────
 
 func TestE2E_FallbackExecutiveSummary(t *testing.T) {
@@ -450,9 +450,22 @@ func TestE2E_FallbackExecutiveSummary(t *testing.T) {
 	fallbackEvents := filterTimelineByType(timeline, timelineevent.EventTypeProviderFallback)
 	assert.Empty(t, fallbackEvents, "no agent-level fallback should have occurred")
 
-	// ── LLM calls: Investigator (2) + exec summary (1 retry + 1 fallback success) = 5 ──
-	// The extra call proves the exec summary path retried before falling back.
-	assert.Equal(t, 5, llm.CallCount())
+	// ── LLM calls: Investigator (2) + exec summary (1 fail + 1 retry + 1 fallback) = 5 ──
+	inputs := llm.CapturedInputs()
+	require.Equal(t, 5, len(inputs))
+
+	// The last call (exec summary fallback) should prove a provider switch:
+	// ClearCache=true and a different model than the primary provider.
+	summaryFallbackCall := inputs[4]
+	assert.True(t, summaryFallbackCall.ClearCache,
+		"exec summary fallback call should have ClearCache=true")
+	assert.Equal(t, "test-fallback-1", summaryFallbackCall.Config.Model,
+		"exec summary fallback should use fallback-1 provider model")
+
+	// Earlier exec summary calls used the primary provider
+	assert.False(t, inputs[2].ClearCache, "first exec summary attempt should not clear cache")
+	assert.Equal(t, "test-primary", inputs[2].Config.Model,
+		"first exec summary attempt should use primary model")
 }
 
 // ────────────────────────────────────────────────────────────

--- a/test/e2e/mock_llm.go
+++ b/test/e2e/mock_llm.go
@@ -136,6 +136,13 @@ func (c *ScriptedLLMClient) CallCount() int {
 	return len(c.capturedInputs)
 }
 
+// CapturedInputs returns a copy of all captured GenerateInput values in call order.
+func (c *ScriptedLLMClient) CapturedInputs() []*agent.GenerateInput {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]*agent.GenerateInput(nil), c.capturedInputs...)
+}
+
 // nextEntry selects the next script entry using dual dispatch.
 // Must be called with c.mu held.
 func (c *ScriptedLLMClient) nextEntry(input *agent.GenerateInput) (*LLMScriptEntry, error) {

--- a/test/e2e/testdata/configs/fallback/llm-providers.yaml
+++ b/test/e2e/testdata/configs/fallback/llm-providers.yaml
@@ -1,0 +1,13 @@
+llm_providers:
+  primary-provider:
+    type: google
+    model: test-primary
+    max_tool_result_tokens: 10000
+  fallback-1:
+    type: google
+    model: test-fallback-1
+    max_tool_result_tokens: 10000
+  fallback-2:
+    type: google
+    model: test-fallback-2
+    max_tool_result_tokens: 10000

--- a/test/e2e/testdata/configs/fallback/tarsy.yaml
+++ b/test/e2e/testdata/configs/fallback/tarsy.yaml
@@ -1,0 +1,73 @@
+defaults:
+  llm_provider: "primary-provider"
+  llm_backend: "google-native"
+  max_iterations: 5
+  fallback_providers:
+    - provider: "fallback-1"
+      backend: "google-native"
+    - provider: "fallback-2"
+      backend: "google-native"
+
+mcp_servers:
+  test-mcp:
+    transport:
+      type: stdio
+      command: mock
+  # Dummy entry so built-in agents (KubernetesAgent, etc.) pass validation.
+  kubernetes-server:
+    transport:
+      type: stdio
+      command: mock
+
+agents:
+  Investigator:
+    mcp_servers: [test-mcp]
+    custom_instructions: "You are Investigator, investigating the issue."
+  LimitedAgent:
+    max_iterations: 3
+    custom_instructions: "You are LimitedAgent, analyzing the alert."
+  AlphaChecker:
+    custom_instructions: "You are AlphaChecker, checking system health."
+  BetaChecker:
+    mcp_servers: [test-mcp]
+    custom_instructions: "You are BetaChecker, analyzing logs."
+
+agent_chains:
+  # Used by: TestE2E_FallbackOnMaxRetries, TestE2E_FallbackCascade
+  single-fallback:
+    alert_types: [test-fallback, test-cascade]
+    executive_summary_provider: "primary-provider"
+    stages:
+      - name: investigation
+        agents:
+          - name: Investigator
+
+  # Used by: TestE2E_FallbackAllExhausted
+  exhausted-chain:
+    alert_types: [test-exhausted]
+    stages:
+      - name: investigation
+        agents:
+          - name: LimitedAgent
+
+  # Used by: TestE2E_FallbackParallelAgents
+  parallel-fallback:
+    alert_types: [test-parallel-fallback]
+    stages:
+      - name: analysis
+        success_policy: all
+        agents:
+          - name: AlphaChecker
+          - name: BetaChecker
+        synthesis:
+          llm_provider: "primary-provider"
+          llm_backend: "google-native"
+
+  # Used by: TestE2E_FallbackExecutiveSummary
+  exec-summary-chain:
+    alert_types: [test-exec-fallback]
+    executive_summary_provider: "primary-provider"
+    stages:
+      - name: investigation
+        agents:
+          - name: Investigator


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic LLM provider fallback across single-shot, iterative, and executive-summary flows; preserves original provider info, emits timeline events, and signals cache clearing between provider switches.
* **Behavior change**
  * Fallback now triggers after two consecutive failures for provider_error/invalid_request/partial_stream_error; adds explicit error codes, retry semantics, and unified status mapping for context errors.
* **Tests**
  * Extensive unit and end-to-end tests for fallback logic, cache-clearing propagation, timeline events, and status mapping.
* **Documentation**
  * Design doc and example config updated to document fallback behavior and observability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->