### PR TITLE
Allow bulk sessoin review

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ TARSy uses a hybrid Go + Python architecture where the Go orchestrator handles a
 - `POST /api/v1/sessions/:id/score` -- Trigger (re-)scoring (202 Accepted, 409 if already in progress)
 
 ### Review & Triage
-- `PATCH /api/v1/sessions/:id/review` -- Review workflow transition (claim, unclaim, resolve, reopen)
+- `PATCH /api/v1/sessions/review` -- Review workflow transition for one or more sessions (claim, unclaim, resolve, reopen, update_note)
 - `GET /api/v1/sessions/:id/review-activity` -- Review activity audit log
 - `GET /api/v1/sessions/triage/:group` -- Per-group paginated triage view
 

--- a/pkg/api/handler_review.go
+++ b/pkg/api/handler_review.go
@@ -19,73 +19,62 @@ const (
 	maxPageSize     = 200
 )
 
-// updateReviewHandler handles PATCH /api/v1/sessions/:id/review.
-func (s *Server) updateReviewHandler(c *echo.Context) error {
-	sessionID := c.Param("id")
-	if sessionID == "" {
-		return echo.NewHTTPError(http.StatusBadRequest, "session id is required")
-	}
+const maxSessionIDs = 50
 
+// updateReviewHandler handles PATCH /api/v1/sessions/review.
+// Accepts one or more session IDs in the request body.
+func (s *Server) updateReviewHandler(c *echo.Context) error {
 	var req models.UpdateReviewRequest
 	if err := c.Bind(&req); err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid request body")
 	}
+	if len(req.SessionIDs) == 0 {
+		return echo.NewHTTPError(http.StatusBadRequest, "session_ids is required and must not be empty")
+	}
+	if len(req.SessionIDs) > maxSessionIDs {
+		return echo.NewHTTPError(http.StatusBadRequest,
+			fmt.Sprintf("session_ids must not exceed %d entries", maxSessionIDs))
+	}
+	if !models.ValidReviewAction(req.Action) {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("unknown action %q", req.Action))
+	}
+	if models.ReviewAction(req.Action) == models.ReviewActionResolve && req.ResolutionReason == nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "resolution_reason is required for resolve action")
+	}
 	req.Actor = extractAuthor(c)
 
-	session, err := s.sessionService.UpdateReviewStatus(c.Request().Context(), sessionID, req)
-	if err != nil {
-		return mapServiceError(err)
-	}
+	resp, updated := s.sessionService.UpdateReviewStatus(c.Request().Context(), req)
 
-	// Publish review.status event (caller-owns-publishing pattern).
-	// Use a detached context so client disconnects don't cancel the publish.
 	if s.eventPublisher != nil {
-		pubCtx, pubCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		pubCtx, pubCancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer pubCancel()
 
-		payload := events.ReviewStatusPayload{
-			BasePayload: events.BasePayload{
-				Type:      events.EventTypeReviewStatus,
-				SessionID: sessionID,
-				Timestamp: time.Now().Format(time.RFC3339Nano),
-			},
-			Actor:    req.Actor,
-			Assignee: session.Assignee,
-		}
-		if session.ReviewStatus != nil {
-			rs := string(*session.ReviewStatus)
-			payload.ReviewStatus = &rs
-		}
-		if session.ResolutionReason != nil {
-			reason := string(*session.ResolutionReason)
-			payload.ResolutionReason = &reason
-		}
-		if err := s.eventPublisher.PublishReviewStatus(pubCtx, sessionID, payload); err != nil {
-			slog.Warn("Failed to publish review status from handler",
-				"session_id", sessionID, "error", err)
+		for _, session := range updated {
+			payload := events.ReviewStatusPayload{
+				BasePayload: events.BasePayload{
+					Type:      events.EventTypeReviewStatus,
+					SessionID: session.ID,
+					Timestamp: time.Now().Format(time.RFC3339Nano),
+				},
+				Actor:    req.Actor,
+				Assignee: session.Assignee,
+			}
+			if session.ReviewStatus != nil {
+				rs := string(*session.ReviewStatus)
+				payload.ReviewStatus = &rs
+			}
+			if session.ResolutionReason != nil {
+				reason := string(*session.ResolutionReason)
+				payload.ResolutionReason = &reason
+			}
+			if err := s.eventPublisher.PublishReviewStatus(pubCtx, session.ID, payload); err != nil {
+				slog.Warn("Failed to publish review status event",
+					"session_id", session.ID, "error", err)
+			}
 		}
 	}
 
-	var reviewStatus *string
-	if session.ReviewStatus != nil {
-		statusStr := string(*session.ReviewStatus)
-		reviewStatus = &statusStr
-	}
-	var resolutionReason *string
-	if session.ResolutionReason != nil {
-		reasonStr := string(*session.ResolutionReason)
-		resolutionReason = &reasonStr
-	}
-
-	return c.JSON(http.StatusOK, map[string]any{
-		"id":                session.ID,
-		"review_status":     reviewStatus,
-		"assignee":          session.Assignee,
-		"assigned_at":       session.AssignedAt,
-		"resolved_at":       session.ResolvedAt,
-		"resolution_reason": resolutionReason,
-		"resolution_note":   session.ResolutionNote,
-	})
+	return c.JSON(http.StatusOK, resp)
 }
 
 // getReviewActivityHandler handles GET /api/v1/sessions/:id/review-activity.

