### PR TITLE
Stage types - Phase 1 - Stage Type Field

### DIFF
--- a/.cursor/skills/golang-type-safety/SKILL.md
+++ b/.cursor/skills/golang-type-safety/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: golang-type-safety
+description: Prefer typed constants and named types over magic strings/numbers in Go. Use when writing function signatures, struct fields, switch statements, or passing enum-like values.
+---
+
+# Go Type Safety
+
+Use typed constants and named types instead of magic strings and numbers. This catches misuse at compile time and makes intent explicit.
+
+## Named String Types for Enums
+
+When a value comes from a defined set (e.g. ent-generated enums, config enums), use the named type:
+
+```go
+// Bad — magic string, no compile-time checking
+publishStageStatus(ctx, pub, sid, stgID, name, idx, "investigation", status)
+
+// Good — typed constant, typos caught at compile time
+publishStageStatus(ctx, pub, sid, stgID, name, idx, stage.StageTypeInvestigation, status)
+```
+
+## Function Signatures
+
+Accept the named type, not `string`, when the parameter is always one of a known set:
+
+```go
+// Bad — caller can pass any string
+func publishStageStatus(ctx context.Context, ..., stageType string, status string)
+
+// Good — compiler enforces valid stage types
+func publishStageStatus(ctx context.Context, ..., stageType stage.StageType, status string)
+```
+
+Convert to `string` at serialization boundaries (JSON payloads, DB queries, log messages):
+
+```go
+payload.StageType = string(stageType)
+```
+
+## Struct Fields
+
+Use `string` for DTOs/payloads that cross API boundaries (JSON serialization).
+Use the named type for internal structs where type safety helps:
+
+```go
+// API payload — string is fine (wire format)
+type StageStatusPayload struct {
+    StageType string `json:"stage_type"`
+}
+
+// Internal struct — use the named type
+type stageInput struct {
+    stageType stage.StageType
+}
+```
+
+## Struct Literals
+
+When constructing structs with string fields that accept enum values, use `string(constant)`:
+
+```go
+// Bad
+req := CreateStageRequest{StageType: "synthesis"}
+
+// Good
+req := CreateStageRequest{StageType: string(stage.StageTypeSynthesis)}
+```
+
+## When NOT to Use Named Types
+
+- One-off values that aren't from a defined set (free-form names, user input)
+- Test data where the literal is the point (e.g. `"bogus"` for invalid input tests)
+- String comparisons in tests asserting wire-format output

