### PR TITLE
Skip fallback models which match current model

### DIFF
--- a/docs/proposals/llm-provider-fallback-design.md
+++ b/docs/proposals/llm-provider-fallback-design.md
@@ -153,6 +153,10 @@ An entry in the fallback list: `{provider: string, backend: LLMBackend}`. The pr
 
 Each fallback entry specifies both a provider and a backend. When fallback triggers, the system switches to both — including changing the backend if the fallback entry uses a different one (e.g., `google-native` → `langchain`). If a provider/backend combination doesn't work, that's a configuration error caught at startup (Q4).
 
+### Same-Provider Skip
+
+When selecting the next fallback entry, `tryFallback` skips entries whose provider name matches the currently active provider (regardless of backend). This prevents wasting iterations by "falling back" to the same model that is already failing.
+
 ### Fallback Trigger Conditions
 
 Fallback triggers depend on the error code from the Python LLM service, since each code carries different retry history:

--- a/pkg/agent/controller/fallback.go
+++ b/pkg/agent/controller/fallback.go
@@ -132,9 +132,23 @@ func tryFallback(
 		return false
 	}
 
-	// Defensive: shouldFallback already rejects exhausted lists, but guard
-	// the slice access in case the two checks ever diverge.
+	// Find the next fallback entry that differs from the currently active
+	// provider+backend. An entry identical to the current provider would just
+	// repeat the same failure, so skip it.
 	nextIdx := state.CurrentProviderIndex + 1
+	for nextIdx < len(execCtx.Config.ResolvedFallbackProviders) {
+		candidate := execCtx.Config.ResolvedFallbackProviders[nextIdx]
+		if candidate.ProviderName != execCtx.Config.LLMProviderName {
+			break
+		}
+		slog.Info("Skipping fallback entry identical to current provider",
+			"session_id", execCtx.SessionID,
+			"execution_id", execCtx.ExecutionID,
+			"skipped_provider", candidate.ProviderName,
+			"skipped_backend", candidate.Backend,
+		)
+		nextIdx++
+	}
 	if nextIdx >= len(execCtx.Config.ResolvedFallbackProviders) {
 		return false
 	}

--- a/pkg/agent/controller/fallback_test.go
+++ b/pkg/agent/controller/fallback_test.go
@@ -351,6 +351,98 @@ func TestTryFallback_ExhaustsFallbackList(t *testing.T) {
 	assert.False(t, result, "should fail when all providers exhausted")
 }
 
+func TestTryFallback_SkipsSameProviderEntries(t *testing.T) {
+	llm := &mockLLMClient{
+		responses: []mockLLMResponse{
+			{chunks: []agent.Chunk{&agent.TextChunk{Content: "hello"}}},
+		},
+	}
+	execCtx := newTestExecCtx(t, llm, &mockToolExecutor{})
+	execCtx.Config.LLMProviderName = "primary"
+	execCtx.Config.LLMBackend = config.LLMBackendNativeGemini
+	execCtx.Config.ResolvedFallbackProviders = []agent.ResolvedFallbackEntry{
+		{
+			ProviderName: "primary",
+			Backend:      config.LLMBackendNativeGemini,
+			Config:       &config.LLMProviderConfig{Model: "same-model"},
+		},
+		{
+			ProviderName: "actual-fallback",
+			Backend:      config.LLMBackendLangChain,
+			Config:       &config.LLMProviderConfig{Model: "different-model"},
+		},
+	}
+
+	state := NewFallbackState(execCtx)
+	eventSeq := 0
+
+	result := tryFallback(context.Background(), execCtx, state,
+		makePartialError(LLMErrorMaxRetries), &eventSeq)
+	require.True(t, result)
+
+	assert.Equal(t, "actual-fallback", execCtx.Config.LLMProviderName,
+		"should skip the entry identical to current provider")
+	assert.Equal(t, config.LLMBackendLangChain, execCtx.Config.LLMBackend)
+	assert.Equal(t, 1, state.CurrentProviderIndex,
+		"index should point to the entry that was actually used")
+}
+
+func TestTryFallback_AllFallbacksSameAsCurrentProvider(t *testing.T) {
+	llm := &mockLLMClient{
+		responses: []mockLLMResponse{
+			{chunks: []agent.Chunk{&agent.TextChunk{Content: "hello"}}},
+		},
+	}
+	execCtx := newTestExecCtx(t, llm, &mockToolExecutor{})
+	execCtx.Config.LLMProviderName = "primary"
+	execCtx.Config.LLMBackend = config.LLMBackendNativeGemini
+	execCtx.Config.ResolvedFallbackProviders = []agent.ResolvedFallbackEntry{
+		{
+			ProviderName: "primary",
+			Backend:      config.LLMBackendNativeGemini,
+			Config:       &config.LLMProviderConfig{Model: "same-model"},
+		},
+	}
+
+	state := NewFallbackState(execCtx)
+	eventSeq := 0
+
+	result := tryFallback(context.Background(), execCtx, state,
+		makePartialError(LLMErrorMaxRetries), &eventSeq)
+	assert.False(t, result,
+		"should return false when all fallback entries match current provider")
+	assert.Equal(t, "primary", execCtx.Config.LLMProviderName,
+		"provider should not have changed")
+}
+
+func TestTryFallback_SameProviderDifferentBackendAlsoSkipped(t *testing.T) {
+	llm := &mockLLMClient{
+		responses: []mockLLMResponse{
+			{chunks: []agent.Chunk{&agent.TextChunk{Content: "hello"}}},
+		},
+	}
+	execCtx := newTestExecCtx(t, llm, &mockToolExecutor{})
+	execCtx.Config.LLMProviderName = "gemini-flash"
+	execCtx.Config.LLMBackend = config.LLMBackendNativeGemini
+	execCtx.Config.ResolvedFallbackProviders = []agent.ResolvedFallbackEntry{
+		{
+			ProviderName: "gemini-flash",
+			Backend:      config.LLMBackendLangChain,
+			Config:       &config.LLMProviderConfig{Model: "gemini-flash"},
+		},
+	}
+
+	state := NewFallbackState(execCtx)
+	eventSeq := 0
+
+	result := tryFallback(context.Background(), execCtx, state,
+		makePartialError(LLMErrorMaxRetries), &eventSeq)
+	assert.False(t, result,
+		"same provider name with different backend should still be skipped")
+	assert.Equal(t, config.LLMBackendNativeGemini, execCtx.Config.LLMBackend,
+		"backend should not have changed")
+}
+
 func TestTryFallback_CancelledContext(t *testing.T) {
 	llm := &mockLLMClient{
 		responses: []mockLLMResponse{


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Fallback selection now skips any fallback entries whose provider matches the currently active provider, preventing repeated attempts from failing providers.

* **Documentation**
  * Updated fallback design documentation with new Same-Provider Skip rule.

* **Tests**
  * Added test cases validating same-provider fallback skipping across multiple scenarios, including when all fallback entries match the current provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->