--- a/pkg/api/handler_review_test.go
+++ b/pkg/api/handler_review_test.go
@@ -10,29 +10,52 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestUpdateReviewHandler_MissingSessionID(t *testing.T) {
+func TestUpdateReviewHandler_Validation(t *testing.T) {
 	s := &Server{}
 	e := echo.New()
-	req := httptest.NewRequest(http.MethodPatch, "/api/v1/sessions//review", nil)
-	rec := httptest.NewRecorder()
-	c := e.NewContext(req, rec)
+	e.PATCH("/api/v1/sessions/review", s.updateReviewHandler)
 
-	err := s.updateReviewHandler(c)
-	if assert.Error(t, err) {
-		he, ok := err.(*echo.HTTPError)
-		if assert.True(t, ok) {
-			assert.Equal(t, http.StatusBadRequest, he.Code)
-		}
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "invalid json", body: "{bad json"},
+		{name: "empty session_ids", body: `{"session_ids":[],"action":"claim"}`},
+		{name: "missing session_ids", body: `{"action":"claim"}`},
+		{name: "unknown action", body: `{"session_ids":["id1"],"action":"bogus"}`},
+		{name: "resolve without resolution_reason", body: `{"session_ids":["id1"],"action":"resolve"}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPatch, "/api/v1/sessions/review",
+				strings.NewReader(tt.body))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			e.ServeHTTP(rec, req)
+
+			assert.Equal(t, http.StatusBadRequest, rec.Code)
+		})
 	}
 }
 
-func TestUpdateReviewHandler_InvalidBody(t *testing.T) {
+func TestUpdateReviewHandler_TooManyIDs(t *testing.T) {
 	s := &Server{}
 	e := echo.New()
-	e.PATCH("/api/v1/sessions/:id/review", s.updateReviewHandler)
+	e.PATCH("/api/v1/sessions/review", s.updateReviewHandler)
 
-	req := httptest.NewRequest(http.MethodPatch, "/api/v1/sessions/test-123/review",
-		strings.NewReader("{invalid json"))
+	var ids strings.Builder
+	ids.WriteString(`{"session_ids":[`)
+	for i := range 51 {
+		if i > 0 {
+			ids.WriteString(",")
+		}
+		ids.WriteString(`"id-` + strings.Repeat("x", 5) + `"`)
+	}
+	ids.WriteString(`],"action":"claim"}`)
+
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/sessions/review",
+		strings.NewReader(ids.String()))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
 	e.ServeHTTP(rec, req)
@@ -43,15 +66,14 @@ func TestUpdateReviewHandler_InvalidBody(t *testing.T) {
 func TestUpdateReviewHandler_NilSessionService(t *testing.T) {
 	s := &Server{}
 	e := echo.New()
-	e.PATCH("/api/v1/sessions/:id/review", s.updateReviewHandler)
+	e.PATCH("/api/v1/sessions/review", s.updateReviewHandler)
 
-	body := `{"action": "claim"}`
-	req := httptest.NewRequest(http.MethodPatch, "/api/v1/sessions/test-123/review",
+	body := `{"session_ids":["test-123"],"action":"claim"}`
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/sessions/review",
 		strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
 
-	// sessionService is nil — should panic or 500, testing that it doesn't crash silently
 	assert.Panics(t, func() {
 		e.ServeHTTP(rec, req)
 	})

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -251,6 +251,7 @@ func (s *Server) setupRoutes() {
 	v1.GET("/sessions/active", s.activeSessionsHandler)
 	v1.GET("/sessions/filter-options", s.filterOptionsHandler)
 	v1.GET("/sessions/triage/:group", s.getTriageGroupHandler)
+	v1.PATCH("/sessions/review", s.updateReviewHandler)
 
 	// Session detail and actions.
 	v1.GET("/sessions/:id", s.getSessionHandler)
@@ -260,7 +261,6 @@ func (s *Server) setupRoutes() {
 	v1.POST("/sessions/:id/chat/messages", s.sendChatMessageHandler)
 	v1.POST("/sessions/:id/score", s.scoreSessionHandler)
 	v1.GET("/sessions/:id/score", s.getScoreHandler)
-	v1.PATCH("/sessions/:id/review", s.updateReviewHandler)
 	v1.GET("/sessions/:id/review-activity", s.getReviewActivityHandler)
 	v1.GET("/sessions/:id/timeline", s.getTimelineHandler)
 

--- a/pkg/models/session.go
+++ b/pkg/models/session.go
@@ -297,12 +297,26 @@ func ValidReviewAction(s string) bool {
 	}
 }
 
-// UpdateReviewRequest is the request body for PATCH /sessions/:id/review.
+// UpdateReviewRequest is the request body for PATCH /api/v1/sessions/review.
+// SessionIDs contains one or more session IDs to apply the action to.
 type UpdateReviewRequest struct {
-	Action           string  `json:"action"`            // claim, unclaim, resolve, reopen
-	Actor            string  `json:"-"`                 // populated from extractAuthor, not from JSON
-	ResolutionReason *string `json:"resolution_reason"` // required for resolve
-	Note             *string `json:"note"`              // optional free text
+	SessionIDs       []string `json:"session_ids"`
+	Action           string   `json:"action"`
+	Actor            string   `json:"-"`
+	ResolutionReason *string  `json:"resolution_reason,omitempty"`
+	Note             *string  `json:"note,omitempty"`
+}
+
+// UpdateReviewResponse reports per-session results from a review action.
+type UpdateReviewResponse struct {
+	Results []UpdateReviewResult `json:"results"`
+}
+
+// UpdateReviewResult is the outcome for a single session in a review action.
+type UpdateReviewResult struct {
+	SessionID string `json:"session_id"`
+	Success   bool   `json:"success"`
+	Error     string `json:"error,omitempty"`
 }
 
 // ReviewActivityItem is a single entry in the review activity log.

--- a/pkg/services/session_service_review.go
+++ b/pkg/services/session_service_review.go
@@ -14,10 +14,36 @@ import (
 	"github.com/google/uuid"
 )
 
-// UpdateReviewStatus performs an atomic compare-and-transition on the session's
+// UpdateReviewStatus applies a review action to one or more sessions.
+// Each session is processed independently in its own transaction; a failure
+// on one does not affect others. Returns the per-session results and the
+// list of successfully updated ent sessions (for event publishing).
+func (s *SessionService) UpdateReviewStatus(_ context.Context, req models.UpdateReviewRequest) (models.UpdateReviewResponse, []*ent.AlertSession) {
+	results := make([]models.UpdateReviewResult, 0, len(req.SessionIDs))
+	var updated []*ent.AlertSession
+	for _, sid := range req.SessionIDs {
+		session, err := s.updateSingleReview(sid, req)
+		if err != nil {
+			results = append(results, models.UpdateReviewResult{
+				SessionID: sid,
+				Success:   false,
+				Error:     err.Error(),
+			})
+		} else {
+			results = append(results, models.UpdateReviewResult{
+				SessionID: sid,
+				Success:   true,
+			})
+			updated = append(updated, session)
+		}
+	}
+	return models.UpdateReviewResponse{Results: results}, updated
+}
+
+// updateSingleReview performs an atomic compare-and-transition on one session's
 // review_status. Returns the updated session or ErrConflict if the precondition
 // (expected current review_status) was not met.
-func (s *SessionService) UpdateReviewStatus(_ context.Context, sessionID string, req models.UpdateReviewRequest) (*ent.AlertSession, error) {
+func (s *SessionService) updateSingleReview(sessionID string, req models.UpdateReviewRequest) (*ent.AlertSession, error) {
 	if !models.ValidReviewAction(req.Action) {
 		return nil, NewValidationError("action", fmt.Sprintf("unknown action %q", req.Action))
 	}

--- a/pkg/services/session_service_review.go
+++ b/pkg/services/session_service_review.go
@@ -16,12 +16,22 @@ import (
 
 // UpdateReviewStatus applies a review action to one or more sessions.
 // Each session is processed independently in its own transaction; a failure
-// on one does not affect others. Returns the per-session results and the
-// list of successfully updated ent sessions (for event publishing).
-func (s *SessionService) UpdateReviewStatus(_ context.Context, req models.UpdateReviewRequest) (models.UpdateReviewResponse, []*ent.AlertSession) {
+// on one does not affect others. The parent context is checked between
+// iterations so bulk operations abort early if the caller disconnects.
+// Returns the per-session results and the list of successfully updated
+// ent sessions (for event publishing).
+func (s *SessionService) UpdateReviewStatus(ctx context.Context, req models.UpdateReviewRequest) (models.UpdateReviewResponse, []*ent.AlertSession) {
 	results := make([]models.UpdateReviewResult, 0, len(req.SessionIDs))
 	var updated []*ent.AlertSession
 	for _, sid := range req.SessionIDs {
+		if err := ctx.Err(); err != nil {
+			results = append(results, models.UpdateReviewResult{
+				SessionID: sid,
+				Success:   false,
+				Error:     err.Error(),
+			})
+			continue
+		}
 		session, err := s.updateSingleReview(sid, req)
 		if err != nil {
 			results = append(results, models.UpdateReviewResult{

--- a/pkg/services/session_service_review.go
+++ b/pkg/services/session_service_review.go
@@ -21,6 +21,14 @@ import (
 // Returns the per-session results and the list of successfully updated
 // ent sessions (for event publishing).
 func (s *SessionService) UpdateReviewStatus(ctx context.Context, req models.UpdateReviewRequest) (models.UpdateReviewResponse, []*ent.AlertSession) {
+	if err := validateReviewRequest(req); err != nil {
+		results := make([]models.UpdateReviewResult, len(req.SessionIDs))
+		for i, sid := range req.SessionIDs {
+			results[i] = models.UpdateReviewResult{SessionID: sid, Success: false, Error: err.Error()}
+		}
+		return models.UpdateReviewResponse{Results: results}, nil
+	}
+
 	results := make([]models.UpdateReviewResult, 0, len(req.SessionIDs))
 	var updated []*ent.AlertSession
 	for _, sid := range req.SessionIDs {
@@ -50,14 +58,21 @@ func (s *SessionService) UpdateReviewStatus(ctx context.Context, req models.Upda
 	return models.UpdateReviewResponse{Results: results}, updated
 }
 
+func validateReviewRequest(req models.UpdateReviewRequest) error {
+	if !models.ValidReviewAction(req.Action) {
+		return NewValidationError("action", fmt.Sprintf("unknown action %q", req.Action))
+	}
+	if models.ReviewAction(req.Action) == models.ReviewActionResolve && req.ResolutionReason == nil {
+		return NewValidationError("resolution_reason", "required for resolve action")
+	}
+	return nil
+}
+
 // updateSingleReview performs an atomic compare-and-transition on one session's
 // review_status. Returns the updated session or ErrConflict if the precondition
 // (expected current review_status) was not met.
+// Caller must validate req via validateReviewRequest before calling.
 func (s *SessionService) updateSingleReview(sessionID string, req models.UpdateReviewRequest) (*ent.AlertSession, error) {
-	if !models.ValidReviewAction(req.Action) {
-		return nil, NewValidationError("action", fmt.Sprintf("unknown action %q", req.Action))
-	}
-
 	writeCtx, cancel := context.WithTimeoutCause(
 		context.Background(), 5*time.Second,
 		fmt.Errorf("update review status for %s: db write timed out", sessionID),
@@ -103,9 +118,6 @@ func (s *SessionService) updateSingleReview(sessionID string, req models.UpdateR
 		}
 
 	case models.ReviewActionResolve:
-		if req.ResolutionReason == nil {
-			return nil, NewValidationError("resolution_reason", "required for resolve action")
-		}
 		if err := s.doResolve(writeCtx, tx, sessionID, req.Actor, *req.ResolutionReason, req.Note, now); err != nil {
 			return nil, err
 		}

--- a/pkg/services/session_service_review_test.go
+++ b/pkg/services/session_service_review_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/codeready-toolchain/tarsy/ent"
 	"github.com/codeready-toolchain/tarsy/ent/alertsession"
 	"github.com/codeready-toolchain/tarsy/ent/sessionreviewactivity"
 	"github.com/codeready-toolchain/tarsy/ent/sessionscore"
@@ -72,19 +73,41 @@ func seedReviewSession(t *testing.T, service *SessionService, reviewStatus strin
 	return sess.ID
 }
 
+// doReview is a test helper that calls UpdateReviewStatus for a single session
+// and returns the updated ent session (or fails the test on error).
+func doReview(t *testing.T, service *SessionService, id string, req models.UpdateReviewRequest) *ent.AlertSession {
+	t.Helper()
+	req.SessionIDs = []string{id}
+	resp, updated := service.UpdateReviewStatus(context.Background(), req)
+	require.Len(t, resp.Results, 1)
+	require.True(t, resp.Results[0].Success, "expected success, got error: %s", resp.Results[0].Error)
+	require.Len(t, updated, 1)
+	return updated[0]
+}
+
+// doReviewExpectError is a test helper that calls UpdateReviewStatus for a single
+// session and asserts that the per-session result reports a failure.
+func doReviewExpectError(t *testing.T, service *SessionService, id string, req models.UpdateReviewRequest) string {
+	t.Helper()
+	req.SessionIDs = []string{id}
+	resp, updated := service.UpdateReviewStatus(context.Background(), req)
+	require.Len(t, resp.Results, 1)
+	require.False(t, resp.Results[0].Success, "expected failure, but got success")
+	assert.Empty(t, updated)
+	return resp.Results[0].Error
+}
+
 func TestSessionService_UpdateReviewStatus(t *testing.T) {
 	client := testdb.NewTestClient(t)
 	service := setupTestSessionService(t, client.Client)
-	ctx := context.Background()
 
 	t.Run("claim from needs_review", func(t *testing.T) {
 		id := seedReviewSession(t, service, "needs_review", "")
 
-		sess, err := service.UpdateReviewStatus(ctx, id, models.UpdateReviewRequest{
+		sess := doReview(t, service, id, models.UpdateReviewRequest{
 			Action: "claim",
 			Actor:  "john@test.com",
 		})
-		require.NoError(t, err)
 		require.NotNil(t, sess.ReviewStatus)
 		assert.Equal(t, alertsession.ReviewStatusInProgress, *sess.ReviewStatus)
 		assert.NotNil(t, sess.Assignee)
@@ -95,11 +118,10 @@ func TestSessionService_UpdateReviewStatus(t *testing.T) {
 	t.Run("claim reassignment from in_progress", func(t *testing.T) {
 		id := seedReviewSession(t, service, "in_progress", "john@test.com")
 
-		sess, err := service.UpdateReviewStatus(ctx, id, models.UpdateReviewRequest{
+		sess := doReview(t, service, id, models.UpdateReviewRequest{
 			Action: "claim",
 			Actor:  "bob@test.com",
 		})
-		require.NoError(t, err)
 		require.NotNil(t, sess.ReviewStatus)
 		assert.Equal(t, alertsession.ReviewStatusInProgress, *sess.ReviewStatus)
 		assert.Equal(t, "bob@test.com", *sess.Assignee)
@@ -108,21 +130,20 @@ func TestSessionService_UpdateReviewStatus(t *testing.T) {
 	t.Run("claim conflict from resolved", func(t *testing.T) {
 		id := seedReviewSession(t, service, "resolved", "john@test.com")
 
-		_, err := service.UpdateReviewStatus(ctx, id, models.UpdateReviewRequest{
+		errMsg := doReviewExpectError(t, service, id, models.UpdateReviewRequest{
 			Action: "claim",
 			Actor:  "bob@test.com",
 		})
-		assert.ErrorIs(t, err, ErrConflict)
+		assert.Contains(t, errMsg, "conflict")
 	})
 
 	t.Run("unclaim from in_progress", func(t *testing.T) {
 		id := seedReviewSession(t, service, "in_progress", "john@test.com")
 
-		sess, err := service.UpdateReviewStatus(ctx, id, models.UpdateReviewRequest{
+		sess := doReview(t, service, id, models.UpdateReviewRequest{
 			Action: "unclaim",
 			Actor:  "john@test.com",
 		})
-		require.NoError(t, err)
 		require.NotNil(t, sess.ReviewStatus)
 		assert.Equal(t, alertsession.ReviewStatusNeedsReview, *sess.ReviewStatus)
 		assert.Nil(t, sess.Assignee)
@@ -132,11 +153,11 @@ func TestSessionService_UpdateReviewStatus(t *testing.T) {
 	t.Run("unclaim conflict from needs_review", func(t *testing.T) {
 		id := seedReviewSession(t, service, "needs_review", "")
 
-		_, err := service.UpdateReviewStatus(ctx, id, models.UpdateReviewRequest{
+		errMsg := doReviewExpectError(t, service, id, models.UpdateReviewRequest{
 			Action: "unclaim",
 			Actor:  "john@test.com",
 		})
-		assert.ErrorIs(t, err, ErrConflict)
+		assert.Contains(t, errMsg, "conflict")
 	})
 
 	t.Run("resolve from in_progress", func(t *testing.T) {
@@ -144,13 +165,12 @@ func TestSessionService_UpdateReviewStatus(t *testing.T) {
 		reason := "actioned"
 		note := "Applied fix from runbook"
 
-		sess, err := service.UpdateReviewStatus(ctx, id, models.UpdateReviewRequest{
+		sess := doReview(t, service, id, models.UpdateReviewRequest{
 			Action:           "resolve",
 			Actor:            "john@test.com",
 			ResolutionReason: &reason,
 			Note:             &note,
 		})
-		require.NoError(t, err)
 		require.NotNil(t, sess.ReviewStatus)
 		assert.Equal(t, alertsession.ReviewStatusResolved, *sess.ReviewStatus)
 		assert.NotNil(t, sess.ResolvedAt)
@@ -164,18 +184,18 @@ func TestSessionService_UpdateReviewStatus(t *testing.T) {
 		id := seedReviewSession(t, service, "needs_review", "")
 		reason := "dismissed"
 
-		sess, err := service.UpdateReviewStatus(ctx, id, models.UpdateReviewRequest{
+		sess := doReview(t, service, id, models.UpdateReviewRequest{
 			Action:           "resolve",
 			Actor:            "john@test.com",
 			ResolutionReason: &reason,
 		})
-		require.NoError(t, err)
 		require.NotNil(t, sess.ReviewStatus)
 		assert.Equal(t, alertsession.ReviewStatusResolved, *sess.ReviewStatus)
 		assert.Equal(t, "john@test.com", *sess.Assignee, "direct resolve should auto-assign")
 		assert.Equal(t, alertsession.ResolutionReasonDismissed, *sess.ResolutionReason)
 
 		// Direct resolve should create 2 activity rows (claim + resolve).
+		ctx := context.Background()
 		activities, err := service.GetReviewActivity(ctx, id)
 		require.NoError(t, err)
 		require.Len(t, activities, 2)
@@ -183,36 +203,35 @@ func TestSessionService_UpdateReviewStatus(t *testing.T) {
 		assert.Equal(t, "resolve", string(activities[1].Action))
 	})
 
-	t.Run("resolve without resolution_reason returns validation error", func(t *testing.T) {
+	t.Run("resolve without resolution_reason returns error", func(t *testing.T) {
 		id := seedReviewSession(t, service, "in_progress", "john@test.com")
 
-		_, err := service.UpdateReviewStatus(ctx, id, models.UpdateReviewRequest{
+		errMsg := doReviewExpectError(t, service, id, models.UpdateReviewRequest{
 			Action: "resolve",
 			Actor:  "john@test.com",
 		})
-		assert.True(t, IsValidationError(err))
+		assert.Contains(t, errMsg, "resolution_reason")
 	})
 
 	t.Run("resolve conflict from resolved", func(t *testing.T) {
 		id := seedReviewSession(t, service, "resolved", "john@test.com")
 		reason := "actioned"
 
-		_, err := service.UpdateReviewStatus(ctx, id, models.UpdateReviewRequest{
+		errMsg := doReviewExpectError(t, service, id, models.UpdateReviewRequest{
 			Action:           "resolve",
 			Actor:            "bob@test.com",
 			ResolutionReason: &reason,
 		})
-		assert.ErrorIs(t, err, ErrConflict)
+		assert.Contains(t, errMsg, "conflict")
 	})
 
 	t.Run("reopen from resolved", func(t *testing.T) {
 		id := seedReviewSession(t, service, "resolved", "john@test.com")
 
-		sess, err := service.UpdateReviewStatus(ctx, id, models.UpdateReviewRequest{
+		sess := doReview(t, service, id, models.UpdateReviewRequest{
 			Action: "reopen",
 			Actor:  "bob@test.com",
 		})
-		require.NoError(t, err)
 		require.NotNil(t, sess.ReviewStatus)
 		assert.Equal(t, alertsession.ReviewStatusNeedsReview, *sess.ReviewStatus)
 		assert.Nil(t, sess.Assignee)
@@ -225,27 +244,27 @@ func TestSessionService_UpdateReviewStatus(t *testing.T) {
 	t.Run("reopen conflict from needs_review", func(t *testing.T) {
 		id := seedReviewSession(t, service, "needs_review", "")
 
-		_, err := service.UpdateReviewStatus(ctx, id, models.UpdateReviewRequest{
+		errMsg := doReviewExpectError(t, service, id, models.UpdateReviewRequest{
 			Action: "reopen",
 			Actor:  "john@test.com",
 		})
-		assert.ErrorIs(t, err, ErrConflict)
+		assert.Contains(t, errMsg, "conflict")
 	})
 
 	t.Run("update_note on resolved session", func(t *testing.T) {
 		id := seedReviewSession(t, service, "resolved", "john@test.com")
 		note := "Updated fix details"
 
-		sess, err := service.UpdateReviewStatus(ctx, id, models.UpdateReviewRequest{
+		sess := doReview(t, service, id, models.UpdateReviewRequest{
 			Action: "update_note",
 			Actor:  "john@test.com",
 			Note:   &note,
 		})
-		require.NoError(t, err)
 		require.NotNil(t, sess.ResolutionNote)
 		assert.Equal(t, "Updated fix details", *sess.ResolutionNote)
 		assert.Equal(t, alertsession.ReviewStatusResolved, *sess.ReviewStatus, "status should not change")
 
+		ctx := context.Background()
 		activities, err := service.GetReviewActivity(ctx, id)
 		require.NoError(t, err)
 		last := activities[len(activities)-1]
@@ -260,16 +279,14 @@ func TestSessionService_UpdateReviewStatus(t *testing.T) {
 
 		// Set a note first.
 		note := "Some note"
-		_, err := service.UpdateReviewStatus(ctx, id, models.UpdateReviewRequest{
+		doReview(t, service, id, models.UpdateReviewRequest{
 			Action: "update_note", Actor: "john@test.com", Note: &note,
 		})
-		require.NoError(t, err)
 
 		// Clear it.
-		sess, err := service.UpdateReviewStatus(ctx, id, models.UpdateReviewRequest{
+		sess := doReview(t, service, id, models.UpdateReviewRequest{
 			Action: "update_note", Actor: "john@test.com",
 		})
-		require.NoError(t, err)
 		assert.Nil(t, sess.ResolutionNote)
 	})
 
@@ -277,22 +294,64 @@ func TestSessionService_UpdateReviewStatus(t *testing.T) {
 		id := seedReviewSession(t, service, "in_progress", "john@test.com")
 		note := "Should fail"
 
-		_, err := service.UpdateReviewStatus(ctx, id, models.UpdateReviewRequest{
+		errMsg := doReviewExpectError(t, service, id, models.UpdateReviewRequest{
 			Action: "update_note",
 			Actor:  "john@test.com",
 			Note:   &note,
 		})
-		assert.ErrorIs(t, err, ErrConflict)
+		assert.Contains(t, errMsg, "conflict")
 	})
 
-	t.Run("unknown action returns validation error", func(t *testing.T) {
+	t.Run("unknown action returns error", func(t *testing.T) {
 		id := seedReviewSession(t, service, "needs_review", "")
 
-		_, err := service.UpdateReviewStatus(ctx, id, models.UpdateReviewRequest{
+		errMsg := doReviewExpectError(t, service, id, models.UpdateReviewRequest{
 			Action: "bogus",
 			Actor:  "john@test.com",
 		})
-		assert.True(t, IsValidationError(err))
+		assert.Contains(t, errMsg, "unknown action")
+	})
+
+	t.Run("multiple sessions in one call", func(t *testing.T) {
+		id1 := seedReviewSession(t, service, "needs_review", "")
+		id2 := seedReviewSession(t, service, "needs_review", "")
+
+		resp, updated := service.UpdateReviewStatus(context.Background(), models.UpdateReviewRequest{
+			SessionIDs: []string{id1, id2},
+			Action:     "claim",
+			Actor:      "john@test.com",
+		})
+		require.Len(t, resp.Results, 2)
+		assert.True(t, resp.Results[0].Success)
+		assert.True(t, resp.Results[1].Success)
+		assert.Len(t, updated, 2)
+	})
+
+	t.Run("partial failure when some sessions conflict", func(t *testing.T) {
+		goodID := seedReviewSession(t, service, "needs_review", "")
+		conflictID := seedReviewSession(t, service, "resolved", "john@test.com")
+
+		resp, updated := service.UpdateReviewStatus(context.Background(), models.UpdateReviewRequest{
+			SessionIDs: []string{goodID, conflictID},
+			Action:     "claim",
+			Actor:      "bob@test.com",
+		})
+		require.Len(t, resp.Results, 2)
+		assert.True(t, resp.Results[0].Success)
+		assert.False(t, resp.Results[1].Success)
+		assert.NotEmpty(t, resp.Results[1].Error)
+		assert.Len(t, updated, 1)
+		assert.Equal(t, goodID, updated[0].ID)
+	})
+
+	t.Run("empty session IDs returns empty results", func(t *testing.T) {
+		resp, updated := service.UpdateReviewStatus(context.Background(), models.UpdateReviewRequest{
+			SessionIDs: []string{},
+			Action:     "claim",
+			Actor:      "john@test.com",
+		})
+		assert.Empty(t, resp.Results)
+		assert.Empty(t, updated)
 	})
 }
 
@@ -305,16 +364,14 @@ func TestSessionService_GetReviewActivity(t *testing.T) {
 		id := seedReviewSession(t, service, "needs_review", "")
 
 		// Perform claim then resolve — creates 2 activity rows.
-		_, err := service.UpdateReviewStatus(ctx, id, models.UpdateReviewRequest{
+		doReview(t, service, id, models.UpdateReviewRequest{
 			Action: "claim", Actor: "john@test.com",
 		})
-		require.NoError(t, err)
 
 		reason := "actioned"
-		_, err = service.UpdateReviewStatus(ctx, id, models.UpdateReviewRequest{
+		doReview(t, service, id, models.UpdateReviewRequest{
 			Action: "resolve", Actor: "john@test.com", ResolutionReason: &reason,
 		})
-		require.NoError(t, err)
 
 		activities, err := service.GetReviewActivity(ctx, id)
 		require.NoError(t, err)

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -221,10 +221,12 @@ func (app *TestApp) patchJSON(t *testing.T, path string, body interface{}, expec
 	return result
 }
 
-// PatchReview calls PATCH /api/v1/sessions/:id/review.
+// PatchReview calls PATCH /api/v1/sessions/review with the given session ID
+// injected into the body as session_ids. Returns the raw response map.
 func (app *TestApp) PatchReview(t *testing.T, sessionID string, body map[string]interface{}) map[string]interface{} {
 	t.Helper()
-	return app.patchJSON(t, "/api/v1/sessions/"+sessionID+"/review", body, http.StatusOK)
+	body["session_ids"] = []string{sessionID}
+	return app.patchJSON(t, "/api/v1/sessions/review", body, http.StatusOK)
 }
 
 // GetReviewActivity calls GET /api/v1/sessions/:id/review-activity.

--- a/test/e2e/review_workflow_test.go
+++ b/test/e2e/review_workflow_test.go
@@ -73,7 +73,9 @@ func TestE2E_ReviewWorkflow_CompletedSession(t *testing.T) {
 	claimResp := app.PatchReview(t, sessionID, map[string]interface{}{
 		"action": "claim",
 	})
-	assert.Equal(t, "in_progress", claimResp["review_status"])
+	claimResults := claimResp["results"].([]interface{})
+	require.Len(t, claimResults, 1)
+	assert.Equal(t, true, claimResults[0].(map[string]interface{})["success"])
 
 	ws.WaitForEvent(t, func(e WSEvent) bool {
 		return e.Type == "review.status" && e.Parsed["review_status"] == "in_progress"
@@ -85,8 +87,9 @@ func TestE2E_ReviewWorkflow_CompletedSession(t *testing.T) {
 		"resolution_reason": "actioned",
 		"note":              "Verified and closed.",
 	})
-	assert.Equal(t, "resolved", resolveResp["review_status"])
-	assert.Equal(t, "actioned", resolveResp["resolution_reason"])
+	resolveResults := resolveResp["results"].([]interface{})
+	require.Len(t, resolveResults, 1)
+	assert.Equal(t, true, resolveResults[0].(map[string]interface{})["success"])
 
 	ws.WaitForEvent(t, func(e WSEvent) bool {
 		return e.Type == "review.status" && e.Parsed["review_status"] == "resolved"

--- a/web/dashboard/src/components/dashboard/DashboardView.tsx
+++ b/web/dashboard/src/components/dashboard/DashboardView.tsx
@@ -59,7 +59,7 @@ import {
 import type { SessionFilter, PaginationState, SortState, DashboardTab, TriageFilter } from '../../types/dashboard.ts';
 import type { DashboardSessionItem, ActiveSessionItem, QueuedSessionItem } from '../../types/session.ts';
 import { REVIEW_ACTION } from '../../types/api.ts';
-import type { DashboardListParams, TriageGroup, TriageGroupKey, TriageGroupParams } from '../../types/api.ts';
+import type { DashboardListParams, TriageGroup, TriageGroupKey, TriageGroupParams, UpdateReviewResponse } from '../../types/api.ts';
 import type { FilterOptionsResponse } from '../../types/system.ts';
 import type { SessionProgressPayload } from '../../types/events.ts';
 import {
@@ -606,9 +606,20 @@ export function DashboardView() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [triageFilters]);
 
+  const checkReviewResults = (resp: UpdateReviewResponse) => {
+    const failures = resp.results.filter((r) => !r.success);
+    if (failures.length > 0) {
+      const msg = failures.length === 1
+        ? `Failed for session ${failures[0].session_id}: ${failures[0].error}`
+        : `Failed for ${failures.length} sessions: ${failures.map((f) => f.error).join('; ')}`;
+      setTriageError(msg);
+    }
+  };
+
   const handleBulkTriageClaim = async (sessionIds: string[]) => {
     try {
-      await updateReview({ session_ids: sessionIds, action: REVIEW_ACTION.CLAIM });
+      const resp = await updateReview({ session_ids: sessionIds, action: REVIEW_ACTION.CLAIM });
+      checkReviewResults(resp);
       fetchAllTriageGroups();
     } catch (err) {
       setTriageError(handleAPIError(err));
@@ -617,7 +628,8 @@ export function DashboardView() {
 
   const handleBulkTriageUnclaim = async (sessionIds: string[]) => {
     try {
-      await updateReview({ session_ids: sessionIds, action: REVIEW_ACTION.UNCLAIM });
+      const resp = await updateReview({ session_ids: sessionIds, action: REVIEW_ACTION.UNCLAIM });
+      checkReviewResults(resp);
       fetchAllTriageGroups();
     } catch (err) {
       setTriageError(handleAPIError(err));
@@ -626,7 +638,8 @@ export function DashboardView() {
 
   const handleBulkTriageResolve = async (sessionIds: string[], reason: string, note?: string) => {
     try {
-      await updateReview({ session_ids: sessionIds, action: REVIEW_ACTION.RESOLVE, resolution_reason: reason, note });
+      const resp = await updateReview({ session_ids: sessionIds, action: REVIEW_ACTION.RESOLVE, resolution_reason: reason, note });
+      checkReviewResults(resp);
       fetchAllTriageGroups();
     } catch (err) {
       setTriageError(handleAPIError(err));
@@ -635,7 +648,8 @@ export function DashboardView() {
 
   const handleBulkTriageReopen = async (sessionIds: string[]) => {
     try {
-      await updateReview({ session_ids: sessionIds, action: REVIEW_ACTION.REOPEN });
+      const resp = await updateReview({ session_ids: sessionIds, action: REVIEW_ACTION.REOPEN });
+      checkReviewResults(resp);
       fetchAllTriageGroups();
     } catch (err) {
       setTriageError(handleAPIError(err));
@@ -648,7 +662,8 @@ export function DashboardView() {
 
   const handleTriageResolve = async (sessionId: string, reason: string, note?: string) => {
     try {
-      await updateReview({ session_ids: [sessionId], action: REVIEW_ACTION.RESOLVE, resolution_reason: reason, note });
+      const resp = await updateReview({ session_ids: [sessionId], action: REVIEW_ACTION.RESOLVE, resolution_reason: reason, note });
+      checkReviewResults(resp);
       fetchAllTriageGroups();
     } catch (err) {
       setTriageError(handleAPIError(err));
@@ -657,7 +672,8 @@ export function DashboardView() {
 
   const handleTriageUpdateNote = async (sessionId: string, note: string) => {
     try {
-      await updateReview({ session_ids: [sessionId], action: REVIEW_ACTION.UPDATE_NOTE, note: note || undefined });
+      const resp = await updateReview({ session_ids: [sessionId], action: REVIEW_ACTION.UPDATE_NOTE, note: note || undefined });
+      checkReviewResults(resp);
       fetchAllTriageGroups();
     } catch (err) {
       setTriageError(handleAPIError(err));

--- a/web/dashboard/src/components/dashboard/DashboardView.tsx
+++ b/web/dashboard/src/components/dashboard/DashboardView.tsx
@@ -606,63 +606,9 @@ export function DashboardView() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [triageFilters]);
 
-  const handleTriageClaim = async (sessionId: string) => {
-    try {
-      await updateReview({ session_ids: [sessionId], action: REVIEW_ACTION.CLAIM });
-      fetchAllTriageGroups();
-    } catch (err) {
-      setTriageError(handleAPIError(err));
-    }
-  };
-
-  const handleTriageUnclaim = async (sessionId: string) => {
-    try {
-      await updateReview({ session_ids: [sessionId], action: REVIEW_ACTION.UNCLAIM });
-      fetchAllTriageGroups();
-    } catch (err) {
-      setTriageError(handleAPIError(err));
-    }
-  };
-
-  const handleTriageResolve = async (sessionId: string, reason: string, note?: string) => {
-    try {
-      await updateReview({ session_ids: [sessionId], action: REVIEW_ACTION.RESOLVE, resolution_reason: reason, note });
-      fetchAllTriageGroups();
-    } catch (err) {
-      setTriageError(handleAPIError(err));
-    }
-  };
-
-  const handleTriageReopen = async (sessionId: string) => {
-    try {
-      await updateReview({ session_ids: [sessionId], action: REVIEW_ACTION.REOPEN });
-      fetchAllTriageGroups();
-    } catch (err) {
-      setTriageError(handleAPIError(err));
-    }
-  };
-
-  const handleTriageUpdateNote = async (sessionId: string, note: string) => {
-    try {
-      await updateReview({ session_ids: [sessionId], action: REVIEW_ACTION.UPDATE_NOTE, note: note || undefined });
-      fetchAllTriageGroups();
-    } catch (err) {
-      setTriageError(handleAPIError(err));
-    }
-  };
-
   const handleBulkTriageClaim = async (sessionIds: string[]) => {
     try {
       await updateReview({ session_ids: sessionIds, action: REVIEW_ACTION.CLAIM });
-      fetchAllTriageGroups();
-    } catch (err) {
-      setTriageError(handleAPIError(err));
-    }
-  };
-
-  const handleBulkTriageResolve = async (sessionIds: string[], reason: string, note?: string) => {
-    try {
-      await updateReview({ session_ids: sessionIds, action: REVIEW_ACTION.RESOLVE, resolution_reason: reason, note });
       fetchAllTriageGroups();
     } catch (err) {
       setTriageError(handleAPIError(err));
@@ -678,9 +624,40 @@ export function DashboardView() {
     }
   };
 
+  const handleBulkTriageResolve = async (sessionIds: string[], reason: string, note?: string) => {
+    try {
+      await updateReview({ session_ids: sessionIds, action: REVIEW_ACTION.RESOLVE, resolution_reason: reason, note });
+      fetchAllTriageGroups();
+    } catch (err) {
+      setTriageError(handleAPIError(err));
+    }
+  };
+
   const handleBulkTriageReopen = async (sessionIds: string[]) => {
     try {
       await updateReview({ session_ids: sessionIds, action: REVIEW_ACTION.REOPEN });
+      fetchAllTriageGroups();
+    } catch (err) {
+      setTriageError(handleAPIError(err));
+    }
+  };
+
+  const handleTriageClaim = (sessionId: string) => handleBulkTriageClaim([sessionId]);
+  const handleTriageUnclaim = (sessionId: string) => handleBulkTriageUnclaim([sessionId]);
+  const handleTriageReopen = (sessionId: string) => handleBulkTriageReopen([sessionId]);
+
+  const handleTriageResolve = async (sessionId: string, reason: string, note?: string) => {
+    try {
+      await updateReview({ session_ids: [sessionId], action: REVIEW_ACTION.RESOLVE, resolution_reason: reason, note });
+      fetchAllTriageGroups();
+    } catch (err) {
+      setTriageError(handleAPIError(err));
+    }
+  };
+
+  const handleTriageUpdateNote = async (sessionId: string, note: string) => {
+    try {
+      await updateReview({ session_ids: [sessionId], action: REVIEW_ACTION.UPDATE_NOTE, note: note || undefined });
       fetchAllTriageGroups();
     } catch (err) {
       setTriageError(handleAPIError(err));

--- a/web/dashboard/src/components/dashboard/DashboardView.tsx
+++ b/web/dashboard/src/components/dashboard/DashboardView.tsx
@@ -58,6 +58,7 @@ import {
 } from '../../constants/eventTypes.ts';
 import type { SessionFilter, PaginationState, SortState, DashboardTab, TriageFilter } from '../../types/dashboard.ts';
 import type { DashboardSessionItem, ActiveSessionItem, QueuedSessionItem } from '../../types/session.ts';
+import { REVIEW_ACTION } from '../../types/api.ts';
 import type { DashboardListParams, TriageGroup, TriageGroupKey, TriageGroupParams } from '../../types/api.ts';
 import type { FilterOptionsResponse } from '../../types/system.ts';
 import type { SessionProgressPayload } from '../../types/events.ts';
@@ -607,7 +608,7 @@ export function DashboardView() {
 
   const handleTriageClaim = async (sessionId: string) => {
     try {
-      await updateReview(sessionId, { action: 'claim' });
+      await updateReview({ session_ids: [sessionId], action: REVIEW_ACTION.CLAIM });
       fetchAllTriageGroups();
     } catch (err) {
       setTriageError(handleAPIError(err));
@@ -616,7 +617,7 @@ export function DashboardView() {
 
   const handleTriageUnclaim = async (sessionId: string) => {
     try {
-      await updateReview(sessionId, { action: 'unclaim' });
+      await updateReview({ session_ids: [sessionId], action: REVIEW_ACTION.UNCLAIM });
       fetchAllTriageGroups();
     } catch (err) {
       setTriageError(handleAPIError(err));
@@ -625,7 +626,7 @@ export function DashboardView() {
 
   const handleTriageResolve = async (sessionId: string, reason: string, note?: string) => {
     try {
-      await updateReview(sessionId, { action: 'resolve', resolution_reason: reason, note });
+      await updateReview({ session_ids: [sessionId], action: REVIEW_ACTION.RESOLVE, resolution_reason: reason, note });
       fetchAllTriageGroups();
     } catch (err) {
       setTriageError(handleAPIError(err));
@@ -634,7 +635,7 @@ export function DashboardView() {
 
   const handleTriageReopen = async (sessionId: string) => {
     try {
-      await updateReview(sessionId, { action: 'reopen' });
+      await updateReview({ session_ids: [sessionId], action: REVIEW_ACTION.REOPEN });
       fetchAllTriageGroups();
     } catch (err) {
       setTriageError(handleAPIError(err));
@@ -643,7 +644,43 @@ export function DashboardView() {
 
   const handleTriageUpdateNote = async (sessionId: string, note: string) => {
     try {
-      await updateReview(sessionId, { action: 'update_note', note: note || undefined });
+      await updateReview({ session_ids: [sessionId], action: REVIEW_ACTION.UPDATE_NOTE, note: note || undefined });
+      fetchAllTriageGroups();
+    } catch (err) {
+      setTriageError(handleAPIError(err));
+    }
+  };
+
+  const handleBulkTriageClaim = async (sessionIds: string[]) => {
+    try {
+      await updateReview({ session_ids: sessionIds, action: REVIEW_ACTION.CLAIM });
+      fetchAllTriageGroups();
+    } catch (err) {
+      setTriageError(handleAPIError(err));
+    }
+  };
+
+  const handleBulkTriageResolve = async (sessionIds: string[], reason: string, note?: string) => {
+    try {
+      await updateReview({ session_ids: sessionIds, action: REVIEW_ACTION.RESOLVE, resolution_reason: reason, note });
+      fetchAllTriageGroups();
+    } catch (err) {
+      setTriageError(handleAPIError(err));
+    }
+  };
+
+  const handleBulkTriageUnclaim = async (sessionIds: string[]) => {
+    try {
+      await updateReview({ session_ids: sessionIds, action: REVIEW_ACTION.UNCLAIM });
+      fetchAllTriageGroups();
+    } catch (err) {
+      setTriageError(handleAPIError(err));
+    }
+  };
+
+  const handleBulkTriageReopen = async (sessionIds: string[]) => {
+    try {
+      await updateReview({ session_ids: sessionIds, action: REVIEW_ACTION.REOPEN });
       fetchAllTriageGroups();
     } catch (err) {
       setTriageError(handleAPIError(err));
@@ -1021,6 +1058,10 @@ export function DashboardView() {
           onResolve={handleTriageResolve}
           onReopen={handleTriageReopen}
           onUpdateNote={handleTriageUpdateNote}
+          onBulkClaim={handleBulkTriageClaim}
+          onBulkResolve={handleBulkTriageResolve}
+          onBulkUnclaim={handleBulkTriageUnclaim}
+          onBulkReopen={handleBulkTriageReopen}
           onPageChange={handleTriagePageChange}
           onPageSizeChange={handleTriagePageSizeChange}
         />

--- a/web/dashboard/src/components/dashboard/ResolveModal.tsx
+++ b/web/dashboard/src/components/dashboard/ResolveModal.tsx
@@ -22,9 +22,10 @@ export interface ResolveModalProps {
   onClose: () => void;
   onResolve: (reason: string, note?: string) => void;
   loading?: boolean;
+  title?: string;
 }
 
-export function ResolveModal({ open, onClose, onResolve, loading }: ResolveModalProps) {
+export function ResolveModal({ open, onClose, onResolve, loading, title }: ResolveModalProps) {
   const [reason, setReason] = useState<string>('');
   const [note, setNote] = useState('');
 
@@ -45,7 +46,7 @@ export function ResolveModal({ open, onClose, onResolve, loading }: ResolveModal
       <DialogTitle sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
           <CheckCircleOutline color="success" />
-          <Typography variant="h6">Resolve Session</Typography>
+          <Typography variant="h6">{title ?? 'Resolve Session'}</Typography>
         </Box>
         <IconButton onClick={onClose} size="small">
           <Close />

--- a/web/dashboard/src/components/dashboard/ResolveModal.tsx
+++ b/web/dashboard/src/components/dashboard/ResolveModal.tsx
@@ -31,7 +31,7 @@ export function ResolveModal({ open, onClose, onResolve, loading, title }: Resol
 
   useEffect(() => {
     if (open) {
-      setReason('');
+      setReason('actioned');
       setNote('');
     }
   }, [open]);

--- a/web/dashboard/src/components/dashboard/TriageGroupedList.tsx
+++ b/web/dashboard/src/components/dashboard/TriageGroupedList.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import {
   Box,
   Paper,
@@ -12,6 +12,8 @@ import {
   TableContainer,
   TableHead,
   TableRow,
+  Checkbox,
+  Button,
 } from '@mui/material';
 import {
   ExpandMore,
@@ -20,6 +22,7 @@ import {
   RateReview,
   AssignmentTurnedIn,
   CheckCircleOutline,
+  Close,
 } from '@mui/icons-material';
 import { PaginationControls } from './PaginationControls.tsx';
 import { TriageSessionRow, type TriageGroup as TriageGroupName } from './TriageSessionRow.tsx';
@@ -34,6 +37,10 @@ interface TriageGroupedListProps {
   onEditNote: (sessionId: string, currentNote: string) => void;
   onPageChange: (group: TriageGroupKey, page: number) => void;
   onPageSizeChange: (group: TriageGroupKey, pageSize: number) => void;
+  onBulkClaim?: (sessionIds: string[]) => void;
+  onBulkResolve?: (sessionIds: string[]) => void;
+  onBulkUnclaim?: (sessionIds: string[]) => void;
+  onBulkReopen?: (sessionIds: string[]) => void;
   actionLoading?: boolean;
 }
 
@@ -83,6 +90,18 @@ const groups_config: GroupConfig[] = [
   },
 ];
 
+const SELECTABLE_GROUPS = new Set<TriageGroupName>(['needs_review', 'in_progress', 'resolved']);
+const MAX_BULK_SELECTION = 50;
+
+type SelectionState = Record<TriageGroupKey, Set<string>>;
+
+const emptySelection = (): SelectionState => ({
+  investigating: new Set(),
+  needs_review: new Set(),
+  in_progress: new Set(),
+  resolved: new Set(),
+});
+
 export function TriageGroupedList({
   groups,
   onClaim,
@@ -92,6 +111,10 @@ export function TriageGroupedList({
   onEditNote,
   onPageChange,
   onPageSizeChange,
+  onBulkClaim,
+  onBulkResolve,
+  onBulkUnclaim,
+  onBulkReopen,
   actionLoading,
 }: TriageGroupedListProps) {
   const STORAGE_KEY = 'triage-open-sections';
@@ -108,6 +131,13 @@ export function TriageGroupedList({
     return initial;
   });
 
+  const [selection, setSelection] = useState<SelectionState>(emptySelection);
+
+  // Clear selection when group data changes (e.g. after a bulk action refetch).
+  useEffect(() => {
+    setSelection(emptySelection());
+  }, [groups]);
+
   const toggleSection = (key: string) => {
     setOpenSections((prev) => {
       const next = { ...prev, [key]: !prev[key] };
@@ -116,6 +146,35 @@ export function TriageGroupedList({
     });
   };
 
+  const toggleSelect = useCallback((groupKey: TriageGroupKey, sessionId: string) => {
+    setSelection((prev) => {
+      const next = new Set(prev[groupKey]);
+      if (next.has(sessionId)) {
+        next.delete(sessionId);
+      } else if (next.size < MAX_BULK_SELECTION) {
+        next.add(sessionId);
+      }
+      return { ...prev, [groupKey]: next };
+    });
+  }, []);
+
+  const toggleSelectAll = useCallback((groupKey: TriageGroupKey, sessionIds: string[]) => {
+    setSelection((prev) => {
+      const current = prev[groupKey];
+      const allSelected = sessionIds.length > 0 && sessionIds.every((id) => current.has(id));
+      return {
+        ...prev,
+        [groupKey]: allSelected
+          ? new Set<string>()
+          : new Set(sessionIds.slice(0, MAX_BULK_SELECTION)),
+      };
+    });
+  }, []);
+
+  const clearGroupSelection = useCallback((groupKey: TriageGroupKey) => {
+    setSelection((prev) => ({ ...prev, [groupKey]: new Set<string>() }));
+  }, []);
+
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
       {groups_config.map((group) => {
@@ -123,8 +182,14 @@ export function TriageGroupedList({
         if (!groupData) return null;
         const isOpen = openSections[group.key];
         const isEmpty = groupData.count === 0;
+        const selectable = SELECTABLE_GROUPS.has(group.key);
+        const selectedIds = selection[group.dataKey];
+        const selectedCount = selectedIds.size;
+        const atSelectionLimit = selectedCount >= MAX_BULK_SELECTION;
+        const visibleIds = groupData.sessions.map((s) => s.id);
+        const allVisibleSelected = visibleIds.length > 0 && visibleIds.every((id) => selectedIds.has(id));
+        const someVisibleSelected = visibleIds.some((id) => selectedIds.has(id));
 
-        // Compact single-line header for empty investigating
         if (group.key === 'investigating' && isEmpty) {
           return (
             <Paper key={group.key} variant="outlined">
@@ -228,10 +293,106 @@ export function TriageGroupedList({
                 </Box>
               ) : (
                 <>
+                  {/* Bulk action toolbar */}
+                  {selectable && selectedCount > 0 && (
+                    <Box
+                      sx={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: 1,
+                        px: 2,
+                        py: 0.75,
+                        backgroundColor: 'action.selected',
+                        borderBottom: '1px solid',
+                        borderColor: 'divider',
+                      }}
+                    >
+                      <Typography variant="body2" fontWeight={600} sx={{ mr: 1 }}>
+                        {selectedCount} selected{atSelectionLimit ? ` (max ${MAX_BULK_SELECTION})` : ''}
+                      </Typography>
+
+                      {group.key === 'needs_review' && (
+                        <>
+                          <Button
+                            size="small"
+                            variant="contained"
+                            disabled={actionLoading}
+                            onClick={() => onBulkClaim?.([...selectedIds])}
+                            sx={{ textTransform: 'none', fontSize: '0.75rem', py: 0.25, px: 1.5 }}
+                          >
+                            Claim All
+                          </Button>
+                          <Button
+                            size="small"
+                            variant="contained"
+                            color="success"
+                            disabled={actionLoading}
+                            onClick={() => onBulkResolve?.([...selectedIds])}
+                            sx={{ textTransform: 'none', fontSize: '0.75rem', py: 0.25, px: 1.5 }}
+                          >
+                            Resolve All
+                          </Button>
+                        </>
+                      )}
+
+                      {group.key === 'in_progress' && (
+                        <>
+                          <Button
+                            size="small"
+                            variant="contained"
+                            color="success"
+                            disabled={actionLoading}
+                            onClick={() => onBulkResolve?.([...selectedIds])}
+                            sx={{ textTransform: 'none', fontSize: '0.75rem', py: 0.25, px: 1.5 }}
+                          >
+                            Resolve All
+                          </Button>
+                          <Button
+                            size="small"
+                            variant="outlined"
+                            disabled={actionLoading}
+                            onClick={() => onBulkUnclaim?.([...selectedIds])}
+                            sx={{ textTransform: 'none', fontSize: '0.75rem', py: 0.25, px: 1.5 }}
+                          >
+                            Unclaim All
+                          </Button>
+                        </>
+                      )}
+
+                      {group.key === 'resolved' && (
+                        <Button
+                          size="small"
+                          variant="outlined"
+                          disabled={actionLoading}
+                          onClick={() => onBulkReopen?.([...selectedIds])}
+                          sx={{ textTransform: 'none', fontSize: '0.75rem', py: 0.25, px: 1.5 }}
+                        >
+                          Reopen All
+                        </Button>
+                      )}
+
+                      <Box sx={{ flexGrow: 1 }} />
+                      <IconButton size="small" onClick={() => clearGroupSelection(group.dataKey)}>
+                        <Close sx={{ fontSize: 16 }} />
+                      </IconButton>
+                    </Box>
+                  )}
+
                   <TableContainer>
                     <Table size="small">
                       <TableHead>
                         <TableRow>
+                          {selectable && (
+                            <TableCell padding="checkbox">
+                              <Checkbox
+                                size="small"
+                                checked={allVisibleSelected}
+                                indeterminate={someVisibleSelected && !allVisibleSelected}
+                                disabled={atSelectionLimit && !allVisibleSelected}
+                                onChange={() => toggleSelectAll(group.dataKey, visibleIds)}
+                              />
+                            </TableCell>
+                          )}
                           <TableCell sx={{ fontWeight: 600 }}>Status</TableCell>
                           <TableCell sx={{ fontWeight: 600 }}>Type</TableCell>
                           <TableCell sx={{ fontWeight: 600 }}>Submitted by</TableCell>
@@ -247,6 +408,9 @@ export function TriageGroupedList({
                             key={session.id}
                             session={session}
                             group={group.key}
+                            selected={selectedIds.has(session.id)}
+                            selectionDisabled={atSelectionLimit}
+                            onToggleSelect={selectable ? (id) => toggleSelect(group.dataKey, id) : undefined}
                             onClaim={onClaim}
                             onUnclaim={onUnclaim}
                             onResolve={onResolve}

--- a/web/dashboard/src/components/dashboard/TriageSessionRow.tsx
+++ b/web/dashboard/src/components/dashboard/TriageSessionRow.tsx
@@ -6,6 +6,7 @@ import {
   Tooltip,
   IconButton,
   Box,
+  Checkbox,
 } from '@mui/material';
 import { Undo, StickyNote2Outlined, Check, NotInterested } from '@mui/icons-material';
 import { useNavigate } from 'react-router-dom';
@@ -22,6 +23,9 @@ export type TriageGroup = 'investigating' | 'needs_review' | 'in_progress' | 're
 interface TriageSessionRowProps {
   session: DashboardSessionItem;
   group: TriageGroup;
+  selected?: boolean;
+  selectionDisabled?: boolean;
+  onToggleSelect?: (sessionId: string) => void;
   onClaim?: (sessionId: string) => void;
   onUnclaim?: (sessionId: string) => void;
   onResolve?: (sessionId: string) => void;
@@ -38,6 +42,9 @@ const resolutionReasonConfig: Record<string, { label: string }> = {
 export function TriageSessionRow({
   session,
   group,
+  selected,
+  selectionDisabled,
+  onToggleSelect,
   onClaim,
   onUnclaim,
   onResolve,
@@ -52,17 +59,28 @@ export function TriageSessionRow({
   };
 
   const hasActions = group !== 'investigating';
+  const selectable = hasActions && onToggleSelect;
 
   return (
     <TableRow
       hover
+      selected={selected}
       onClick={handleRowClick}
       sx={{
         cursor: 'pointer',
         '&:hover .triage-actions': { opacity: 1 },
       }}
     >
-      {/* Status + Summary hover + Resolution reason */}
+      {selectable && (
+        <TableCell padding="checkbox" onClick={(e) => e.stopPropagation()}>
+          <Checkbox
+            size="small"
+            checked={!!selected}
+            disabled={!selected && selectionDisabled}
+            onChange={() => onToggleSelect(session.id)}
+          />
+        </TableCell>
+      )}
       <TableCell>
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
           <StatusBadge status={session.status} size="small" />

--- a/web/dashboard/src/components/dashboard/TriageView.tsx
+++ b/web/dashboard/src/components/dashboard/TriageView.tsx
@@ -24,6 +24,10 @@ interface TriageViewProps {
   onResolve: (sessionId: string, reason: string, note?: string) => Promise<void>;
   onReopen: (sessionId: string) => Promise<void>;
   onUpdateNote: (sessionId: string, note: string) => Promise<void>;
+  onBulkClaim: (sessionIds: string[]) => Promise<void>;
+  onBulkResolve: (sessionIds: string[], reason: string, note?: string) => Promise<void>;
+  onBulkUnclaim: (sessionIds: string[]) => Promise<void>;
+  onBulkReopen: (sessionIds: string[]) => Promise<void>;
   onPageChange: (group: TriageGroupKey, page: number) => void;
   onPageSizeChange: (group: TriageGroupKey, pageSize: number) => void;
 }
@@ -40,10 +44,14 @@ export function TriageView({
   onResolve,
   onReopen,
   onUpdateNote,
+  onBulkClaim,
+  onBulkResolve,
+  onBulkUnclaim,
+  onBulkReopen,
   onPageChange,
   onPageSizeChange,
 }: TriageViewProps) {
-  const [resolveSessionId, setResolveSessionId] = useState<string | null>(null);
+  const [resolveSessionIds, setResolveSessionIds] = useState<string[] | null>(null);
   const [editNoteState, setEditNoteState] = useState<{ sessionId: string; note: string } | null>(null);
   const [actionLoading, setActionLoading] = useState(false);
   const [snackbar, setSnackbar] = useState<{ message: string; severity: 'success' | 'error' } | null>(null);
@@ -69,14 +77,18 @@ export function TriageView({
   };
 
   const handleResolveClick = (sessionId: string) => {
-    setResolveSessionId(sessionId);
+    setResolveSessionIds([sessionId]);
   };
 
   const handleResolveConfirm = (reason: string, note?: string) => {
-    if (!resolveSessionId) return;
-    const sessionId = resolveSessionId;
-    setResolveSessionId(null);
-    withAction(() => onResolve(sessionId, reason, note));
+    if (!resolveSessionIds) return;
+    const ids = resolveSessionIds;
+    setResolveSessionIds(null);
+    if (ids.length === 1) {
+      withAction(() => onResolve(ids[0], reason, note));
+    } else {
+      withAction(() => onBulkResolve(ids, reason, note));
+    }
   };
 
   const handleReopen = (sessionId: string) => {
@@ -94,10 +106,30 @@ export function TriageView({
     withAction(() => onUpdateNote(sessionId, note));
   };
 
+  const handleBulkClaim = (sessionIds: string[]) => {
+    withAction(() => onBulkClaim(sessionIds));
+  };
+
+  const handleBulkResolve = (sessionIds: string[]) => {
+    setResolveSessionIds(sessionIds);
+  };
+
+  const handleBulkUnclaim = (sessionIds: string[]) => {
+    withAction(() => onBulkUnclaim(sessionIds));
+  };
+
+  const handleBulkReopen = (sessionIds: string[]) => {
+    withAction(() => onBulkReopen(sessionIds));
+  };
+
   const hasAnyData = Object.values(groups).some(g => g !== null);
   const emptyGroups: Record<TriageGroupKey, TriageGroup | null> = {
     investigating: null, needs_review: null, in_progress: null, resolved: null,
   };
+
+  const resolveModalTitle = resolveSessionIds && resolveSessionIds.length > 1
+    ? `Resolve ${resolveSessionIds.length} Sessions`
+    : undefined;
 
   if (error) {
     return (
@@ -152,16 +184,21 @@ export function TriageView({
         onResolve={handleResolveClick}
         onReopen={handleReopen}
         onEditNote={handleEditNote}
+        onBulkClaim={handleBulkClaim}
+        onBulkResolve={handleBulkResolve}
+        onBulkUnclaim={handleBulkUnclaim}
+        onBulkReopen={handleBulkReopen}
         onPageChange={onPageChange}
         onPageSizeChange={onPageSizeChange}
         actionLoading={actionLoading}
       />
 
       <ResolveModal
-        open={resolveSessionId !== null}
-        onClose={() => setResolveSessionId(null)}
+        open={resolveSessionIds !== null}
+        onClose={() => setResolveSessionIds(null)}
         onResolve={handleResolveConfirm}
         loading={actionLoading}
+        title={resolveModalTitle}
       />
 
       <EditNoteModal

--- a/web/dashboard/src/services/api.ts
+++ b/web/dashboard/src/services/api.ts
@@ -184,12 +184,9 @@ export async function getTriageGroup(group: TriageGroupKey, params?: TriageGroup
   return response.data;
 }
 
-export async function updateReview(
-  sessionId: string,
-  req: UpdateReviewRequest,
-): Promise<UpdateReviewResponse> {
+export async function updateReview(req: UpdateReviewRequest): Promise<UpdateReviewResponse> {
   const response = await client.patch<UpdateReviewResponse>(
-    `/api/v1/sessions/${sessionId}/review`,
+    '/api/v1/sessions/review',
     req,
   );
   return response.data;

--- a/web/dashboard/src/types/api.ts
+++ b/web/dashboard/src/types/api.ts
@@ -106,24 +106,34 @@ export interface TriageGroupParams {
 }
 
 /** Allowed review workflow actions. */
-export type ReviewAction = 'claim' | 'unclaim' | 'resolve' | 'reopen' | 'update_note';
+export const REVIEW_ACTION = {
+  CLAIM: 'claim',
+  UNCLAIM: 'unclaim',
+  RESOLVE: 'resolve',
+  REOPEN: 'reopen',
+  UPDATE_NOTE: 'update_note',
+} as const;
 
-/** Request body for PATCH /sessions/:id/review. */
+export type ReviewAction = (typeof REVIEW_ACTION)[keyof typeof REVIEW_ACTION];
+
+/** Request body for PATCH /api/v1/sessions/review. */
 export interface UpdateReviewRequest {
+  session_ids: string[];
   action: ReviewAction;
   resolution_reason?: string;
   note?: string;
 }
 
-/** Response from PATCH /sessions/:id/review. */
+/** Per-session result from a review action. */
+export interface UpdateReviewResult {
+  session_id: string;
+  success: boolean;
+  error?: string;
+}
+
+/** Response from PATCH /api/v1/sessions/review. */
 export interface UpdateReviewResponse {
-  id: string;
-  review_status: string;
-  assignee: string | null;
-  assigned_at: string | null;
-  resolved_at: string | null;
-  resolution_reason: string | null;
-  resolution_note: string | null;
+  results: UpdateReviewResult[];
 }
 
 /** Single entry in the review activity log. */


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bulk triage: select up to 50 sessions to claim, resolve, unclaim, reopen, or add notes in one action
  * Per-group selection controls, header checkboxes, bulk action toolbar, and per-row selection checkboxes
  * Resolve modal shows dynamic title for multiple sessions; UI surfaces per-session failures from bulk responses

* **Documentation**
  * API docs updated: PATCH /api/v1/sessions/review accepts session_ids[] and returns per-session results with success/error details
<!-- end of auto-generated comment: release notes by coderabbit.ai -->