--- a/.cursor/skills/golang-type-safety/SKILL.md
+++ b/.cursor/skills/golang-type-safety/SKILL.md
@@ -37,6 +37,48 @@ Convert to `string` at serialization boundaries (JSON payloads, DB queries, log 
 payload.StageType = string(stageType)
 ```
 
+### Warning: Direct Casting Does Not Validate
+
+`stage.StageType(s)` compiles but does **not** check whether `s` is a known value.
+Always use a parse helper at API/deserialize boundaries where the input is untrusted:
+
+```go
+// Bad — silently accepts unknown values
+stageType := stage.StageType(req.StageType)
+
+// Good — rejects unknown values at the boundary
+stageType, err := parseStageType(req.StageType)
+if err != nil {
+    return nil, err
+}
+```
+
+### parseStageType Helper
+
+Define this once near the package entry point (e.g., handler or service layer):
+
+```go
+// parseStageType converts a raw string from an API payload or query parameter
+// into a stage.StageType, returning an error for unknown values.
+//
+// Allowed values: stage.StageTypeInvestigation, stage.StageTypeSynthesis,
+// stage.StageTypeChat, stage.StageTypeExecSummary, stage.StageTypeScoring.
+func parseStageType(s string) (stage.StageType, error) {
+    switch stage.StageType(s) {
+    case stage.StageTypeInvestigation,
+        stage.StageTypeSynthesis,
+        stage.StageTypeChat,
+        stage.StageTypeExecSummary,
+        stage.StageTypeScoring:
+        return stage.StageType(s), nil
+    default:
+        return "", fmt.Errorf("unknown stage type %q", s)
+    }
+}
+```
+
+This is the only place where an unvalidated cast is acceptable — all call sites receive an already-validated `stage.StageType`.
+
 ## Struct Fields
 
 Use `string` for DTOs/payloads that cross API boundaries (JSON serialization).

--- a/docs/proposals/stage-types-design.md
+++ b/docs/proposals/stage-types-design.md
@@ -329,7 +329,7 @@ This migration is safe and idempotent. The heuristics match exactly the stages t
 
 ## Implementation Plan
 
-### PR 1: Stage Type Field (additive, no behavior change)
+### PR 1: Stage Type Field (additive, no behavior change) — ✅ DONE
 
 1. **Schema:** Add `stage_type` enum field to `ent/schema/stage.go` with 5 values (`investigation`, `synthesis`, `chat`, `exec_summary`, `scoring`). Regenerate ent code. Add backfill SQL to the migration.
 2. **Service:** Add `StageType` to `CreateStageRequest`. Wire in `StageService.CreateStage` with `"investigation"` default.

--- a/ent/migrate/schema.go
+++ b/ent/migrate/schema.go
@@ -513,6 +513,7 @@ var (
 		{Name: "expected_agent_count", Type: field.TypeInt},
 		{Name: "parallel_type", Type: field.TypeEnum, Nullable: true, Enums: []string{"multi_agent", "replica"}},
 		{Name: "success_policy", Type: field.TypeEnum, Nullable: true, Enums: []string{"all", "any"}},
+		{Name: "stage_type", Type: field.TypeEnum, Enums: []string{"investigation", "synthesis", "chat", "exec_summary", "scoring"}, Default: "investigation"},
 		{Name: "status", Type: field.TypeEnum, Enums: []string{"pending", "active", "completed", "failed", "timed_out", "cancelled"}, Default: "pending"},
 		{Name: "started_at", Type: field.TypeTime, Nullable: true},
 		{Name: "completed_at", Type: field.TypeTime, Nullable: true},
@@ -530,19 +531,19 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "stages_alert_sessions_stages",
-				Columns:    []*schema.Column{StagesColumns[11]},
+				Columns:    []*schema.Column{StagesColumns[12]},
 				RefColumns: []*schema.Column{AlertSessionsColumns[0]},
 				OnDelete:   schema.Cascade,
 			},
 			{
 				Symbol:     "stages_chats_stages",
-				Columns:    []*schema.Column{StagesColumns[12]},
+				Columns:    []*schema.Column{StagesColumns[13]},
 				RefColumns: []*schema.Column{ChatsColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "stages_chat_user_messages_stage",
-				Columns:    []*schema.Column{StagesColumns[13]},
+				Columns:    []*schema.Column{StagesColumns[14]},
 				RefColumns: []*schema.Column{ChatUserMessagesColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
@@ -551,7 +552,7 @@ var (
 			{
 				Name:    "stage_session_id_stage_index",
 				Unique:  true,
-				Columns: []*schema.Column{StagesColumns[11], StagesColumns[2]},
+				Columns: []*schema.Column{StagesColumns[12], StagesColumns[2]},
 			},
 		},
 	}

--- a/ent/mutation.go
+++ b/ent/mutation.go
@@ -11953,6 +11953,7 @@ type StageMutation struct {
 	addexpected_agent_count  *int
 	parallel_type            *stage.ParallelType
 	success_policy           *stage.SuccessPolicy
+	stage_type               *stage.StageType
 	status                   *stage.Status
 	started_at               *time.Time
 	completed_at             *time.Time
@@ -12370,6 +12371,42 @@ func (m *StageMutation) SuccessPolicyCleared() bool {
 func (m *StageMutation) ResetSuccessPolicy() {
 	m.success_policy = nil
 	delete(m.clearedFields, stage.FieldSuccessPolicy)
+}
+
+// SetStageType sets the "stage_type" field.
+func (m *StageMutation) SetStageType(st stage.StageType) {
+	m.stage_type = &st
+}
+
+// StageType returns the value of the "stage_type" field in the mutation.
+func (m *StageMutation) StageType() (r stage.StageType, exists bool) {
+	v := m.stage_type
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldStageType returns the old "stage_type" field's value of the Stage entity.
+// If the Stage object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *StageMutation) OldStageType(ctx context.Context) (v stage.StageType, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldStageType is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldStageType requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldStageType: %w", err)
+	}
+	return oldValue.StageType, nil
+}
+
+// ResetStageType resets all changes to the "stage_type" field.
+func (m *StageMutation) ResetStageType() {
+	m.stage_type = nil
 }
 
 // SetStatus sets the "status" field.
@@ -13108,7 +13145,7 @@ func (m *StageMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *StageMutation) Fields() []string {
-	fields := make([]string, 0, 13)
+	fields := make([]string, 0, 14)
 	if m.session != nil {
 		fields = append(fields, stage.FieldSessionID)
 	}
@@ -13126,6 +13163,9 @@ func (m *StageMutation) Fields() []string {
 	}
 	if m.success_policy != nil {
 		fields = append(fields, stage.FieldSuccessPolicy)
+	}
+	if m.stage_type != nil {
+		fields = append(fields, stage.FieldStageType)
 	}
 	if m.status != nil {
 		fields = append(fields, stage.FieldStatus)
@@ -13168,6 +13208,8 @@ func (m *StageMutation) Field(name string) (ent.Value, bool) {
 		return m.ParallelType()
 	case stage.FieldSuccessPolicy:
 		return m.SuccessPolicy()
+	case stage.FieldStageType:
+		return m.StageType()
 	case stage.FieldStatus:
 		return m.Status()
 	case stage.FieldStartedAt:
@@ -13203,6 +13245,8 @@ func (m *StageMutation) OldField(ctx context.Context, name string) (ent.Value, e
 		return m.OldParallelType(ctx)
 	case stage.FieldSuccessPolicy:
 		return m.OldSuccessPolicy(ctx)
+	case stage.FieldStageType:
+		return m.OldStageType(ctx)
 	case stage.FieldStatus:
 		return m.OldStatus(ctx)
 	case stage.FieldStartedAt:
@@ -13267,6 +13311,13 @@ func (m *StageMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetSuccessPolicy(v)
+		return nil
+	case stage.FieldStageType:
+		v, ok := value.(stage.StageType)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetStageType(v)
 		return nil
 	case stage.FieldStatus:
 		v, ok := value.(stage.Status)
@@ -13473,6 +13524,9 @@ func (m *StageMutation) ResetField(name string) error {
 		return nil
 	case stage.FieldSuccessPolicy:
 		m.ResetSuccessPolicy()
+		return nil
+	case stage.FieldStageType:
+		m.ResetStageType()
 		return nil
 	case stage.FieldStatus:
 		m.ResetStatus()

--- a/ent/schema/stage.go
+++ b/ent/schema/stage.go
@@ -44,6 +44,12 @@ func (Stage) Fields() []ent.Field {
 			Nillable().
 			Comment("null if count=1, 'all'/'any' if count>1"),
 
+		// Stage Type
+		field.Enum("stage_type").
+			Values("investigation", "synthesis", "chat", "exec_summary", "scoring").
+			Default("investigation").
+			Comment("Kind of stage: investigation (from chain), synthesis (auto-generated), chat (user message), exec_summary (executive summary), scoring (quality evaluation)"),
+
 		// Stage-Level Status & Timing (aggregated from agent executions)
 		field.Enum("status").
 			Values("pending", "active", "completed", "failed", "timed_out", "cancelled").

--- a/ent/stage.go
+++ b/ent/stage.go
@@ -32,6 +32,8 @@ type Stage struct {
 	ParallelType *stage.ParallelType `json:"parallel_type,omitempty"`
 	// null if count=1, 'all'/'any' if count>1
 	SuccessPolicy *stage.SuccessPolicy `json:"success_policy,omitempty"`
+	// Kind of stage: investigation (from chain), synthesis (auto-generated), chat (user message), exec_summary (executive summary), scoring (quality evaluation)
+	StageType stage.StageType `json:"stage_type,omitempty"`
 	// Status holds the value of the "status" field.
 	Status stage.Status `json:"status,omitempty"`
 	// When first agent started
@@ -160,7 +162,7 @@ func (*Stage) scanValues(columns []string) ([]any, error) {
 		switch columns[i] {
 		case stage.FieldStageIndex, stage.FieldExpectedAgentCount, stage.FieldDurationMs:
 			values[i] = new(sql.NullInt64)
-		case stage.FieldID, stage.FieldSessionID, stage.FieldStageName, stage.FieldParallelType, stage.FieldSuccessPolicy, stage.FieldStatus, stage.FieldErrorMessage, stage.FieldChatID, stage.FieldChatUserMessageID:
+		case stage.FieldID, stage.FieldSessionID, stage.FieldStageName, stage.FieldParallelType, stage.FieldSuccessPolicy, stage.FieldStageType, stage.FieldStatus, stage.FieldErrorMessage, stage.FieldChatID, stage.FieldChatUserMessageID:
 			values[i] = new(sql.NullString)
 		case stage.FieldStartedAt, stage.FieldCompletedAt:
 			values[i] = new(sql.NullTime)
@@ -222,6 +224,12 @@ func (_m *Stage) assignValues(columns []string, values []any) error {
 			} else if value.Valid {
 				_m.SuccessPolicy = new(stage.SuccessPolicy)
 				*_m.SuccessPolicy = stage.SuccessPolicy(value.String)
+			}
+		case stage.FieldStageType:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field stage_type", values[i])
+			} else if value.Valid {
+				_m.StageType = stage.StageType(value.String)
 			}
 		case stage.FieldStatus:
 			if value, ok := values[i].(*sql.NullString); !ok {
@@ -368,6 +376,9 @@ func (_m *Stage) String() string {
 		builder.WriteString("success_policy=")
 		builder.WriteString(fmt.Sprintf("%v", *v))
 	}
+	builder.WriteString(", ")
+	builder.WriteString("stage_type=")
+	builder.WriteString(fmt.Sprintf("%v", _m.StageType))
 	builder.WriteString(", ")
 	builder.WriteString("status=")
 	builder.WriteString(fmt.Sprintf("%v", _m.Status))

--- a/ent/stage/stage.go
+++ b/ent/stage/stage.go
@@ -26,6 +26,8 @@ const (
 	FieldParallelType = "parallel_type"
 	// FieldSuccessPolicy holds the string denoting the success_policy field in the database.
 	FieldSuccessPolicy = "success_policy"
+	// FieldStageType holds the string denoting the stage_type field in the database.
+	FieldStageType = "stage_type"
 	// FieldStatus holds the string denoting the status field in the database.
 	FieldStatus = "status"
 	// FieldStartedAt holds the string denoting the started_at field in the database.
@@ -141,6 +143,7 @@ var Columns = []string{
 	FieldExpectedAgentCount,
 	FieldParallelType,
 	FieldSuccessPolicy,
+	FieldStageType,
 	FieldStatus,
 	FieldStartedAt,
 	FieldCompletedAt,
@@ -203,6 +206,35 @@ func SuccessPolicyValidator(sp SuccessPolicy) error {
 		return nil
 	default:
 		return fmt.Errorf("stage: invalid enum value for success_policy field: %q", sp)
+	}
+}
+
+// StageType defines the type for the "stage_type" enum field.
+type StageType string
+
+// StageTypeInvestigation is the default value of the StageType enum.
+const DefaultStageType = StageTypeInvestigation
+
+// StageType values.
+const (
+	StageTypeInvestigation StageType = "investigation"
+	StageTypeSynthesis     StageType = "synthesis"
+	StageTypeChat          StageType = "chat"
+	StageTypeExecSummary   StageType = "exec_summary"
+	StageTypeScoring       StageType = "scoring"
+)
+
+func (st StageType) String() string {
+	return string(st)
+}
+
+// StageTypeValidator is a validator for the "stage_type" field enum values. It is called by the builders before save.
+func StageTypeValidator(st StageType) error {
+	switch st {
+	case StageTypeInvestigation, StageTypeSynthesis, StageTypeChat, StageTypeExecSummary, StageTypeScoring:
+		return nil
+	default:
+		return fmt.Errorf("stage: invalid enum value for stage_type field: %q", st)
 	}
 }
 
@@ -272,6 +304,11 @@ func ByParallelType(opts ...sql.OrderTermOption) OrderOption {
 // BySuccessPolicy orders the results by the success_policy field.
 func BySuccessPolicy(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldSuccessPolicy, opts...).ToFunc()
+}
+
+// ByStageType orders the results by the stage_type field.
+func ByStageType(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldStageType, opts...).ToFunc()
 }
 
 // ByStatus orders the results by the status field.

--- a/ent/stage/where.go
+++ b/ent/stage/where.go
@@ -385,6 +385,26 @@ func SuccessPolicyNotNil() predicate.Stage {
 	return predicate.Stage(sql.FieldNotNull(FieldSuccessPolicy))
 }
 
+// StageTypeEQ applies the EQ predicate on the "stage_type" field.
+func StageTypeEQ(v StageType) predicate.Stage {
+	return predicate.Stage(sql.FieldEQ(FieldStageType, v))
+}
+
+// StageTypeNEQ applies the NEQ predicate on the "stage_type" field.
+func StageTypeNEQ(v StageType) predicate.Stage {
+	return predicate.Stage(sql.FieldNEQ(FieldStageType, v))
+}
+
+// StageTypeIn applies the In predicate on the "stage_type" field.
+func StageTypeIn(vs ...StageType) predicate.Stage {
+	return predicate.Stage(sql.FieldIn(FieldStageType, vs...))
+}
+
+// StageTypeNotIn applies the NotIn predicate on the "stage_type" field.
+func StageTypeNotIn(vs ...StageType) predicate.Stage {
+	return predicate.Stage(sql.FieldNotIn(FieldStageType, vs...))
+}
+
 // StatusEQ applies the EQ predicate on the "status" field.
 func StatusEQ(v Status) predicate.Stage {
 	return predicate.Stage(sql.FieldEQ(FieldStatus, v))

--- a/ent/stage_create.go
+++ b/ent/stage_create.go
@@ -80,6 +80,20 @@ func (_c *StageCreate) SetNillableSuccessPolicy(v *stage.SuccessPolicy) *StageCr
 	return _c
 }
 
+// SetStageType sets the "stage_type" field.
+func (_c *StageCreate) SetStageType(v stage.StageType) *StageCreate {
+	_c.mutation.SetStageType(v)
+	return _c
+}
+
+// SetNillableStageType sets the "stage_type" field if the given value is not nil.
+func (_c *StageCreate) SetNillableStageType(v *stage.StageType) *StageCreate {
+	if v != nil {
+		_c.SetStageType(*v)
+	}
+	return _c
+}
+
 // SetStatus sets the "status" field.
 func (_c *StageCreate) SetStatus(v stage.Status) *StageCreate {
 	_c.mutation.SetStatus(v)
@@ -309,6 +323,10 @@ func (_c *StageCreate) ExecX(ctx context.Context) {
 
 // defaults sets the default values of the builder before save.
 func (_c *StageCreate) defaults() {
+	if _, ok := _c.mutation.StageType(); !ok {
+		v := stage.DefaultStageType
+		_c.mutation.SetStageType(v)
+	}
 	if _, ok := _c.mutation.Status(); !ok {
 		v := stage.DefaultStatus
 		_c.mutation.SetStatus(v)
@@ -337,6 +355,14 @@ func (_c *StageCreate) check() error {
 	if v, ok := _c.mutation.SuccessPolicy(); ok {
 		if err := stage.SuccessPolicyValidator(v); err != nil {
 			return &ValidationError{Name: "success_policy", err: fmt.Errorf(`ent: validator failed for field "Stage.success_policy": %w`, err)}
+		}
+	}
+	if _, ok := _c.mutation.StageType(); !ok {
+		return &ValidationError{Name: "stage_type", err: errors.New(`ent: missing required field "Stage.stage_type"`)}
+	}
+	if v, ok := _c.mutation.StageType(); ok {
+		if err := stage.StageTypeValidator(v); err != nil {
+			return &ValidationError{Name: "stage_type", err: fmt.Errorf(`ent: validator failed for field "Stage.stage_type": %w`, err)}
 		}
 	}
 	if _, ok := _c.mutation.Status(); !ok {
@@ -404,6 +430,10 @@ func (_c *StageCreate) createSpec() (*Stage, *sqlgraph.CreateSpec) {
 	if value, ok := _c.mutation.SuccessPolicy(); ok {
 		_spec.SetField(stage.FieldSuccessPolicy, field.TypeEnum, value)
 		_node.SuccessPolicy = &value
+	}
+	if value, ok := _c.mutation.StageType(); ok {
+		_spec.SetField(stage.FieldStageType, field.TypeEnum, value)
+		_node.StageType = value
 	}
 	if value, ok := _c.mutation.Status(); ok {
 		_spec.SetField(stage.FieldStatus, field.TypeEnum, value)

--- a/ent/stage_update.go
+++ b/ent/stage_update.go
@@ -132,6 +132,20 @@ func (_u *StageUpdate) ClearSuccessPolicy() *StageUpdate {
 	return _u
 }
 
+// SetStageType sets the "stage_type" field.
+func (_u *StageUpdate) SetStageType(v stage.StageType) *StageUpdate {
+	_u.mutation.SetStageType(v)
+	return _u
+}
+
+// SetNillableStageType sets the "stage_type" field if the given value is not nil.
+func (_u *StageUpdate) SetNillableStageType(v *stage.StageType) *StageUpdate {
+	if v != nil {
+		_u.SetStageType(*v)
+	}
+	return _u
+}
+
 // SetStatus sets the "status" field.
 func (_u *StageUpdate) SetStatus(v stage.Status) *StageUpdate {
 	_u.mutation.SetStatus(v)
@@ -519,6 +533,11 @@ func (_u *StageUpdate) check() error {
 			return &ValidationError{Name: "success_policy", err: fmt.Errorf(`ent: validator failed for field "Stage.success_policy": %w`, err)}
 		}
 	}
+	if v, ok := _u.mutation.StageType(); ok {
+		if err := stage.StageTypeValidator(v); err != nil {
+			return &ValidationError{Name: "stage_type", err: fmt.Errorf(`ent: validator failed for field "Stage.stage_type": %w`, err)}
+		}
+	}
 	if v, ok := _u.mutation.Status(); ok {
 		if err := stage.StatusValidator(v); err != nil {
 			return &ValidationError{Name: "status", err: fmt.Errorf(`ent: validator failed for field "Stage.status": %w`, err)}
@@ -574,6 +593,9 @@ func (_u *StageUpdate) sqlSave(ctx context.Context) (_node int, err error) {
 	}
 	if _u.mutation.SuccessPolicyCleared() {
 		_spec.ClearField(stage.FieldSuccessPolicy, field.TypeEnum)
+	}
+	if value, ok := _u.mutation.StageType(); ok {
+		_spec.SetField(stage.FieldStageType, field.TypeEnum, value)
 	}
 	if value, ok := _u.mutation.Status(); ok {
 		_spec.SetField(stage.FieldStatus, field.TypeEnum, value)
@@ -1006,6 +1028,20 @@ func (_u *StageUpdateOne) ClearSuccessPolicy() *StageUpdateOne {
 	return _u
 }
 
+// SetStageType sets the "stage_type" field.
+func (_u *StageUpdateOne) SetStageType(v stage.StageType) *StageUpdateOne {
+	_u.mutation.SetStageType(v)
+	return _u
+}
+
+// SetNillableStageType sets the "stage_type" field if the given value is not nil.
+func (_u *StageUpdateOne) SetNillableStageType(v *stage.StageType) *StageUpdateOne {
+	if v != nil {
+		_u.SetStageType(*v)
+	}
+	return _u
+}
+
 // SetStatus sets the "status" field.
 func (_u *StageUpdateOne) SetStatus(v stage.Status) *StageUpdateOne {
 	_u.mutation.SetStatus(v)
@@ -1406,6 +1442,11 @@ func (_u *StageUpdateOne) check() error {
 			return &ValidationError{Name: "success_policy", err: fmt.Errorf(`ent: validator failed for field "Stage.success_policy": %w`, err)}
 		}
 	}
+	if v, ok := _u.mutation.StageType(); ok {
+		if err := stage.StageTypeValidator(v); err != nil {
+			return &ValidationError{Name: "stage_type", err: fmt.Errorf(`ent: validator failed for field "Stage.stage_type": %w`, err)}
+		}
+	}
 	if v, ok := _u.mutation.Status(); ok {
 		if err := stage.StatusValidator(v); err != nil {
 			return &ValidationError{Name: "status", err: fmt.Errorf(`ent: validator failed for field "Stage.status": %w`, err)}
@@ -1478,6 +1519,9 @@ func (_u *StageUpdateOne) sqlSave(ctx context.Context) (_node *Stage, err error)
 	}
 	if _u.mutation.SuccessPolicyCleared() {
 		_spec.ClearField(stage.FieldSuccessPolicy, field.TypeEnum)
+	}
+	if value, ok := _u.mutation.StageType(); ok {
+		_spec.SetField(stage.FieldStageType, field.TypeEnum, value)
 	}
 	if value, ok := _u.mutation.Status(); ok {
 		_spec.SetField(stage.FieldStatus, field.TypeEnum, value)

--- a/pkg/api/handler_trace.go
+++ b/pkg/api/handler_trace.go
@@ -139,6 +139,7 @@ func buildTraceListResponse(
 		sg := models.TraceStageGroup{
 			StageID:   stg.ID,
 			StageName: stg.StageName,
+			StageType: string(stg.StageType),
 		}
 
 		// Eager-loaded agent executions, sorted by agent_index for deterministic order.

--- a/pkg/api/handler_trace_test.go
+++ b/pkg/api/handler_trace_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/codeready-toolchain/tarsy/ent/mcpinteraction"
 	"github.com/codeready-toolchain/tarsy/ent/message"
 	"github.com/codeready-toolchain/tarsy/ent/schema"
+	"github.com/codeready-toolchain/tarsy/ent/stage"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -28,6 +29,7 @@ func TestBuildTraceListResponse_StageWithNoInteractions(t *testing.T) {
 		{
 			ID:        "stg-1",
 			StageName: "investigation",
+			StageType: stage.StageTypeInvestigation,
 			Edges: ent.StageEdges{
 				AgentExecutions: []*ent.AgentExecution{
 					{ID: "exec-1", AgentName: "DataCollector", AgentIndex: 1},
@@ -40,6 +42,7 @@ func TestBuildTraceListResponse_StageWithNoInteractions(t *testing.T) {
 	require.Len(t, resp.Stages, 1)
 	assert.Equal(t, "stg-1", resp.Stages[0].StageID)
 	assert.Equal(t, "investigation", resp.Stages[0].StageName)
+	assert.Equal(t, "investigation", resp.Stages[0].StageType)
 	require.Len(t, resp.Stages[0].Executions, 1)
 	assert.Equal(t, "exec-1", resp.Stages[0].Executions[0].ExecutionID)
 	assert.Equal(t, "DataCollector", resp.Stages[0].Executions[0].AgentName)
@@ -57,6 +60,7 @@ func TestBuildTraceListResponse_GroupingAndSorting(t *testing.T) {
 		{
 			ID:        "stg-1",
 			StageName: "investigation",
+			StageType: stage.StageTypeInvestigation,
 			Edges: ent.StageEdges{
 				AgentExecutions: []*ent.AgentExecution{
 					{ID: "exec-1", AgentName: "Agent1", AgentIndex: 1},
@@ -66,6 +70,7 @@ func TestBuildTraceListResponse_GroupingAndSorting(t *testing.T) {
 		{
 			ID:        "stg-2",
 			StageName: "validation",
+			StageType: stage.StageTypeInvestigation,
 			Edges: ent.StageEdges{
 				// Deliberately out of order to verify sorting.
 				AgentExecutions: []*ent.AgentExecution{
@@ -131,7 +136,7 @@ func TestBuildTraceListResponse_SessionLevelInteractions(t *testing.T) {
 
 	stages := []*ent.Stage{
 		{
-			ID: "stg-1", StageName: "investigation",
+			ID: "stg-1", StageName: "investigation", StageType: stage.StageTypeInvestigation,
 			Edges: ent.StageEdges{
 				AgentExecutions: []*ent.AgentExecution{
 					{ID: "exec-1", AgentName: "Agent1", AgentIndex: 1},
@@ -165,6 +170,7 @@ func TestBuildTraceListResponse_StageWithNoExecutions(t *testing.T) {
 		{
 			ID:        "stg-1",
 			StageName: "empty-stage",
+			StageType: stage.StageTypeInvestigation,
 			// No AgentExecutions edge.
 		},
 	}
@@ -185,6 +191,7 @@ func TestBuildTraceListResponse_SubAgentNesting(t *testing.T) {
 		{
 			ID:        "stg-1",
 			StageName: "orchestrate",
+			StageType: stage.StageTypeInvestigation,
 			Edges: ent.StageEdges{
 				AgentExecutions: []*ent.AgentExecution{
 					{ID: "exec-orch", AgentName: "Orchestrator", AgentIndex: 1},

--- a/pkg/database/migrations/20260304214237_add_stage_type.up.sql
+++ b/pkg/database/migrations/20260304214237_add_stage_type.up.sql
@@ -1,0 +1,14 @@
+-- drop index "agentexecution_parent_execution_id_agent_index_sub_agent" from table: "agent_executions"
+DROP INDEX "public"."agentexecution_parent_execution_id_agent_index_sub_agent";
+-- drop index "agentexecution_stage_id_agent_index_top_level" from table: "agent_executions"
+DROP INDEX "public"."agentexecution_stage_id_agent_index_top_level";
+-- drop index "sessionscore_session_id" from table: "session_scores"
+DROP INDEX "public"."sessionscore_session_id";
+-- create index "sessionscore_session_id" to table: "session_scores"
+CREATE UNIQUE INDEX "sessionscore_session_id" ON "public"."session_scores" ("session_id") WHERE ((status)::text = ANY ((ARRAY['pending'::character varying, 'in_progress'::character varying])::text[]));
+-- modify "stages" table
+ALTER TABLE "public"."stages" ADD COLUMN "stage_type" character varying NOT NULL DEFAULT 'investigation';
+-- Backfill synthesis stages (identified by name suffix)
+UPDATE stages SET stage_type = 'synthesis' WHERE stage_name LIKE '% - Synthesis';
+-- Backfill chat stages (identified by non-null chat_id)
+UPDATE stages SET stage_type = 'chat' WHERE chat_id IS NOT NULL;

--- a/pkg/database/migrations/20260304214237_add_stage_type.up.sql
+++ b/pkg/database/migrations/20260304214237_add_stage_type.up.sql
@@ -1,7 +1,3 @@
--- drop index "agentexecution_parent_execution_id_agent_index_sub_agent" from table: "agent_executions"
-DROP INDEX "public"."agentexecution_parent_execution_id_agent_index_sub_agent";
--- drop index "agentexecution_stage_id_agent_index_top_level" from table: "agent_executions"
-DROP INDEX "public"."agentexecution_stage_id_agent_index_top_level";
 -- drop index "sessionscore_session_id" from table: "session_scores"
 DROP INDEX "public"."sessionscore_session_id";
 -- create index "sessionscore_session_id" to table: "session_scores"

--- a/pkg/database/migrations/atlas.sum
+++ b/pkg/database/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:Bh8d2qwUeNnqLZ/1fBbLYO2t46ax0GX0xAIeIWvU/Ns=
+h1:Yf8xqSl+/Fiiwd9WKZh+QO9pilBzafTOP1fbZZvqeuU=
 20260209015211_initial_schema.up.sql h1:BNZPcBZlJWvzJPXR63PmUeO5O6j4T/Hh+LpKyHT2Sxw=
 20260211041222_optional_stage_execution_on_timeline.up.sql h1:+h7vYATBxceFqqGwjYSCfcnQDJ+QicHkSWG/rSprdtU=
 20260214053406_add_llm_provider_to_agent_executions.up.sql h1:jLGeQixypPjJnbC0StmO5X7sovplIl9FxHjAi8NKlA4=
@@ -8,4 +8,4 @@ h1:Bh8d2qwUeNnqLZ/1fBbLYO2t46ax0GX0xAIeIWvU/Ns=
 20260226223249_add_parent_execution_id_to_timeline_events.up.sql h1:Iek6XoKGCPLppeAJEnbybLPMLJ90lThDOcicCYgE8Cg=
 20260304000000_add_fallback_fields.up.sql h1:sBQcMdjvYOidROCrm+yeRbFE+MCJoXYJLKgmcdsSAQQ=
 20260304100000_add_mcp_session_id_index.up.sql h1:8BB62JLlxaaYorxQWTS9u8Aj0jlKJyAfDePaueEY3Vo=
-20260304214237_add_stage_type.up.sql h1:vQn2pCufgpnf/cO5ojyiZEcV2WVvzKzFRzVCxgKd5oQ=
+20260304214237_add_stage_type.up.sql h1:BMIY5E8IzY1EAGqqjQ0Ok83VyLAzlXwpsVA14Bh4+kA=

--- a/pkg/database/migrations/atlas.sum
+++ b/pkg/database/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:KLX4KEwMC+QAzWNCypTjaxgOuFwZAABI4cRNK4m/sAc=
+h1:Bh8d2qwUeNnqLZ/1fBbLYO2t46ax0GX0xAIeIWvU/Ns=
 20260209015211_initial_schema.up.sql h1:BNZPcBZlJWvzJPXR63PmUeO5O6j4T/Hh+LpKyHT2Sxw=
 20260211041222_optional_stage_execution_on_timeline.up.sql h1:+h7vYATBxceFqqGwjYSCfcnQDJ+QicHkSWG/rSprdtU=
 20260214053406_add_llm_provider_to_agent_executions.up.sql h1:jLGeQixypPjJnbC0StmO5X7sovplIl9FxHjAi8NKlA4=
@@ -7,3 +7,5 @@ h1:KLX4KEwMC+QAzWNCypTjaxgOuFwZAABI4cRNK4m/sAc=
 20260225235224_add_orchestrator_sub_agent_fields.up.sql h1:nxWAfQl80guRRMA/OcUUjtRd1FMNFssESzoPR7dhhiw=
 20260226223249_add_parent_execution_id_to_timeline_events.up.sql h1:Iek6XoKGCPLppeAJEnbybLPMLJ90lThDOcicCYgE8Cg=
 20260304000000_add_fallback_fields.up.sql h1:sBQcMdjvYOidROCrm+yeRbFE+MCJoXYJLKgmcdsSAQQ=
+20260304100000_add_mcp_session_id_index.up.sql h1:8BB62JLlxaaYorxQWTS9u8Aj0jlKJyAfDePaueEY3Vo=
+20260304214237_add_stage_type.up.sql h1:vQn2pCufgpnf/cO5ojyiZEcV2WVvzKzFRzVCxgKd5oQ=

--- a/pkg/events/payloads.go
+++ b/pkg/events/payloads.go
@@ -67,6 +67,7 @@ type StageStatusPayload struct {
 	StageID    string `json:"stage_id,omitempty"` // may be empty on "started" if stage creation hasn't happened yet
 	StageName  string `json:"stage_name"`         // human-readable stage name from config
 	StageIndex int    `json:"stage_index"`        // 1-based
+	StageType  string `json:"stage_type"`         // investigation, synthesis, chat
 	Status     string `json:"status"`             // started, completed, failed, timed_out, cancelled
 }
 

--- a/pkg/models/interaction.go
+++ b/pkg/models/interaction.go
@@ -48,6 +48,7 @@ type TraceListResponse struct {
 type TraceStageGroup struct {
 	StageID    string                `json:"stage_id"`
 	StageName  string                `json:"stage_name"`
+	StageType  string                `json:"stage_type"`
 	Executions []TraceExecutionGroup `json:"executions"`
 }
 

--- a/pkg/models/session.go
+++ b/pkg/models/session.go
@@ -185,6 +185,7 @@ type StageOverview struct {
 	ID                 string              `json:"id"`
 	StageName          string              `json:"stage_name"`
 	StageIndex         int                 `json:"stage_index"`
+	StageType          string              `json:"stage_type"`
 	Status             string              `json:"status"`
 	ParallelType       *string             `json:"parallel_type"`
 	ExpectedAgentCount int                 `json:"expected_agent_count"`

--- a/pkg/models/stage.go
+++ b/pkg/models/stage.go
@@ -13,6 +13,7 @@ type CreateStageRequest struct {
 	ExpectedAgentCount int     `json:"expected_agent_count"`
 	ParallelType       *string `json:"parallel_type,omitempty"`  // "multi_agent" or "replica"
 	SuccessPolicy      *string `json:"success_policy,omitempty"` // "all" or "any"
+	StageType          string  `json:"stage_type,omitempty"`     // defaults to "investigation" if empty
 	ChatID             *string `json:"chat_id,omitempty"`
 	ChatUserMessageID  *string `json:"chat_user_message_id,omitempty"`
 }

--- a/pkg/queue/chat_executor.go
+++ b/pkg/queue/chat_executor.go
@@ -445,7 +445,7 @@ func (e *ChatMessageExecutor) buildChatContext(ctx context.Context, input ChatEx
 			parentName := strings.TrimSuffix(stg.StageName, " - Synthesis")
 			// Scan backwards to find the nearest parent investigation stage.
 			for j := i - 1; j >= 0; j-- {
-				if stages[j].StageName == parentName {
+				if stages[j].StageName == parentName && stages[j].StageType == stage.StageTypeInvestigation {
 					if fa := e.extractFinalAnalysis(ctx, stg); fa != "" {
 						synthResults[stages[j].ID] = fa
 					}
@@ -471,8 +471,10 @@ func (e *ChatMessageExecutor) buildChatContext(ctx context.Context, input ChatEx
 				}
 			}
 			continue
+		case stage.StageTypeInvestigation:
+			// Fall through to build per-agent timelines below.
 		default:
-			// Investigation stage — fall through to build per-agent timelines.
+			continue
 		}
 
 		// Investigation stage — build per-agent timelines.

--- a/pkg/queue/chat_executor.go
+++ b/pkg/queue/chat_executor.go
@@ -13,6 +13,7 @@ import (
 	"github.com/codeready-toolchain/tarsy/ent/agentexecution"
 	"github.com/codeready-toolchain/tarsy/ent/alertsession"
 	"github.com/codeready-toolchain/tarsy/ent/event"
+	"github.com/codeready-toolchain/tarsy/ent/stage"
 	"github.com/codeready-toolchain/tarsy/ent/timelineevent"
 	"github.com/codeready-toolchain/tarsy/pkg/agent"
 	agentctx "github.com/codeready-toolchain/tarsy/pkg/agent/context"
@@ -174,6 +175,7 @@ func (e *ChatMessageExecutor) Submit(ctx context.Context, input ChatExecuteInput
 		StageName:          "Chat Response",
 		StageIndex:         stageIndex,
 		ExpectedAgentCount: 1,
+		StageType:          string(stage.StageTypeChat),
 		ChatID:             &chatID,
 		ChatUserMessageID:  &messageID,
 	})
@@ -228,7 +230,7 @@ func (e *ChatMessageExecutor) execute(parentCtx context.Context, input ChatExecu
 	chain, err := e.cfg.GetChain(input.Chat.ChainID)
 	if err != nil {
 		logger.Error("Failed to resolve chain config", "error", err)
-		e.finishStage(stageID, input.Session.ID, "Chat Response", stageIndex, events.StageStatusFailed, err.Error())
+		e.finishStage(stageID, input.Session.ID, "Chat Response", stageIndex, stage.StageTypeChat, events.StageStatusFailed, err.Error())
 		return
 	}
 
@@ -242,7 +244,7 @@ func (e *ChatMessageExecutor) execute(parentCtx context.Context, input ChatExecu
 		logger.Error("Failed to resolve chat agent config", "error", err)
 		// Best-effort: create a failed AgentExecution for audit trail.
 		e.createFailedChatExecution(stageID, input.Session.ID, "chat", chatProviderName, err.Error(), logger)
-		e.finishStage(stageID, input.Session.ID, "Chat Response", stageIndex, events.StageStatusFailed, err.Error())
+		e.finishStage(stageID, input.Session.ID, "Chat Response", stageIndex, stage.StageTypeChat, events.StageStatusFailed, err.Error())
 		return
 	}
 
@@ -252,7 +254,7 @@ func (e *ChatMessageExecutor) execute(parentCtx context.Context, input ChatExecu
 		logger.Error("Failed to resolve MCP selection", "error", err)
 		// Best-effort: create a failed AgentExecution for audit trail.
 		e.createFailedChatExecution(stageID, input.Session.ID, resolvedConfig.AgentName, chatProviderName, err.Error(), logger)
-		e.finishStage(stageID, input.Session.ID, "Chat Response", stageIndex, events.StageStatusFailed, err.Error())
+		e.finishStage(stageID, input.Session.ID, "Chat Response", stageIndex, stage.StageTypeChat, events.StageStatusFailed, err.Error())
 		return
 	}
 
@@ -267,7 +269,7 @@ func (e *ChatMessageExecutor) execute(parentCtx context.Context, input ChatExecu
 	})
 	if err != nil {
 		logger.Error("Failed to create agent execution", "error", err)
-		e.finishStage(stageID, input.Session.ID, "Chat Response", stageIndex, events.StageStatusFailed, err.Error())
+		e.finishStage(stageID, input.Session.ID, "Chat Response", stageIndex, stage.StageTypeChat, events.StageStatusFailed, err.Error())
 		return
 	}
 
@@ -318,7 +320,7 @@ func (e *ChatMessageExecutor) execute(parentCtx context.Context, input ChatExecu
 		logger.Warn("Failed to update agent execution to active", "error", updateErr)
 	}
 	publishExecutionStatus(execCtx, e.eventPublisher, input.Session.ID, stageID, exec.ID, 1, string(agentexecution.StatusActive), "")
-	publishStageStatus(execCtx, e.eventPublisher, input.Session.ID, stageID, "Chat Response", stageIndex, events.StageStatusStarted)
+	publishStageStatus(execCtx, e.eventPublisher, input.Session.ID, stageID, "Chat Response", stageIndex, stage.StageTypeChat, events.StageStatusStarted)
 
 	heartbeatCtx, cancelHeartbeat := context.WithCancel(execCtx)
 	defer cancelHeartbeat()
@@ -361,7 +363,7 @@ func (e *ChatMessageExecutor) execute(parentCtx context.Context, input ChatExecu
 			logger.Error("Failed to update agent execution status", "error", updateErr)
 		}
 		publishExecutionStatus(execCtx, e.eventPublisher, input.Session.ID, stageID, exec.ID, 1, string(agentexecution.StatusFailed), err.Error())
-		e.finishStage(stageID, input.Session.ID, "Chat Response", stageIndex, events.StageStatusFailed, err.Error())
+		e.finishStage(stageID, input.Session.ID, "Chat Response", stageIndex, stage.StageTypeChat, events.StageStatusFailed, err.Error())
 		return
 	}
 
@@ -401,7 +403,7 @@ func (e *ChatMessageExecutor) execute(parentCtx context.Context, input ChatExecu
 	}
 
 	// 14. Publish stage.status: completed/failed/cancelled/timed_out
-	publishStageStatus(context.Background(), e.eventPublisher, input.Session.ID, stageID, "Chat Response", stageIndex, terminalStatus)
+	publishStageStatus(context.Background(), e.eventPublisher, input.Session.ID, stageID, "Chat Response", stageIndex, stage.StageTypeChat, terminalStatus)
 
 	// 15. Stop heartbeat
 	cancelHeartbeat()
@@ -431,15 +433,15 @@ func (e *ChatMessageExecutor) buildChatContext(ctx context.Context, input ChatEx
 
 	// 2. Build structured stage investigations.
 	//    - Investigation stages → per-agent timelines
-	//    - Synthesis stages (name ends with " - Synthesis") → paired with parent
-	//    - Chat stages (have chat_id) → treated as previous chat Q&A
+	//    - Synthesis stages (stage_type = synthesis) → paired with parent
+	//    - Chat stages (stage_type = chat) → treated as previous chat Q&A
 	//    Synthesis results are keyed by parent stage ID for pairing.
 	//    Since stages are ordered by StageIndex, each synthesis stage is paired
 	//    with the closest preceding investigation stage whose name matches.
 	//    This avoids collisions when multiple stages share the same name.
 	synthResults := make(map[string]string) // parent stage ID → synthesis final analysis
 	for i, stg := range stages {
-		if strings.HasSuffix(stg.StageName, " - Synthesis") {
+		if stg.StageType == stage.StageTypeSynthesis {
 			parentName := strings.TrimSuffix(stg.StageName, " - Synthesis")
 			// Scan backwards to find the nearest parent investigation stage.
 			for j := i - 1; j >= 0; j-- {
@@ -458,13 +460,10 @@ func (e *ChatMessageExecutor) buildChatContext(ctx context.Context, input ChatEx
 	var executiveSummary string
 
 	for _, stg := range stages {
-		// Skip synthesis stages — already paired above.
-		if strings.HasSuffix(stg.StageName, " - Synthesis") {
+		switch stg.StageType {
+		case stage.StageTypeSynthesis:
 			continue
-		}
-
-		// Chat stages → collect as previous Q&A (skip the current chat's stage).
-		if stg.ChatID != nil && *stg.ChatID != "" {
+		case stage.StageTypeChat:
 			isCurrentChat := stg.ChatUserMessageID != nil && *stg.ChatUserMessageID == input.Message.ID
 			if !isCurrentChat {
 				if qa := e.buildChatQA(ctx, stg); qa.Question != "" {
@@ -472,6 +471,8 @@ func (e *ChatMessageExecutor) buildChatContext(ctx context.Context, input ChatEx
 				}
 			}
 			continue
+		default:
+			// Investigation stage — fall through to build per-agent timelines.
 		}
 
 		// Investigation stage — build per-agent timelines.
@@ -790,8 +791,8 @@ func (e *ChatMessageExecutor) createFailedChatExecution(
 // Used for early-exit error paths where no AgentExecution may exist yet.
 // Uses ForceStageFailure to directly set terminal status, bypassing the
 // execution-derived UpdateStageStatus which is a no-op without executions.
-func (e *ChatMessageExecutor) finishStage(stageID, sessionID, stageName string, stageIndex int, status, errMsg string) {
-	publishStageStatus(context.Background(), e.eventPublisher, sessionID, stageID, stageName, stageIndex, status)
+func (e *ChatMessageExecutor) finishStage(stageID, sessionID, stageName string, stageIndex int, stageType stage.StageType, status, errMsg string) {
+	publishStageStatus(context.Background(), e.eventPublisher, sessionID, stageID, stageName, stageIndex, stageType, status)
 	if updateErr := e.stageService.ForceStageFailure(context.Background(), stageID, errMsg); updateErr != nil {
 		slog.Warn("Failed to update stage status on early exit",
 			"stage_id", stageID,

--- a/pkg/queue/chat_executor_integration_test.go
+++ b/pkg/queue/chat_executor_integration_test.go
@@ -199,7 +199,9 @@ func TestChatExecutor_FirstMessage_ExecutesThroughAgentFramework(t *testing.T) {
 	require.GreaterOrEqual(t, len(publisher.stageStatuses), 2)
 	assert.Equal(t, events.StageStatusStarted, publisher.stageStatuses[0].Status)
 	assert.Equal(t, "Chat Response", publisher.stageStatuses[0].StageName)
+	assert.Equal(t, "chat", publisher.stageStatuses[0].StageType)
 	assert.Equal(t, events.StageStatusCompleted, publisher.stageStatuses[len(publisher.stageStatuses)-1].Status)
+	assert.Equal(t, "chat", publisher.stageStatuses[len(publisher.stageStatuses)-1].StageType)
 
 	// Verify user_question timeline event was published via WS (prod bug fix).
 	// Without the PublishTimelineCreated call in chat_executor, the dashboard

--- a/pkg/queue/chat_executor_test.go
+++ b/pkg/queue/chat_executor_test.go
@@ -287,6 +287,7 @@ func TestChatMessageExecutor_BuildChatContext_SynthesisPairingWithDuplicateStage
 		StageName:          "Analysis - Synthesis",
 		StageIndex:         1,
 		ExpectedAgentCount: 1,
+		StageType:          string(stage.StageTypeSynthesis),
 	})
 	require.NoError(t, err)
 
@@ -303,6 +304,7 @@ func TestChatMessageExecutor_BuildChatContext_SynthesisPairingWithDuplicateStage
 		StageName:          "Analysis - Synthesis",
 		StageIndex:         3,
 		ExpectedAgentCount: 1,
+		StageType:          string(stage.StageTypeSynthesis),
 	})
 	require.NoError(t, err)
 
@@ -428,6 +430,132 @@ func TestChatMessageExecutor_BuildChatContext_SynthesisPairingWithDuplicateStage
 	assert.Equal(t, "What happened?", result.UserQuestion)
 }
 
+func TestChatMessageExecutor_BuildChatContext_StageTypeRouting(t *testing.T) {
+	client := testdb.NewTestClient(t)
+	ctx := context.Background()
+
+	stageService := services.NewStageService(client.Client)
+	timelineService := services.NewTimelineService(client.Client)
+	chatService := services.NewChatService(client.Client)
+
+	session := createChatTestSession(t, client.Client)
+
+	// 1. Investigation stage with an agent execution and timeline event.
+	investStage, err := stageService.CreateStage(ctx, models.CreateStageRequest{
+		SessionID:          session.ID,
+		StageName:          "Analysis",
+		StageIndex:         0,
+		ExpectedAgentCount: 1,
+	})
+	require.NoError(t, err)
+
+	investExec, err := stageService.CreateAgentExecution(ctx, models.CreateAgentExecutionRequest{
+		StageID:    investStage.ID,
+		SessionID:  session.ID,
+		AgentName:  "agent-1",
+		AgentIndex: 1,
+		LLMBackend: config.LLMBackendLangChain,
+	})
+	require.NoError(t, err)
+
+	investStageID := investStage.ID
+	investExecID := investExec.ID
+	_, err = timelineService.CreateTimelineEvent(ctx, models.CreateTimelineEventRequest{
+		SessionID:      session.ID,
+		StageID:        &investStageID,
+		ExecutionID:    &investExecID,
+		SequenceNumber: 1,
+		EventType:      "llm_response",
+		Content:        "INVESTIGATION-FINDINGS",
+	})
+	require.NoError(t, err)
+
+	// 2. Single chat with two messages (unique constraint: one chat per session).
+	chat, err := chatService.CreateChat(ctx, models.CreateChatRequest{
+		SessionID: session.ID,
+		CreatedBy: "test@example.com",
+	})
+	require.NoError(t, err)
+
+	prevMsg, err := chatService.AddChatMessage(ctx, models.AddChatMessageRequest{
+		ChatID:  chat.ID,
+		Content: "Why did it crash?",
+		Author:  "test@example.com",
+	})
+	require.NoError(t, err)
+
+	// Previous chat stage — identified by StageType, not ChatID.
+	chatID := chat.ID
+	prevMsgID := prevMsg.ID
+	prevChatStage, err := stageService.CreateStage(ctx, models.CreateStageRequest{
+		SessionID:          session.ID,
+		StageName:          "Chat Response",
+		StageIndex:         1,
+		ExpectedAgentCount: 1,
+		StageType:          string(stage.StageTypeChat),
+		ChatID:             &chatID,
+		ChatUserMessageID:  &prevMsgID,
+	})
+	require.NoError(t, err)
+
+	prevChatExec, err := stageService.CreateAgentExecution(ctx, models.CreateAgentExecutionRequest{
+		StageID:    prevChatStage.ID,
+		SessionID:  session.ID,
+		AgentName:  "ChatAgent",
+		AgentIndex: 1,
+		LLMBackend: config.LLMBackendLangChain,
+	})
+	require.NoError(t, err)
+
+	prevChatStageID := prevChatStage.ID
+	prevChatExecID := prevChatExec.ID
+	_, err = timelineService.CreateTimelineEvent(ctx, models.CreateTimelineEventRequest{
+		SessionID:      session.ID,
+		StageID:        &prevChatStageID,
+		ExecutionID:    &prevChatExecID,
+		SequenceNumber: 1,
+		EventType:      "user_question",
+		Content:        "Why did it crash?",
+	})
+	require.NoError(t, err)
+	_, err = timelineService.CreateTimelineEvent(ctx, models.CreateTimelineEventRequest{
+		SessionID:      session.ID,
+		StageID:        &prevChatStageID,
+		ExecutionID:    &prevChatExecID,
+		SequenceNumber: 2,
+		EventType:      "final_analysis",
+		Content:        "It crashed due to OOM.",
+	})
+	require.NoError(t, err)
+
+	// 3. Current message — the one being answered now.
+	curMsg, err := chatService.AddChatMessage(ctx, models.AddChatMessageRequest{
+		ChatID:  chat.ID,
+		Content: "What should we do?",
+		Author:  "test@example.com",
+	})
+	require.NoError(t, err)
+
+	executor := &ChatMessageExecutor{
+		stageService:    stageService,
+		timelineService: timelineService,
+	}
+
+	result := executor.buildChatContext(ctx, ChatExecuteInput{
+		Chat:    chat,
+		Message: curMsg,
+		Session: session,
+	})
+
+	assert.Equal(t, "What should we do?", result.UserQuestion)
+	assert.Contains(t, result.InvestigationContext, "INVESTIGATION-FINDINGS",
+		"investigation stage should be included in context")
+	assert.Contains(t, result.InvestigationContext, "Why did it crash?",
+		"previous chat question should appear in context")
+	assert.Contains(t, result.InvestigationContext, "It crashed due to OOM.",
+		"previous chat answer should appear in context")
+}
+
 // ────────────────────────────────────────────────────────────
 // finishStage / createFailedChatExecution tests
 // ────────────────────────────────────────────────────────────
@@ -454,7 +582,7 @@ func TestChatMessageExecutor_FinishStage_MarksStageFailedWithoutExecutions(t *te
 		// eventPublisher is nil — publishStageStatus handles nil gracefully
 	}
 
-	executor.finishStage(stg.ID, session.ID, "Chat Response", 1, events.StageStatusFailed, "chain not found")
+	executor.finishStage(stg.ID, session.ID, "Chat Response", 1, stage.StageTypeChat, events.StageStatusFailed, "chain not found")
 
 	// Stage must be failed in DB (previously would stay pending)
 	updated, err := stageService.GetStageByID(ctx, stg.ID, false)

--- a/pkg/queue/chat_executor_test.go
+++ b/pkg/queue/chat_executor_test.go
@@ -279,6 +279,7 @@ func TestChatMessageExecutor_BuildChatContext_SynthesisPairingWithDuplicateStage
 		StageName:          "Analysis",
 		StageIndex:         0,
 		ExpectedAgentCount: 1,
+		StageType:          string(stage.StageTypeInvestigation),
 	})
 	require.NoError(t, err)
 
@@ -296,6 +297,7 @@ func TestChatMessageExecutor_BuildChatContext_SynthesisPairingWithDuplicateStage
 		StageName:          "Analysis",
 		StageIndex:         2,
 		ExpectedAgentCount: 1,
+		StageType:          string(stage.StageTypeInvestigation),
 	})
 	require.NoError(t, err)
 
@@ -446,6 +448,7 @@ func TestChatMessageExecutor_BuildChatContext_StageTypeRouting(t *testing.T) {
 		StageName:          "Analysis",
 		StageIndex:         0,
 		ExpectedAgentCount: 1,
+		StageType:          string(stage.StageTypeInvestigation),
 	})
 	require.NoError(t, err)
 
@@ -470,7 +473,38 @@ func TestChatMessageExecutor_BuildChatContext_StageTypeRouting(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// 2. Single chat with two messages (unique constraint: one chat per session).
+	// 2. Exec-summary stage — should be skipped by buildChatContext (default: continue).
+	execSummaryStage, err := stageService.CreateStage(ctx, models.CreateStageRequest{
+		SessionID:          session.ID,
+		StageName:          "Executive Summary",
+		StageIndex:         1,
+		ExpectedAgentCount: 1,
+		StageType:          string(stage.StageTypeExecSummary),
+	})
+	require.NoError(t, err)
+
+	execSumExec, err := stageService.CreateAgentExecution(ctx, models.CreateAgentExecutionRequest{
+		StageID:    execSummaryStage.ID,
+		SessionID:  session.ID,
+		AgentName:  "exec-summary-agent",
+		AgentIndex: 1,
+		LLMBackend: config.LLMBackendLangChain,
+	})
+	require.NoError(t, err)
+
+	execSumStageID := execSummaryStage.ID
+	execSumExecID := execSumExec.ID
+	_, err = timelineService.CreateTimelineEvent(ctx, models.CreateTimelineEventRequest{
+		SessionID:      session.ID,
+		StageID:        &execSumStageID,
+		ExecutionID:    &execSumExecID,
+		SequenceNumber: 1,
+		EventType:      "final_analysis",
+		Content:        "EXEC-SUMMARY-SHOULD-NOT-APPEAR",
+	})
+	require.NoError(t, err)
+
+	// 3. Single chat with two messages (unique constraint: one chat per session).
 	chat, err := chatService.CreateChat(ctx, models.CreateChatRequest{
 		SessionID: session.ID,
 		CreatedBy: "test@example.com",
@@ -490,7 +524,7 @@ func TestChatMessageExecutor_BuildChatContext_StageTypeRouting(t *testing.T) {
 	prevChatStage, err := stageService.CreateStage(ctx, models.CreateStageRequest{
 		SessionID:          session.ID,
 		StageName:          "Chat Response",
-		StageIndex:         1,
+		StageIndex:         2,
 		ExpectedAgentCount: 1,
 		StageType:          string(stage.StageTypeChat),
 		ChatID:             &chatID,
@@ -528,7 +562,7 @@ func TestChatMessageExecutor_BuildChatContext_StageTypeRouting(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// 3. Current message — the one being answered now.
+	// 4. Current message — the one being answered now.
 	curMsg, err := chatService.AddChatMessage(ctx, models.AddChatMessageRequest{
 		ChatID:  chat.ID,
 		Content: "What should we do?",
@@ -554,6 +588,8 @@ func TestChatMessageExecutor_BuildChatContext_StageTypeRouting(t *testing.T) {
 		"previous chat question should appear in context")
 	assert.Contains(t, result.InvestigationContext, "It crashed due to OOM.",
 		"previous chat answer should appear in context")
+	assert.NotContains(t, result.InvestigationContext, "EXEC-SUMMARY-SHOULD-NOT-APPEAR",
+		"exec_summary stage should be skipped by default branch")
 }
 
 // ────────────────────────────────────────────────────────────
@@ -573,13 +609,13 @@ func TestChatMessageExecutor_FinishStage_MarksStageFailedWithoutExecutions(t *te
 		StageName:          "Chat Response",
 		StageIndex:         1,
 		ExpectedAgentCount: 1,
+		StageType:          string(stage.StageTypeChat),
 	})
 	require.NoError(t, err)
 	assert.Equal(t, stage.StatusPending, stg.Status)
 
 	executor := &ChatMessageExecutor{
 		stageService: stageService,
-		// eventPublisher is nil — publishStageStatus handles nil gracefully
 	}
 
 	executor.finishStage(stg.ID, session.ID, "Chat Response", 1, stage.StageTypeChat, events.StageStatusFailed, "chain not found")
@@ -605,6 +641,7 @@ func TestChatMessageExecutor_CreateFailedChatExecution(t *testing.T) {
 		StageName:          "Chat Response",
 		StageIndex:         1,
 		ExpectedAgentCount: 1,
+		StageType:          string(stage.StageTypeChat),
 	})
 	require.NoError(t, err)
 

--- a/pkg/queue/executor.go
+++ b/pkg/queue/executor.go
@@ -89,6 +89,7 @@ func (e *RealSessionExecutor) resolveRunbook(ctx context.Context, session *ent.A
 type stageResult struct {
 	stageID       string
 	stageName     string
+	stageType     stage.StageType
 	status        alertsession.Status // mapped from agent status
 	finalAnalysis string
 	err           error
@@ -212,7 +213,7 @@ func (e *RealSessionExecutor) Execute(ctx context.Context, session *ent.AlertSes
 		})
 
 		// Publish stage terminal status (use background context — ctx may be cancelled)
-		publishStageStatus(context.Background(), e.eventPublisher, session.ID, sr.stageID, sr.stageName, dbStageIndex, stage.StageTypeInvestigation, mapTerminalStatus(sr))
+		publishStageStatus(context.Background(), e.eventPublisher, session.ID, sr.stageID, sr.stageName, dbStageIndex, sr.stageType, mapTerminalStatus(sr))
 		dbStageIndex++
 
 		// Fail-fast: if stage didn't complete, stop the chain
@@ -248,7 +249,7 @@ func (e *RealSessionExecutor) Execute(ctx context.Context, session *ent.AlertSes
 			}, sr)
 
 			// Publish synthesis stage terminal status (use background context — ctx may be cancelled)
-			publishStageStatus(context.Background(), e.eventPublisher, session.ID, synthSr.stageID, synthSr.stageName, dbStageIndex, stage.StageTypeSynthesis, mapTerminalStatus(synthSr))
+			publishStageStatus(context.Background(), e.eventPublisher, session.ID, synthSr.stageID, synthSr.stageName, dbStageIndex, synthSr.stageType, mapTerminalStatus(synthSr))
 			dbStageIndex++
 
 			if synthSr.status != alertsession.StatusCompleted {
@@ -360,7 +361,7 @@ func (e *RealSessionExecutor) executeStage(ctx context.Context, input executeSta
 
 	// 3. Update session progress + publish stage.status: started (stageID now available)
 	e.updateSessionProgress(ctx, input.session.ID, input.stageIndex, stg.ID)
-	publishStageStatus(ctx, e.eventPublisher, input.session.ID, stg.ID, input.stageConfig.Name, input.stageIndex, stage.StageTypeInvestigation, events.StageStatusStarted)
+	publishStageStatus(ctx, e.eventPublisher, input.session.ID, stg.ID, input.stageConfig.Name, input.stageIndex, stg.StageType, events.StageStatusStarted)
 	publishSessionProgress(ctx, e.eventPublisher, input.session.ID, input.stageConfig.Name,
 		input.stageIndex, input.totalExpectedStages, len(configs),
 		fmt.Sprintf("Starting stage: %s", input.stageConfig.Name))
@@ -403,6 +404,7 @@ func (e *RealSessionExecutor) executeStage(ctx context.Context, input executeSta
 	return stageResult{
 		stageID:       stg.ID,
 		stageName:     input.stageConfig.Name,
+		stageType:     stg.StageType,
 		status:        stageStatus,
 		finalAnalysis: finalAnalysis,
 		err:           aggregateError(agentResults, stageStatus, input.stageConfig),

--- a/pkg/queue/executor.go
+++ b/pkg/queue/executor.go
@@ -346,6 +346,7 @@ func (e *RealSessionExecutor) executeStage(ctx context.Context, input executeSta
 		ExpectedAgentCount: len(configs),
 		ParallelType:       parallelTypePtr(input.stageConfig),
 		SuccessPolicy:      successPolicyPtr(input.stageConfig, policy),
+		StageType:          string(stage.StageTypeInvestigation),
 	})
 	if err != nil {
 		if r := e.mapCancellation(ctx); r != nil {

--- a/pkg/queue/executor.go
+++ b/pkg/queue/executor.go
@@ -329,6 +329,7 @@ func (e *RealSessionExecutor) executeStage(ctx context.Context, input executeSta
 	if len(input.stageConfig.Agents) == 0 {
 		return stageResult{
 			stageName: input.stageConfig.Name,
+			stageType: stage.StageTypeInvestigation,
 			status:    alertsession.StatusFailed,
 			err:       fmt.Errorf("stage %q has no agents", input.stageConfig.Name),
 		}
@@ -350,11 +351,12 @@ func (e *RealSessionExecutor) executeStage(ctx context.Context, input executeSta
 	})
 	if err != nil {
 		if r := e.mapCancellation(ctx); r != nil {
-			return stageResult{stageName: input.stageConfig.Name, status: r.Status, err: r.Error}
+			return stageResult{stageName: input.stageConfig.Name, stageType: stage.StageTypeInvestigation, status: r.Status, err: r.Error}
 		}
 		logger.Error("Failed to create stage", "error", err)
 		return stageResult{
 			stageName: input.stageConfig.Name,
+			stageType: stage.StageTypeInvestigation,
 			status:    alertsession.StatusFailed,
 			err:       fmt.Errorf("failed to create stage: %w", err),
 		}

--- a/pkg/queue/executor.go
+++ b/pkg/queue/executor.go
@@ -9,6 +9,7 @@ import (
 	"github.com/codeready-toolchain/tarsy/ent"
 	"github.com/codeready-toolchain/tarsy/ent/agentexecution"
 	"github.com/codeready-toolchain/tarsy/ent/alertsession"
+	"github.com/codeready-toolchain/tarsy/ent/stage"
 	"github.com/codeready-toolchain/tarsy/pkg/agent"
 	"github.com/codeready-toolchain/tarsy/pkg/agent/controller"
 	"github.com/codeready-toolchain/tarsy/pkg/agent/orchestrator"
@@ -211,7 +212,7 @@ func (e *RealSessionExecutor) Execute(ctx context.Context, session *ent.AlertSes
 		})
 
 		// Publish stage terminal status (use background context — ctx may be cancelled)
-		publishStageStatus(context.Background(), e.eventPublisher, session.ID, sr.stageID, sr.stageName, dbStageIndex, mapTerminalStatus(sr))
+		publishStageStatus(context.Background(), e.eventPublisher, session.ID, sr.stageID, sr.stageName, dbStageIndex, stage.StageTypeInvestigation, mapTerminalStatus(sr))
 		dbStageIndex++
 
 		// Fail-fast: if stage didn't complete, stop the chain
@@ -247,7 +248,7 @@ func (e *RealSessionExecutor) Execute(ctx context.Context, session *ent.AlertSes
 			}, sr)
 
 			// Publish synthesis stage terminal status (use background context — ctx may be cancelled)
-			publishStageStatus(context.Background(), e.eventPublisher, session.ID, synthSr.stageID, synthSr.stageName, dbStageIndex, mapTerminalStatus(synthSr))
+			publishStageStatus(context.Background(), e.eventPublisher, session.ID, synthSr.stageID, synthSr.stageName, dbStageIndex, stage.StageTypeSynthesis, mapTerminalStatus(synthSr))
 			dbStageIndex++
 
 			if synthSr.status != alertsession.StatusCompleted {
@@ -359,7 +360,7 @@ func (e *RealSessionExecutor) executeStage(ctx context.Context, input executeSta
 
 	// 3. Update session progress + publish stage.status: started (stageID now available)
 	e.updateSessionProgress(ctx, input.session.ID, input.stageIndex, stg.ID)
-	publishStageStatus(ctx, e.eventPublisher, input.session.ID, stg.ID, input.stageConfig.Name, input.stageIndex, events.StageStatusStarted)
+	publishStageStatus(ctx, e.eventPublisher, input.session.ID, stg.ID, input.stageConfig.Name, input.stageIndex, stage.StageTypeInvestigation, events.StageStatusStarted)
 	publishSessionProgress(ctx, e.eventPublisher, input.session.ID, input.stageConfig.Name,
 		input.stageIndex, input.totalExpectedStages, len(configs),
 		fmt.Sprintf("Starting stage: %s", input.stageConfig.Name))

--- a/pkg/queue/executor_helpers.go
+++ b/pkg/queue/executor_helpers.go
@@ -11,6 +11,7 @@ import (
 	"github.com/codeready-toolchain/tarsy/ent"
 	"github.com/codeready-toolchain/tarsy/ent/agentexecution"
 	"github.com/codeready-toolchain/tarsy/ent/alertsession"
+	"github.com/codeready-toolchain/tarsy/ent/stage"
 	"github.com/codeready-toolchain/tarsy/pkg/agent"
 	agentctx "github.com/codeready-toolchain/tarsy/pkg/agent/context"
 	"github.com/codeready-toolchain/tarsy/pkg/agent/orchestrator"
@@ -227,7 +228,7 @@ func publishExecutionStatus(ctx context.Context, eventPublisher agent.EventPubli
 
 // publishStageStatus publishes a stage.status event. Nil-safe for EventPublisher.
 // Package-level function shared by RealSessionExecutor and ChatMessageExecutor.
-func publishStageStatus(ctx context.Context, eventPublisher agent.EventPublisher, sessionID, stageID, stageName string, stageIndex int, status string) {
+func publishStageStatus(ctx context.Context, eventPublisher agent.EventPublisher, sessionID, stageID, stageName string, stageIndex int, stageType stage.StageType, status string) {
 	if eventPublisher == nil {
 		return
 	}
@@ -240,6 +241,7 @@ func publishStageStatus(ctx context.Context, eventPublisher agent.EventPublisher
 		StageID:    stageID,
 		StageName:  stageName,
 		StageIndex: stageIndex + 1, // 1-based for clients
+		StageType:  string(stageType),
 		Status:     status,
 	}); err != nil {
 		slog.Warn("Failed to publish stage status",

--- a/pkg/queue/executor_integration_test.go
+++ b/pkg/queue/executor_integration_test.go
@@ -268,12 +268,15 @@ func TestExecutor_SingleStageChain(t *testing.T) {
 	assert.Equal(t, "investigation", stages[0].StageName)
 	assert.Equal(t, 1, stages[0].StageIndex)
 	assert.Equal(t, stage.StatusCompleted, stages[0].Status)
+	assert.Equal(t, stage.StageTypeInvestigation, stages[0].StageType)
 
 	// Verify stage events: started + completed
 	require.Len(t, publisher.stageStatuses, 2)
 	assert.Equal(t, events.StageStatusStarted, publisher.stageStatuses[0].Status)
 	assert.Equal(t, "investigation", publisher.stageStatuses[0].StageName)
+	assert.Equal(t, "investigation", publisher.stageStatuses[0].StageType)
 	assert.Equal(t, events.StageStatusCompleted, publisher.stageStatuses[1].Status)
+	assert.Equal(t, "investigation", publisher.stageStatuses[1].StageType)
 }
 
 func TestExecutor_MultiStageChain(t *testing.T) {
@@ -673,6 +676,7 @@ func TestExecutor_MultiAgentAllSucceed(t *testing.T) {
 
 	// Investigation stage
 	assert.Equal(t, "parallel-investigation", stages[0].StageName)
+	assert.Equal(t, stage.StageTypeInvestigation, stages[0].StageType)
 	assert.Equal(t, 2, stages[0].ExpectedAgentCount)
 	assert.NotNil(t, stages[0].ParallelType)
 	assert.Equal(t, stage.ParallelTypeMultiAgent, *stages[0].ParallelType)
@@ -680,6 +684,7 @@ func TestExecutor_MultiAgentAllSucceed(t *testing.T) {
 
 	// Synthesis stage
 	assert.Equal(t, "parallel-investigation - Synthesis", stages[1].StageName)
+	assert.Equal(t, stage.StageTypeSynthesis, stages[1].StageType)
 	assert.Equal(t, 1, stages[1].ExpectedAgentCount)
 	assert.Nil(t, stages[1].ParallelType)
 	assert.Equal(t, stage.StatusCompleted, stages[1].Status)
@@ -692,10 +697,14 @@ func TestExecutor_MultiAgentAllSucceed(t *testing.T) {
 	// Verify stage events: started+completed for investigation, started+completed for synthesis = 4
 	require.Len(t, publisher.stageStatuses, 4)
 	assert.Equal(t, "parallel-investigation", publisher.stageStatuses[0].StageName)
+	assert.Equal(t, "investigation", publisher.stageStatuses[0].StageType)
 	assert.Equal(t, events.StageStatusStarted, publisher.stageStatuses[0].Status)
+	assert.Equal(t, "investigation", publisher.stageStatuses[1].StageType)
 	assert.Equal(t, events.StageStatusCompleted, publisher.stageStatuses[1].Status)
 	assert.Equal(t, "parallel-investigation - Synthesis", publisher.stageStatuses[2].StageName)
+	assert.Equal(t, "synthesis", publisher.stageStatuses[2].StageType)
 	assert.Equal(t, events.StageStatusStarted, publisher.stageStatuses[2].Status)
+	assert.Equal(t, "synthesis", publisher.stageStatuses[3].StageType)
 	assert.Equal(t, events.StageStatusCompleted, publisher.stageStatuses[3].Status)
 
 	// Verify execution.status events: each agent emits active + terminal.

--- a/pkg/queue/executor_synthesis.go
+++ b/pkg/queue/executor_synthesis.go
@@ -41,6 +41,7 @@ func (e *RealSessionExecutor) executeSynthesisStage(
 	if r := e.mapCancellation(ctx); r != nil {
 		return stageResult{
 			stageName: synthStageName,
+			stageType: stage.StageTypeSynthesis,
 			status:    r.Status,
 			err:       r.Error,
 		}
@@ -56,11 +57,12 @@ func (e *RealSessionExecutor) executeSynthesisStage(
 	})
 	if err != nil {
 		if r := e.mapCancellation(ctx); r != nil {
-			return stageResult{stageName: synthStageName, status: r.Status, err: r.Error}
+			return stageResult{stageName: synthStageName, stageType: stage.StageTypeSynthesis, status: r.Status, err: r.Error}
 		}
 		logger.Error("Failed to create synthesis stage", "error", err)
 		return stageResult{
 			stageName: synthStageName,
+			stageType: stage.StageTypeSynthesis,
 			status:    alertsession.StatusFailed,
 			err:       fmt.Errorf("failed to create synthesis stage: %w", err),
 		}

--- a/pkg/queue/executor_synthesis.go
+++ b/pkg/queue/executor_synthesis.go
@@ -68,7 +68,7 @@ func (e *RealSessionExecutor) executeSynthesisStage(
 
 	// Update session progress + publish stage.status: started
 	e.updateSessionProgress(ctx, input.session.ID, input.stageIndex, stg.ID)
-	publishStageStatus(ctx, e.eventPublisher, input.session.ID, stg.ID, synthStageName, input.stageIndex, stage.StageTypeSynthesis, events.StageStatusStarted)
+	publishStageStatus(ctx, e.eventPublisher, input.session.ID, stg.ID, synthStageName, input.stageIndex, stg.StageType, events.StageStatusStarted)
 	publishSessionProgress(ctx, e.eventPublisher, input.session.ID, synthStageName,
 		input.stageIndex, input.totalExpectedStages, 1,
 		"Synthesizing...")
@@ -108,6 +108,7 @@ func (e *RealSessionExecutor) executeSynthesisStage(
 	return stageResult{
 		stageID:       stg.ID,
 		stageName:     synthStageName,
+		stageType:     stg.StageType,
 		status:        mapAgentStatusToSessionStatus(ar.status),
 		finalAnalysis: ar.finalAnalysis,
 		err:           ar.err,

--- a/pkg/queue/executor_synthesis.go
+++ b/pkg/queue/executor_synthesis.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/codeready-toolchain/tarsy/ent"
 	"github.com/codeready-toolchain/tarsy/ent/alertsession"
+	"github.com/codeready-toolchain/tarsy/ent/stage"
 	"github.com/codeready-toolchain/tarsy/ent/timelineevent"
 	"github.com/codeready-toolchain/tarsy/pkg/agent"
 	agentctx "github.com/codeready-toolchain/tarsy/pkg/agent/context"
@@ -51,7 +52,7 @@ func (e *RealSessionExecutor) executeSynthesisStage(
 		StageName:          synthStageName,
 		StageIndex:         input.stageIndex + 1, // 1-based in DB
 		ExpectedAgentCount: 1,
-		// No parallel_type, no success_policy (single-agent synthesis)
+		StageType:          string(stage.StageTypeSynthesis),
 	})
 	if err != nil {
 		if r := e.mapCancellation(ctx); r != nil {
@@ -67,7 +68,7 @@ func (e *RealSessionExecutor) executeSynthesisStage(
 
 	// Update session progress + publish stage.status: started
 	e.updateSessionProgress(ctx, input.session.ID, input.stageIndex, stg.ID)
-	publishStageStatus(ctx, e.eventPublisher, input.session.ID, stg.ID, synthStageName, input.stageIndex, events.StageStatusStarted)
+	publishStageStatus(ctx, e.eventPublisher, input.session.ID, stg.ID, synthStageName, input.stageIndex, stage.StageTypeSynthesis, events.StageStatusStarted)
 	publishSessionProgress(ctx, e.eventPublisher, input.session.ID, synthStageName,
 		input.stageIndex, input.totalExpectedStages, 1,
 		"Synthesizing...")

--- a/pkg/services/session_service.go
+++ b/pkg/services/session_service.go
@@ -517,6 +517,7 @@ func (s *SessionService) GetSessionDetail(ctx context.Context, sessionID string)
 			ID:                 stg.ID,
 			StageName:          stg.StageName,
 			StageIndex:         stg.StageIndex,
+			StageType:          string(stg.StageType),
 			Status:             string(stg.Status),
 			ParallelType:       pt,
 			ExpectedAgentCount: stg.ExpectedAgentCount,

--- a/pkg/services/session_service_test.go
+++ b/pkg/services/session_service_test.go
@@ -798,6 +798,7 @@ func TestSessionService_GetSessionDetail(t *testing.T) {
 		require.Len(t, detail.Stages, 1)
 		assert.Equal(t, "analysis", detail.Stages[0].StageName)
 		assert.Equal(t, 1, detail.Stages[0].StageIndex)
+		assert.Equal(t, "investigation", detail.Stages[0].StageType)
 		assert.Equal(t, "completed", detail.Stages[0].Status)
 		assert.Equal(t, 1, detail.Stages[0].ExpectedAgentCount)
 

--- a/pkg/services/stage_service.go
+++ b/pkg/services/stage_service.go
@@ -47,6 +47,14 @@ func (s *StageService) CreateStage(httpCtx context.Context, req models.CreateSta
 		}
 	}
 
+	stageType := stage.StageTypeInvestigation
+	if req.StageType != "" {
+		stageType = stage.StageType(req.StageType)
+		if err := stage.StageTypeValidator(stageType); err != nil {
+			return nil, NewValidationError("stage_type", fmt.Sprintf("invalid: %q", req.StageType))
+		}
+	}
+
 	// Use timeout context derived from incoming context
 	ctx, cancel := context.WithTimeout(httpCtx, 10*time.Second)
 	defer cancel()
@@ -58,6 +66,7 @@ func (s *StageService) CreateStage(httpCtx context.Context, req models.CreateSta
 		SetStageName(req.StageName).
 		SetStageIndex(req.StageIndex).
 		SetExpectedAgentCount(req.ExpectedAgentCount).
+		SetStageType(stageType).
 		SetStatus(stage.StatusPending)
 
 	if req.ParallelType != nil {

--- a/pkg/services/stage_service_test.go
+++ b/pkg/services/stage_service_test.go
@@ -50,6 +50,7 @@ func TestStageService_CreateStage(t *testing.T) {
 		assert.Equal(t, req.StageIndex, stg.StageIndex)
 		assert.Equal(t, req.ExpectedAgentCount, stg.ExpectedAgentCount)
 		assert.Equal(t, stage.StatusPending, stg.Status)
+		assert.Equal(t, stage.StageTypeInvestigation, stg.StageType)
 		assert.Equal(t, stage.ParallelTypeMultiAgent, *stg.ParallelType)
 		assert.Equal(t, stage.SuccessPolicyAll, *stg.SuccessPolicy)
 	})
@@ -111,6 +112,58 @@ func TestStageService_CreateStage(t *testing.T) {
 			_, err := stageService.CreateStage(ctx, req)
 			require.NoError(t, err)
 		}
+	})
+}
+
+func TestStageService_CreateStage_StageType(t *testing.T) {
+	client := testdb.NewTestClient(t)
+	stageService := NewStageService(client.Client)
+	sessionService := setupTestSessionService(t, client.Client)
+	ctx := context.Background()
+
+	session, err := sessionService.CreateSession(ctx, models.CreateSessionRequest{
+		SessionID: uuid.New().String(),
+		AlertData: "test",
+		AgentType: "kubernetes",
+		ChainID:   "k8s-analysis",
+	})
+	require.NoError(t, err)
+
+	t.Run("omitting StageType defaults to investigation", func(t *testing.T) {
+		stg, err := stageService.CreateStage(ctx, models.CreateStageRequest{
+			SessionID:          session.ID,
+			StageName:          "Default Type",
+			StageIndex:         100,
+			ExpectedAgentCount: 1,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, stage.StageTypeInvestigation, stg.StageType)
+	})
+
+	t.Run("explicit StageType persists correctly", func(t *testing.T) {
+		for i, st := range []string{"synthesis", "chat", "exec_summary", "scoring"} {
+			stg, err := stageService.CreateStage(ctx, models.CreateStageRequest{
+				SessionID:          session.ID,
+				StageName:          "Type " + st,
+				StageIndex:         101 + i,
+				ExpectedAgentCount: 1,
+				StageType:          st,
+			})
+			require.NoError(t, err)
+			assert.Equal(t, stage.StageType(st), stg.StageType)
+		}
+	})
+
+	t.Run("invalid StageType returns validation error", func(t *testing.T) {
+		_, err := stageService.CreateStage(ctx, models.CreateStageRequest{
+			SessionID:          session.ID,
+			StageName:          "Bad Type",
+			StageIndex:         200,
+			ExpectedAgentCount: 1,
+			StageType:          "bogus",
+		})
+		require.Error(t, err)
+		assert.True(t, IsValidationError(err))
 	})
 }
 

--- a/test/e2e/testdata/golden/orchestrator/session.golden
+++ b/test/e2e/testdata/golden/orchestrator/session.golden
@@ -68,6 +68,7 @@
       "parallel_type": null,
       "stage_index": 1,
       "stage_name": "orchestrate",
+      "stage_type": "investigation",
       "started_at": null,
       "status": "completed"
     }

--- a/test/e2e/testdata/golden/orchestrator/trace_list.golden
+++ b/test/e2e/testdata/golden/orchestrator/trace_list.golden
@@ -106,7 +106,8 @@
         }
       ],
       "stage_id": "{STAGE_ID_1}",
-      "stage_name": "orchestrate"
+      "stage_name": "orchestrate",
+      "stage_type": "investigation"
     }
   ]
 }

--- a/test/e2e/testdata/golden/pipeline/session.golden
+++ b/test/e2e/testdata/golden/pipeline/session.golden
@@ -49,6 +49,7 @@
       "parallel_type": null,
       "stage_index": 1,
       "stage_name": "investigation",
+      "stage_type": "investigation",
       "started_at": null,
       "status": "completed"
     },
@@ -76,6 +77,7 @@
       "parallel_type": null,
       "stage_index": 2,
       "stage_name": "remediation",
+      "stage_type": "investigation",
       "started_at": null,
       "status": "completed"
     },
@@ -118,6 +120,7 @@
       "parallel_type": "multi_agent",
       "stage_index": 3,
       "stage_name": "validation",
+      "stage_type": "investigation",
       "started_at": null,
       "status": "completed"
     },
@@ -145,6 +148,7 @@
       "parallel_type": null,
       "stage_index": 4,
       "stage_name": "validation - Synthesis",
+      "stage_type": "synthesis",
       "started_at": null,
       "status": "completed"
     },
@@ -187,6 +191,7 @@
       "parallel_type": "replica",
       "stage_index": 5,
       "stage_name": "scaling-review",
+      "stage_type": "investigation",
       "started_at": null,
       "status": "completed"
     },
@@ -214,6 +219,7 @@
       "parallel_type": null,
       "stage_index": 6,
       "stage_name": "scaling-review - Synthesis",
+      "stage_type": "synthesis",
       "started_at": null,
       "status": "completed"
     },
@@ -241,6 +247,7 @@
       "parallel_type": null,
       "stage_index": 7,
       "stage_name": "Chat Response",
+      "stage_type": "chat",
       "started_at": null,
       "status": "completed"
     },
@@ -268,6 +275,7 @@
       "parallel_type": null,
       "stage_index": 8,
       "stage_name": "Chat Response",
+      "stage_type": "chat",
       "started_at": null,
       "status": "completed"
     }

--- a/test/e2e/testdata/golden/pipeline/trace_list.golden
+++ b/test/e2e/testdata/golden/pipeline/trace_list.golden
@@ -100,7 +100,8 @@
         }
       ],
       "stage_id": "{STAGE_ID_1}",
-      "stage_name": "investigation"
+      "stage_name": "investigation",
+      "stage_type": "investigation"
     },
     {
       "executions": [
@@ -182,7 +183,8 @@
         }
       ],
       "stage_id": "{STAGE_ID_2}",
-      "stage_name": "remediation"
+      "stage_name": "remediation",
+      "stage_type": "investigation"
     },
     {
       "executions": [
@@ -272,7 +274,8 @@
         }
       ],
       "stage_id": "{STAGE_ID_3}",
-      "stage_name": "validation"
+      "stage_name": "validation",
+      "stage_type": "investigation"
     },
     {
       "executions": [
@@ -295,7 +298,8 @@
         }
       ],
       "stage_id": "{STAGE_ID_4}",
-      "stage_name": "validation - Synthesis"
+      "stage_name": "validation - Synthesis",
+      "stage_type": "synthesis"
     },
     {
       "executions": [
@@ -349,7 +353,8 @@
         }
       ],
       "stage_id": "{STAGE_ID_5}",
-      "stage_name": "scaling-review"
+      "stage_name": "scaling-review",
+      "stage_type": "investigation"
     },
     {
       "executions": [
@@ -372,7 +377,8 @@
         }
       ],
       "stage_id": "{STAGE_ID_6}",
-      "stage_name": "scaling-review - Synthesis"
+      "stage_name": "scaling-review - Synthesis",
+      "stage_type": "synthesis"
     },
     {
       "executions": [
@@ -436,7 +442,8 @@
         }
       ],
       "stage_id": "{STAGE_ID_7}",
-      "stage_name": "Chat Response"
+      "stage_name": "Chat Response",
+      "stage_type": "chat"
     },
     {
       "executions": [
@@ -490,7 +497,8 @@
         }
       ],
       "stage_id": "{STAGE_ID_8}",
-      "stage_name": "Chat Response"
+      "stage_name": "Chat Response",
+      "stage_type": "chat"
     }
   ]
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced explicit stage types (investigation, synthesis, chat, exec_summary, scoring) surfaced in APIs, WebSocket events, traces, and session payloads. Stage creation accepts stage_type (defaults to investigation); existing stages are backfilled. Exec_summary now executes as a typed stage within the standard stage flow.

* **Documentation**
  * Added a Go type-safety guide covering named types, typed constants, serialization boundaries, parsing/validation helpers, and usage guidance.

* **Tests**
  * Extended unit, integration, and golden tests to validate stage_type propagation, event payloads, and exec_summary behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->