### PR TITLE
LLM provider configuration for scoring agent

### DIFF
--- a/deploy/config/tarsy.yaml.example
+++ b/deploy/config/tarsy.yaml.example
@@ -105,12 +105,13 @@ defaults:
   #   - provider: "anthropic-vertex"
   #     backend: "langchain"
   
-  # Default scoring agent name (fallback when chain has no scoring config)
-  scoring_agent: "ScoringAgent"
-
-  # Enable scoring by default for all chains.
+  # Default scoring configuration for all chains.
   # Chains with an explicit scoring: block are not affected.
-  # scoring_enabled: true
+  # scoring:
+  #   enabled: true                       # Enable scoring for all chains by default
+  #   agent: "ScoringAgent"               # Default scoring agent name
+  #   llm_provider: "gemini-3-flash"      # Default LLM provider for scoring
+  #   llm_backend: "google-native"        # Default LLM backend for scoring
   
   # Default alert type for new sessions (used in UI dropdown)
   alert_type: "kubernetes"

--- a/docs/functional-areas-design.md
+++ b/docs/functional-areas-design.md
@@ -488,7 +488,7 @@ ScoringExecutor.ScoreSession(sessionID)
 
 Turn 1 uses an outcome-first ceiling mechanic: conclusion quality determines the score range (60-100 correct / 35-59 partial / 0-34 wrong), then process quality places the score within that range. A failure vocabulary (defined as a Go slice in `pkg/agent/prompt/vocabulary.go`) is dynamically injected into the prompt; after scoring, `scanFailureTags()` extracts matched terms into a `failure_tags` JSON column. Turn 2 covers both missing MCP tools and improvements to existing tools.
 
-Both turns persist LLM interactions and create streaming timeline events via `callLLMWithStreaming`. Auto-triggered by the worker after session completion (if chain scoring enabled) or on-demand via `POST /api/v1/sessions/:id/score`. See [ADR-0008: Session Scoring](adr/0008-session-scoring.md) and [ADR-0011: Scoring Framework Redesign](adr/0011-scoring-framework-redesign.md).
+Both turns persist LLM interactions and create streaming timeline events via `callLLMWithStreaming`. Auto-triggered by the worker after session completion (if chain scoring enabled via per-chain `scoring:` block or globally via `defaults.scoring`) or on-demand via `POST /api/v1/sessions/:id/score`. The `defaults.scoring` block also supports `llm_provider` and `llm_backend` overrides specific to scoring, inserted into the resolution hierarchy between global defaults and chain-level settings. See [ADR-0008: Session Scoring](adr/0008-session-scoring.md) and [ADR-0011: Scoring Framework Redesign](adr/0011-scoring-framework-redesign.md).
 
 #### Orchestrator Agent (`pkg/agent/orchestrator/`)
 

--- a/pkg/agent/config_resolver.go
+++ b/pkg/agent/config_resolver.go
@@ -274,10 +274,10 @@ func ResolveScoringConfig(
 		defaults = *cfg.Defaults
 	}
 
-	// Agent name: AgentNameScoring → defaults.ScoringAgent → scoringCfg.Agent
+	// Agent name: AgentNameScoring → defaults.Scoring.Agent → scoringCfg.Agent
 	agentName := config.AgentNameScoring
