### PR TITLE
Add index to session_id in mcp interactions

### DIFF
--- a/ent/migrate/schema.go
+++ b/ent/migrate/schema.go
@@ -383,6 +383,11 @@ var (
 				Unique:  false,
 				Columns: []*schema.Column{McpInteractionsColumns[12], McpInteractionsColumns[1]},
 			},
+			{
+				Name:    "mcpinteraction_session_id_created_at",
+				Unique:  false,
+				Columns: []*schema.Column{McpInteractionsColumns[11], McpInteractionsColumns[1]},
+			},
 		},
 	}
 	// MessagesColumns holds the columns for the "messages" table.

--- a/ent/schema/mcpinteraction.go
+++ b/ent/schema/mcpinteraction.go
@@ -99,5 +99,7 @@ func (MCPInteraction) Indexes() []ent.Index {
 		index.Fields("execution_id", "created_at"),
 		// Stage's MCP calls
 		index.Fields("stage_id", "created_at"),
+		// Session-level MCP calls (dashboard aggregation)
+		index.Fields("session_id", "created_at"),
 	}
 }

--- a/pkg/database/migrations/20260304100000_add_mcp_session_id_index.up.sql
+++ b/pkg/database/migrations/20260304100000_add_mcp_session_id_index.up.sql
@@ -1,0 +1,4 @@
+-- Add session_id index to mcp_interactions for dashboard aggregation queries.
+-- Matches the existing llm_interactions pattern (session_id, created_at).
+CREATE INDEX IF NOT EXISTS "mcpinteraction_session_id_created_at"
+    ON "public"."mcp_interactions" ("session_id", "created_at");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Added database index on session identifier and creation timestamp fields to improve query efficiency for dashboard aggregations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->