-	if defaults.ScoringAgent != "" {
-		agentName = defaults.ScoringAgent
+	if defaults.Scoring != nil && defaults.Scoring.Agent != "" {
+		agentName = defaults.Scoring.Agent
 	}
 	if scoringCfg != nil && scoringCfg.Agent != "" {
 		agentName = scoringCfg.Agent
@@ -289,7 +289,14 @@ func ResolveScoringConfig(
 		return nil, fmt.Errorf("agent %q not found: %w", agentName, err)
 	}
 
-	// Extract optional overrides from scoringCfg (may be nil)
+	// Extract optional overrides from defaults.Scoring and scoringCfg
+	var defaultsScoringBackend config.LLMBackend
+	var defaultsScoringProvider string
+	if defaults.Scoring != nil {
+		defaultsScoringBackend = defaults.Scoring.LLMBackend
+		defaultsScoringProvider = defaults.Scoring.LLMProvider
+	}
+
 	var scoringBackend config.LLMBackend
 	var scoringProvider string
 	var scoringMaxIter *int
@@ -299,16 +306,18 @@ func ResolveScoringConfig(
 		scoringMaxIter = scoringCfg.MaxIterations
 	}
 
-	// Resolve LLM backend (defaults → agentDef → scoringCfg).
+	// Resolve LLM backend (defaults → agentDef → defaults.Scoring → scoringCfg).
 	// chain.LLMBackend is intentionally excluded: the chain-level
 	// backend targets investigation agents.
 	backend := resolveLLMBackend(
-		defaults.LLMBackend, agentDef.LLMBackend, scoringBackend,
+		defaults.LLMBackend, agentDef.LLMBackend,
+		defaultsScoringBackend, scoringBackend,
 	)
 
-	// Resolve LLM provider (defaults → chain → scoringCfg)
+	// Resolve LLM provider (defaults → defaults.Scoring → chain → scoringCfg)
 	provider, providerName, err := resolveLLMProvider(cfg,
-		defaults.LLMProvider, chain.LLMProvider, scoringProvider,
+		defaults.LLMProvider, defaultsScoringProvider,
+		chain.LLMProvider, scoringProvider,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/agent/config_resolver_test.go
+++ b/pkg/agent/config_resolver_test.go
@@ -698,12 +698,12 @@ func TestResolveScoringConfig(t *testing.T) {
 		assert.Equal(t, config.AgentTypeScoring, resolved.Type)
 	})
 
-	t.Run("defaults.ScoringAgent used as fallback", func(t *testing.T) {
+	t.Run("defaults.Scoring.Agent used as fallback", func(t *testing.T) {
 		cfgWithDefault := &config.Config{
 			Defaults: &config.Defaults{
 				LLMProvider:   "google-default",
 				MaxIterations: &maxIter25,
-				ScoringAgent:  "CustomScorer",
+				Scoring:       &config.ScoringConfig{Agent: "CustomScorer"},
 			},
 			AgentRegistry:       cfg.AgentRegistry,
 			LLMProviderRegistry: cfg.LLMProviderRegistry,
@@ -715,12 +715,12 @@ func TestResolveScoringConfig(t *testing.T) {
 		assert.Equal(t, "CustomScorer", resolved.AgentName)
 	})
 
-	t.Run("scoringCfg agent overrides defaults.ScoringAgent", func(t *testing.T) {
+	t.Run("scoringCfg agent overrides defaults.Scoring.Agent", func(t *testing.T) {
 		cfgWithDefault := &config.Config{
 			Defaults: &config.Defaults{
 				LLMProvider:   "google-default",
 				MaxIterations: &maxIter25,
-				ScoringAgent:  config.AgentNameKubernetes,
+				Scoring:       &config.ScoringConfig{Agent: config.AgentNameKubernetes},
 			},
 			AgentRegistry:       cfg.AgentRegistry,
 			LLMProviderRegistry: cfg.LLMProviderRegistry,
@@ -733,6 +733,42 @@ func TestResolveScoringConfig(t *testing.T) {
 		resolved, err := ResolveScoringConfig(cfgWithDefault, chain, scoringCfg)
 		require.NoError(t, err)
 		assert.Equal(t, "CustomScorer", resolved.AgentName)
+	})
+
+	t.Run("defaults.Scoring LLM provider overrides defaults.LLMProvider", func(t *testing.T) {
+		cfgWithDefault := &config.Config{
+			Defaults: &config.Defaults{
+				LLMProvider: "google-default",
+				Scoring:     &config.ScoringConfig{LLMProvider: "openai-default"},
+			},
+			AgentRegistry:       cfg.AgentRegistry,
+			LLMProviderRegistry: cfg.LLMProviderRegistry,
+		}
+		chain := &config.ChainConfig{}
+
+		resolved, err := ResolveScoringConfig(cfgWithDefault, chain, nil)
+		require.NoError(t, err)
+		assert.Equal(t, openaiProvider, resolved.LLMProvider)
+		assert.Equal(t, "openai-default", resolved.LLMProviderName)
+	})
+
+	t.Run("defaults.Scoring LLM backend overrides defaults.LLMBackend", func(t *testing.T) {
+		cfgWithDefault := &config.Config{
+			Defaults: &config.Defaults{
+				LLMProvider: "google-default",
+				LLMBackend:  config.LLMBackendLangChain,
+				Scoring:     &config.ScoringConfig{LLMBackend: config.LLMBackendNativeGemini},
+			},
+			AgentRegistry: config.NewAgentRegistry(map[string]*config.AgentConfig{
+				config.AgentNameScoring: {Type: config.AgentTypeScoring},
+			}),
+			LLMProviderRegistry: cfg.LLMProviderRegistry,
+		}
+		chain := &config.ChainConfig{}
+
+		resolved, err := ResolveScoringConfig(cfgWithDefault, chain, nil)
+		require.NoError(t, err)
+		assert.Equal(t, config.LLMBackendNativeGemini, resolved.LLMBackend)
 	})
 
 	t.Run("LLM backend resolution: scoringCfg overrides agentDef", func(t *testing.T) {
@@ -847,6 +883,66 @@ func TestResolveScoringConfig(t *testing.T) {
 		assert.True(t, resolved.LLMProvider.NativeTools[config.GoogleNativeToolGoogleSearch])
 		assert.False(t, resolved.LLMProvider.NativeTools[config.GoogleNativeToolURLContext])
 		assert.NotSame(t, providerWithNative, resolved.LLMProvider)
+	})
+
+	t.Run("LLM provider full hierarchy: scoringCfg overrides chain overrides defaults.Scoring overrides defaults", func(t *testing.T) {
+		cfgFull := &config.Config{
+			Defaults: &config.Defaults{
+				LLMProvider: "google-default",
+				Scoring:     &config.ScoringConfig{LLMProvider: "openai-default"},
+			},
+			AgentRegistry: config.NewAgentRegistry(map[string]*config.AgentConfig{
+				config.AgentNameScoring: {Type: config.AgentTypeScoring},
+			}),
+			LLMProviderRegistry: config.NewLLMProviderRegistry(map[string]*config.LLMProviderConfig{
+				"google-default": googleProvider,
+				"openai-default": openaiProvider,
+			}),
+		}
+
+		// defaults.Scoring overrides defaults
+		resolved, err := ResolveScoringConfig(cfgFull, &config.ChainConfig{}, nil)
+		require.NoError(t, err)
+		assert.Equal(t, "openai-default", resolved.LLMProviderName)
+
+		// chain overrides defaults.Scoring
+		resolved, err = ResolveScoringConfig(cfgFull, &config.ChainConfig{LLMProvider: "google-default"}, nil)
+		require.NoError(t, err)
+		assert.Equal(t, "google-default", resolved.LLMProviderName)
+
+		// scoringCfg overrides chain
+		resolved, err = ResolveScoringConfig(cfgFull,
+			&config.ChainConfig{LLMProvider: "google-default"},
+			&config.ScoringConfig{LLMProvider: "openai-default"},
+		)
+		require.NoError(t, err)
+		assert.Equal(t, "openai-default", resolved.LLMProviderName)
+	})
+
+	t.Run("LLM backend full hierarchy: scoringCfg overrides defaults.Scoring overrides agentDef overrides defaults", func(t *testing.T) {
+		cfgFull := &config.Config{
+			Defaults: &config.Defaults{
+				LLMProvider: "google-default",
+				LLMBackend:  config.LLMBackendLangChain,
+				Scoring:     &config.ScoringConfig{LLMBackend: config.LLMBackendNativeGemini},
+			},
+			AgentRegistry: config.NewAgentRegistry(map[string]*config.AgentConfig{
+				config.AgentNameScoring: {Type: config.AgentTypeScoring},
+			}),
+			LLMProviderRegistry: cfg.LLMProviderRegistry,
+		}
+
+		// defaults.Scoring overrides defaults + agentDef (both LangChain)
+		resolved, err := ResolveScoringConfig(cfgFull, &config.ChainConfig{}, nil)
+		require.NoError(t, err)
+		assert.Equal(t, config.LLMBackendNativeGemini, resolved.LLMBackend)
+
+		// scoringCfg overrides defaults.Scoring
+		resolved, err = ResolveScoringConfig(cfgFull, &config.ChainConfig{},
+			&config.ScoringConfig{LLMBackend: config.LLMBackendLangChain},
+		)
+		require.NoError(t, err)
+		assert.Equal(t, config.LLMBackendLangChain, resolved.LLMBackend)
 	})
 
 	t.Run("errors on unknown agent", func(t *testing.T) {

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -15,12 +15,10 @@ type Defaults struct {
 	// Ordered list of fallback providers to try when the primary provider fails
 	FallbackProviders []FallbackProviderEntry `yaml:"fallback_providers,omitempty"`
 
-	// Default scoring agent name (fallback when chain has no scoring config)
-	ScoringAgent string `yaml:"scoring_agent,omitempty"`
-
-	// Enable scoring by default for all chains that don't explicitly configure it.
-	// Chains with an explicit scoring: block (even with enabled: false) are not affected.
-	ScoringEnabled bool `yaml:"scoring_enabled,omitempty"`
+	// Default scoring configuration for all chains.
+	// Chains with an explicit scoring: block are not affected.
+	// Provides defaults for enabled, agent, llm_provider, llm_backend, etc.
+	Scoring *ScoringConfig `yaml:"scoring,omitempty"`
 
 	// Success policy default for parallel stages
 	SuccessPolicy SuccessPolicy `yaml:"success_policy,omitempty"`

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -148,7 +148,7 @@ func load(_ context.Context, configDir string) (*Config, error) {
 	}
 
 	// 7. Apply default scoring to chains without explicit scoring config
-	if defaults.ScoringEnabled {
+	if defaults.Scoring != nil && defaults.Scoring.Enabled {
 		for _, chain := range chains {
 			if chain.Scoring == nil {
 				chain.Scoring = &ScoringConfig{Enabled: true}

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -1001,11 +1001,12 @@ agent_chains:
 }
 
 func TestLoadAppliesScoringEnabledDefault(t *testing.T) {
-	t.Run("scoring_enabled injects scoring config for chains without it", func(t *testing.T) {
+	t.Run("defaults.scoring.enabled injects scoring config for chains without it", func(t *testing.T) {
 		dir := t.TempDir()
 		tarsyYAML := `
 defaults:
-  scoring_enabled: true
+  scoring:
+    enabled: true
 
 agents:
   test-agent:
@@ -1049,11 +1050,12 @@ agent_chains:
 		assert.Equal(t, "custom-provider", explicit.Scoring.LLMProvider)
 	})
 
-	t.Run("scoring_enabled false does not inject scoring", func(t *testing.T) {
+	t.Run("defaults.scoring.enabled false does not inject scoring", func(t *testing.T) {
 		dir := t.TempDir()
 		tarsyYAML := `
 defaults:
-  scoring_enabled: false
+  scoring:
+    enabled: false
 
 agents:
   test-agent:
@@ -1075,14 +1077,15 @@ agent_chains:
 
 		chain, err := cfg.GetChain("chain-no-scoring")
 		require.NoError(t, err)
-		assert.Nil(t, chain.Scoring, "scoring should not be injected when scoring_enabled is false")
+		assert.Nil(t, chain.Scoring, "scoring should not be injected when scoring.enabled is false")
 	})
 
 	t.Run("explicit scoring block is not overridden by default", func(t *testing.T) {
 		dir := t.TempDir()
 		tarsyYAML := `
 defaults:
-  scoring_enabled: true
+  scoring:
+    enabled: true
 
 agents:
   test-agent:
@@ -1110,12 +1113,45 @@ agent_chains:
 		assert.False(t, chain.Scoring.Enabled, "explicit scoring.enabled=false should not be overridden by default")
 	})
 
-	t.Run("omitted scoring_enabled does not inject scoring", func(t *testing.T) {
+	t.Run("omitted defaults.scoring does not inject scoring", func(t *testing.T) {
 		dir := setupTestConfigDir(t)
 
 		cfg, err := load(context.Background(), dir)
 		require.NoError(t, err)
 
-		assert.False(t, cfg.Defaults.ScoringEnabled)
+		assert.Nil(t, cfg.Defaults.Scoring)
+	})
+
+	t.Run("defaults.scoring with llm_provider is parsed", func(t *testing.T) {
+		dir := t.TempDir()
+		tarsyYAML := `
+defaults:
+  scoring:
+    enabled: true
+    llm_provider: "gemini-3-flash"
+    llm_backend: "google-native"
+
+agents:
+  test-agent:
+    mcp_servers: []
+
+agent_chains:
+  test-chain:
+    alert_types: ["test"]
+    stages:
+      - name: "s1"
+        agents:
+          - name: "test-agent"
+`
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "tarsy.yaml"), []byte(tarsyYAML), 0644))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "llm-providers.yaml"), []byte("llm_providers: {}\n"), 0644))
+
+		cfg, err := load(context.Background(), dir)
+		require.NoError(t, err)
+
+		require.NotNil(t, cfg.Defaults.Scoring)
+		assert.True(t, cfg.Defaults.Scoring.Enabled)
+		assert.Equal(t, "gemini-3-flash", cfg.Defaults.Scoring.LLMProvider)
+		assert.Equal(t, LLMBackendNativeGemini, cfg.Defaults.Scoring.LLMBackend)
 	})
 }

--- a/pkg/config/validator.go
+++ b/pkg/config/validator.go
@@ -109,8 +109,10 @@ func (v *Validator) validateDefaults() error {
 	// Validate defaults.scoring block if specified
 	if defaults.Scoring != nil {
 		if defaults.Scoring.Agent != "" && !v.cfg.AgentRegistry.Has(defaults.Scoring.Agent) {
-			return NewValidationError("defaults", "", "scoring.agent",
-				fmt.Errorf("agent '%s' not found", defaults.Scoring.Agent))
+			if _, isBuiltin := GetBuiltinConfig().Agents[defaults.Scoring.Agent]; !isBuiltin {
+				return NewValidationError("defaults", "", "scoring.agent",
+					fmt.Errorf("agent '%s' not found", defaults.Scoring.Agent))
+			}
 		}
 		if defaults.Scoring.LLMBackend != "" && !defaults.Scoring.LLMBackend.IsValid() {
 			return NewValidationError("defaults", "", "scoring.llm_backend",

--- a/pkg/config/validator.go
+++ b/pkg/config/validator.go
@@ -106,10 +106,24 @@ func (v *Validator) validateDefaults() error {
 		return nil
 	}
 
-	// Validate scoring agent reference if specified
-	if defaults.ScoringAgent != "" && !v.cfg.AgentRegistry.Has(defaults.ScoringAgent) {
-		return NewValidationError("defaults", "", "scoring_agent",
-			fmt.Errorf("agent '%s' not found", defaults.ScoringAgent))
+	// Validate defaults.scoring block if specified
+	if defaults.Scoring != nil {
+		if defaults.Scoring.Agent != "" && !v.cfg.AgentRegistry.Has(defaults.Scoring.Agent) {
+			return NewValidationError("defaults", "", "scoring.agent",
+				fmt.Errorf("agent '%s' not found", defaults.Scoring.Agent))
+		}
+		if defaults.Scoring.LLMBackend != "" && !defaults.Scoring.LLMBackend.IsValid() {
+			return NewValidationError("defaults", "", "scoring.llm_backend",
+				fmt.Errorf("invalid LLM backend: %s", defaults.Scoring.LLMBackend))
+		}
+		if defaults.Scoring.LLMProvider != "" && !v.cfg.LLMProviderRegistry.Has(defaults.Scoring.LLMProvider) {
+			return NewValidationError("defaults", "", "scoring.llm_provider",
+				fmt.Errorf("LLM provider '%s' not found", defaults.Scoring.LLMProvider))
+		}
+		if defaults.Scoring.MaxIterations != nil && *defaults.Scoring.MaxIterations < 1 {
+			return NewValidationError("defaults", "", "scoring.max_iterations",
+				fmt.Errorf("must be at least 1"))
+		}
 	}
 
 	// Validate fallback providers if specified
@@ -560,6 +574,9 @@ func (v *Validator) collectReferencedLLMProviders() map[string]bool {
 		}
 		for _, fb := range v.cfg.Defaults.FallbackProviders {
 			referenced[fb.Provider] = true
+		}
+		if v.cfg.Defaults.Scoring != nil && v.cfg.Defaults.Scoring.LLMProvider != "" {
+			referenced[v.cfg.Defaults.Scoring.LLMProvider] = true
 		}
 	}
 

--- a/pkg/config/validator_test.go
+++ b/pkg/config/validator_test.go
@@ -2108,18 +2108,19 @@ func TestValidateDefaults(t *testing.T) {
 	}
 }
 
-func TestValidateDefaultsScoringAgent(t *testing.T) {
+func TestValidateDefaultsScoring(t *testing.T) {
 	tests := []struct {
-		name     string
-		defaults *Defaults
-		agents   map[string]*AgentConfig
-		wantErr  bool
-		errMsg   string
+		name      string
+		defaults  *Defaults
+		agents    map[string]*AgentConfig
+		providers map[string]*LLMProviderConfig
+		wantErr   bool
+		errMsg    string
 	}{
 		{
 			name: "valid scoring agent passes",
 			defaults: &Defaults{
-				ScoringAgent: "scoring-agent",
+				Scoring: &ScoringConfig{Agent: "scoring-agent"},
 			},
 			agents: map[string]*AgentConfig{
 				"scoring-agent": {},
@@ -2129,25 +2130,77 @@ func TestValidateDefaultsScoringAgent(t *testing.T) {
 		{
 			name: "invalid scoring agent fails",
 			defaults: &Defaults{
-				ScoringAgent: "nonexistent-agent",
+				Scoring: &ScoringConfig{Agent: "nonexistent-agent"},
 			},
 			agents:  map[string]*AgentConfig{},
 			wantErr: true,
 			errMsg:  "agent 'nonexistent-agent' not found",
 		},
 		{
-			name:     "empty scoring agent passes",
+			name:     "nil scoring passes",
 			defaults: &Defaults{},
 			agents:   map[string]*AgentConfig{},
 			wantErr:  false,
+		},
+		{
+			name: "invalid scoring llm_backend fails",
+			defaults: &Defaults{
+				Scoring: &ScoringConfig{LLMBackend: "invalid-backend"},
+			},
+			agents:  map[string]*AgentConfig{},
+			wantErr: true,
+			errMsg:  "invalid LLM backend",
+		},
+		{
+			name: "valid scoring llm_backend passes",
+			defaults: &Defaults{
+				Scoring: &ScoringConfig{LLMBackend: LLMBackendNativeGemini},
+			},
+			agents:  map[string]*AgentConfig{},
+			wantErr: false,
+		},
+		{
+			name: "invalid scoring llm_provider fails",
+			defaults: &Defaults{
+				Scoring: &ScoringConfig{LLMProvider: "nonexistent-provider"},
+			},
+			agents:    map[string]*AgentConfig{},
+			providers: map[string]*LLMProviderConfig{},
+			wantErr:   true,
+			errMsg:    "LLM provider 'nonexistent-provider' not found",
+		},
+		{
+			name: "valid scoring llm_provider passes",
+			defaults: &Defaults{
+				Scoring: &ScoringConfig{LLMProvider: "test-provider"},
+			},
+			agents: map[string]*AgentConfig{},
+			providers: map[string]*LLMProviderConfig{
+				"test-provider": {Type: LLMProviderTypeGoogle, Model: "test", MaxToolResultTokens: 1000},
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid scoring max_iterations fails",
+			defaults: &Defaults{
+				Scoring: &ScoringConfig{MaxIterations: intPtr(0)},
+			},
+			agents:  map[string]*AgentConfig{},
+			wantErr: true,
+			errMsg:  "must be at least 1",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			providers := tt.providers
+			if providers == nil {
+				providers = map[string]*LLMProviderConfig{}
+			}
 			cfg := &Config{
-				Defaults:      tt.defaults,
-				AgentRegistry: NewAgentRegistry(tt.agents),
+				Defaults:            tt.defaults,
+				AgentRegistry:       NewAgentRegistry(tt.agents),
+				LLMProviderRegistry: NewLLMProviderRegistry(providers),
 			}
 
 			validator := NewValidator(cfg)

--- a/pkg/config/validator_test.go
+++ b/pkg/config/validator_test.go
@@ -2128,6 +2128,14 @@ func TestValidateDefaultsScoring(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "built-in scoring agent passes without registry entry",
+			defaults: &Defaults{
+				Scoring: &ScoringConfig{Agent: AgentNameScoring},
+			},
+			agents:  map[string]*AgentConfig{},
+			wantErr: false,
+		},
+		{
 			name: "invalid scoring agent fails",
 			defaults: &Defaults{
 				Scoring: &ScoringConfig{Agent: "nonexistent-agent"},

--- a/pkg/queue/scoring_executor.go
+++ b/pkg/queue/scoring_executor.go
@@ -811,11 +811,14 @@ func IsTerminalStatus(status alertsession.Status) bool {
 }
 
 // resolveScoringProviderName resolves the LLM provider name for scoring using
-// the hierarchy: defaults → chain → scoringCfg.
+// the hierarchy: defaults → defaults.Scoring → chain → scoringCfg.
 func resolveScoringProviderName(defaults *config.Defaults, chain *config.ChainConfig, scoringCfg *config.ScoringConfig) string {
 	var providerName string
 	if defaults != nil {
 		providerName = defaults.LLMProvider
+		if defaults.Scoring != nil && defaults.Scoring.LLMProvider != "" {
+			providerName = defaults.Scoring.LLMProvider
+		}
 	}
 	if chain != nil && chain.LLMProvider != "" {
 		providerName = chain.LLMProvider

--- a/pkg/queue/scoring_executor_test.go
+++ b/pkg/queue/scoring_executor_test.go
@@ -153,6 +153,17 @@ func TestResolveScoringProviderName(t *testing.T) {
 			expected: "default-provider",
 		},
 		{
+			name:     "defaults.Scoring overrides defaults.LLMProvider",
+			defaults: &config.Defaults{LLMProvider: "default-provider", Scoring: &config.ScoringConfig{LLMProvider: "scoring-default"}},
+			expected: "scoring-default",
+		},
+		{
+			name:     "chain overrides defaults.Scoring",
+			defaults: &config.Defaults{LLMProvider: "default-provider", Scoring: &config.ScoringConfig{LLMProvider: "scoring-default"}},
+			chain:    &config.ChainConfig{LLMProvider: "chain-provider"},
+			expected: "chain-provider",
+		},
+		{
 			name:     "chain overrides defaults",
 			defaults: &config.Defaults{LLMProvider: "default-provider"},
 			chain:    &config.ChainConfig{LLMProvider: "chain-provider"},
@@ -161,6 +172,13 @@ func TestResolveScoringProviderName(t *testing.T) {
 		{
 			name:     "scoring overrides chain",
 			defaults: &config.Defaults{LLMProvider: "default-provider"},
+			chain:    &config.ChainConfig{LLMProvider: "chain-provider"},
+			scoring:  &config.ScoringConfig{LLMProvider: "scoring-provider"},
+			expected: "scoring-provider",
+		},
+		{
+			name:     "full hierarchy: scoring overrides chain overrides defaults.Scoring overrides defaults",
+			defaults: &config.Defaults{LLMProvider: "default-provider", Scoring: &config.ScoringConfig{LLMProvider: "scoring-default"}},
 			chain:    &config.ChainConfig{LLMProvider: "chain-provider"},
 			scoring:  &config.ScoringConfig{LLMProvider: "scoring-provider"},
 			expected: "scoring-provider",

--- a/test/e2e/scoring_test.go
+++ b/test/e2e/scoring_test.go
@@ -685,3 +685,65 @@ func TestE2E_Scoring_API_NonTerminalSession(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 0, scoringStageCount, "rejected scoring must not create scoring stages")
 }
+
+// TestE2E_Scoring_DefaultsBlock verifies that scoring auto-triggers when
+// enabled via the defaults.scoring block (no chain-level scoring: config).
+// This exercises the loader path that injects ScoringConfig into chains.
+func TestE2E_Scoring_DefaultsBlock(t *testing.T) {
+	llm := NewScriptedLLMClient()
+
+	// Simple investigation (2) + exec summary (1) + scoring (2) = 5 total.
+	scriptSimpleInvestigation(llm)
+	scriptExecSummary(llm)
+	scriptScoringSuccess(llm)
+
+	podsResult := `[{"name":"pod-1","status":"OOMKilled","restarts":3}]`
+
+	app := NewTestApp(t,
+		WithConfig(configs.Load(t, "scoring-defaults")),
+		WithLLMClient(llm),
+		WithMCPServers(map[string]map[string]mcpsdk.ToolHandler{
+			"test-mcp": {
+				"get_pods": StaticToolHandler(podsResult),
+			},
+		}),
+	)
+
+	resp := app.SubmitAlert(t, "test-scoring-defaults", "Pod OOMKilled")
+	sessionID := resp["session_id"].(string)
+	require.NotEmpty(t, sessionID)
+
+	app.WaitForSessionStatus(t, sessionID, "completed")
+
+	// Wait for the scoring stage to complete (auto-triggered via defaults.scoring).
+	require.Eventually(t, func() bool {
+		stgs, err := app.EntClient.Stage.Query().
+			Where(stage.SessionIDEQ(sessionID), stage.StageTypeEQ(stage.StageTypeScoring)).
+			All(context.Background())
+		if err != nil || len(stgs) == 0 {
+			return false
+		}
+		return stgs[0].Status == stage.StatusCompleted
+	}, 30*time.Second, 200*time.Millisecond, "scoring stage did not complete")
+
+	// Verify scoring record was created.
+	scores, err := app.EntClient.SessionScore.Query().
+		Where(sessionscore.SessionIDEQ(sessionID)).
+		All(context.Background())
+	require.NoError(t, err)
+	require.Len(t, scores, 1)
+
+	score := scores[0]
+	assert.Equal(t, sessionscore.StatusCompleted, score.Status)
+	require.NotNil(t, score.TotalScore)
+	assert.Equal(t, 75, *score.TotalScore)
+	assert.Equal(t, "auto", score.ScoreTriggeredBy)
+
+	// Verify session detail reflects the score.
+	sessionDetail := app.GetSession(t, sessionID)
+	assert.Equal(t, float64(75), sessionDetail["latest_score"])
+	assert.Equal(t, "completed", sessionDetail["scoring_status"])
+
+	// Investigation (2) + exec summary (1) + scoring (2) = 5.
+	assert.Equal(t, 5, llm.CallCount())
+}

--- a/test/e2e/testdata/configs/scoring-defaults/llm-providers.yaml
+++ b/test/e2e/testdata/configs/scoring-defaults/llm-providers.yaml
@@ -1,0 +1,5 @@
+llm_providers:
+  test-provider:
+    type: google
+    model: test-model
+    max_tool_result_tokens: 10000

--- a/test/e2e/testdata/configs/scoring-defaults/tarsy.yaml
+++ b/test/e2e/testdata/configs/scoring-defaults/tarsy.yaml
@@ -1,0 +1,25 @@
+defaults:
+  llm_provider: "test-provider"
+  llm_backend: "google-native"
+  scoring:
+    enabled: true
+
+mcp_servers:
+  test-mcp:
+    transport:
+      type: stdio
+      command: mock
+
+agents:
+  Investigator:
+    mcp_servers: [test-mcp]
+    custom_instructions: "You are Investigator, gathering evidence about the alert."
+
+agent_chains:
+  scoring-via-defaults:
+    alert_types: [test-scoring-defaults]
+    executive_summary_provider: "test-provider"
+    stages:
+      - name: investigation
+        agents:
+          - name: Investigator


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Scoring operations now support default LLM provider and backend configurations via the defaults block.

* **Refactor**
  * Restructured the configuration schema for default scoring settings. Settings are now nested under a `scoring` block with `enabled`, `agent`, `llm_provider`, and `llm_backend` fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->