### PR TITLE
Loading/Loaded Skills label for load_skills tool call in dashboard

### DIFF
--- a/pkg/agent/controller/tool_execution.go
+++ b/pkg/agent/controller/tool_execution.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/codeready-toolchain/tarsy/pkg/agent"
 	"github.com/codeready-toolchain/tarsy/pkg/agent/orchestrator"
+	"github.com/codeready-toolchain/tarsy/pkg/agent/skill"
 	"github.com/codeready-toolchain/tarsy/pkg/events"
 	"github.com/codeready-toolchain/tarsy/pkg/mcp"
 	"github.com/codeready-toolchain/tarsy/pkg/metrics"
@@ -69,8 +70,10 @@ func executeToolCall(
 		if orchestrator.IsOrchestrationTool(toolName) {
 			serverID = orchestrator.OrchestrationServerName
 			toolType = ToolTypeOrchestrator
-		} else {
+		} else if skill.IsSkillTool(toolName) {
 			toolType = ToolTypeSkill
+		} else {
+			toolType = ToolTypeMCP
 		}
 	} else {
 		toolType = ToolTypeMCP

--- a/pkg/agent/controller/tool_execution_test.go
+++ b/pkg/agent/controller/tool_execution_test.go
@@ -339,3 +339,69 @@ func TestExecuteToolCall_ToolError(t *testing.T) {
 	assert.NotNil(t, interactions[0].ErrorMessage)
 	assert.Contains(t, *interactions[0].ErrorMessage, "server unavailable")
 }
+
+func TestExecuteToolCall_ToolTypeClassification(t *testing.T) {
+	tests := []struct {
+		name         string
+		toolCallName string
+		wantToolType string
+	}{
+		{
+			name:         "MCP tool with server prefix",
+			toolCallName: "kubernetes.get_pods",
+			wantToolType: string(ToolTypeMCP),
+		},
+		{
+			name:         "MCP tool with double-underscore format",
+			toolCallName: "kubernetes__get_pods",
+			wantToolType: string(ToolTypeMCP),
+		},
+		{
+			name:         "load_skill classified as skill",
+			toolCallName: "load_skill",
+			wantToolType: string(ToolTypeSkill),
+		},
+		{
+			name:         "dispatch_agent classified as orchestrator",
+			toolCallName: "dispatch_agent",
+			wantToolType: string(ToolTypeOrchestrator),
+		},
+		{
+			name:         "malformed MCP name without server prefix stays MCP",
+			toolCallName: "resources_get",
+			wantToolType: string(ToolTypeMCP),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			toolExec := &mockToolExecutorFunc{
+				tools: []agent.ToolDefinition{{Name: tt.toolCallName}},
+				executeFn: func(_ context.Context, call agent.ToolCall) (*agent.ToolResult, error) {
+					return &agent.ToolResult{
+						CallID:  call.ID,
+						Name:    call.Name,
+						Content: "ok",
+					}, nil
+				},
+			}
+			execCtx := newTestExecCtx(t, &mockLLMClient{}, toolExec)
+			ctx := context.Background()
+			eventSeq := 0
+
+			executeToolCall(ctx, execCtx, agent.ToolCall{
+				ID:        "tc-classify",
+				Name:      tt.toolCallName,
+				Arguments: `{}`,
+			}, nil, &eventSeq)
+
+			events, err := execCtx.Services.Timeline.GetSessionTimeline(ctx, execCtx.SessionID)
+			require.NoError(t, err)
+			require.NotEmpty(t, events)
+
+			lastEvent := events[len(events)-1]
+			assert.Equal(t, tt.wantToolType, lastEvent.Metadata["tool_type"],
+				"tool_type metadata mismatch for %q", tt.toolCallName)
+		})
+	}
+}

--- a/pkg/agent/skill/tool_executor.go
+++ b/pkg/agent/skill/tool_executor.go
@@ -14,11 +14,17 @@ import (
 // Compile-time check that SkillToolExecutor implements agent.ToolExecutor.
 var _ agent.ToolExecutor = (*SkillToolExecutor)(nil)
 
-const toolLoadSkill = "load_skill"
+// ToolLoadSkill is the tool name used by the LLM to load skills.
+const ToolLoadSkill = "load_skill"
+
+// IsSkillTool reports whether name is a known skill tool.
+func IsSkillTool(name string) bool {
+	return name == ToolLoadSkill
+}
 
 // loadSkillTool is the tool definition exposed to the LLM.
 var loadSkillTool = agent.ToolDefinition{
-	Name:        toolLoadSkill,
+	Name:        ToolLoadSkill,
 	Description: "Load skills by name. Returns the full skill content for each requested skill.",
 	ParametersSchema: `{
   "type": "object",
@@ -73,7 +79,7 @@ func (s *SkillToolExecutor) ListTools(ctx context.Context) ([]agent.ToolDefiniti
 			return nil, fmt.Errorf("failed to list inner tools: %w", err)
 		}
 		for _, t := range innerTools {
-			if t.Name == toolLoadSkill {
+			if t.Name == ToolLoadSkill {
 				continue
 			}
 			tools = append(tools, t)
@@ -85,7 +91,7 @@ func (s *SkillToolExecutor) ListTools(ctx context.Context) ([]agent.ToolDefiniti
 
 // Execute routes the tool call to load_skill or the inner executor.
 func (s *SkillToolExecutor) Execute(ctx context.Context, call agent.ToolCall) (*agent.ToolResult, error) {
-	if call.Name == toolLoadSkill {
+	if call.Name == ToolLoadSkill {
 		return s.executeLoadSkill(call)
 	}
 	if s.inner != nil {

--- a/pkg/agent/skill/tool_executor_test.go
+++ b/pkg/agent/skill/tool_executor_test.go
@@ -44,6 +44,24 @@ func loadSkillArgs(names ...string) string {
 	return string(args)
 }
 
+func TestIsSkillTool(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{"load_skill", true},
+		{"dispatch_agent", false},
+		{"kubernetes.get_pods", false},
+		{"resources_get", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsSkillTool(tt.name))
+		})
+	}
+}
+
 func TestSkillToolExecutor_ListTools_PrependToInner(t *testing.T) {
 	inner := agent.NewStubToolExecutor([]agent.ToolDefinition{
 		{Name: "server1.read_file", Description: "Reads a file"},

--- a/web/dashboard/src/components/streaming/StreamingContentRenderer.tsx
+++ b/web/dashboard/src/components/streaming/StreamingContentRenderer.tsx
@@ -232,6 +232,22 @@ const StreamingContentRenderer = memo(({ item }: StreamingContentRendererProps) 
     const toolName = (item.metadata?.tool_name as string) || 'unknown';
     const isSkill = (item.metadata?.tool_type as string) === TOOL_TYPE.SKILL;
     const paletteKey = isSkill ? 'info' : 'primary';
+
+    let displayName = toolName;
+    let statusLabel = 'Executing...';
+    if (isSkill) {
+      displayName = 'Loading Skills';
+      const rawArgs = item.metadata?.arguments;
+      let names: string[] = [];
+      if (typeof rawArgs === 'string') {
+        try { names = (JSON.parse(rawArgs) as { names?: string[] }).names || []; } catch { /* ignore */ }
+      } else if (rawArgs && typeof rawArgs === 'object') {
+        const parsed = rawArgs as { names?: string[] };
+        if (Array.isArray(parsed.names)) names = parsed.names;
+      }
+      statusLabel = names.length > 0 ? names.join(', ') : 'Loading...';
+    }
+
     return (
       <Box sx={{ ml: 4, my: 1, mr: 1 }}>
         <Box
@@ -272,10 +288,10 @@ const StreamingContentRenderer = memo(({ item }: StreamingContentRendererProps) 
               color: theme.palette[paletteKey].main,
             })}
           >
-            {toolName}
+            {displayName}
           </Typography>
           <Typography variant="caption" color="text.secondary" sx={{ fontSize: '0.8rem', flex: 1 }}>
-            {isSkill ? 'Loading skill...' : 'Executing...'}
+            {statusLabel}
           </Typography>
         </Box>
       </Box>

--- a/web/dashboard/src/components/streaming/StreamingContentRenderer.tsx
+++ b/web/dashboard/src/components/streaming/StreamingContentRenderer.tsx
@@ -5,6 +5,7 @@ import TypewriterText from './TypewriterText';
 import ContentCard from '../shared/ContentCard';
 import { TIMELINE_EVENT_TYPES } from '../../constants/eventTypes';
 import { TOOL_TYPE } from '../../constants/toolTypes';
+import { getSkillNamesLabel } from '../../utils/format';
 import { thoughtMarkdownComponents, remarkPlugins } from '../../utils/markdownComponents';
 
 /**
@@ -237,15 +238,7 @@ const StreamingContentRenderer = memo(({ item }: StreamingContentRendererProps) 
     let statusLabel = 'Executing...';
     if (isSkill) {
       displayName = 'Loading Skills';
-      const rawArgs = item.metadata?.arguments;
-      let names: string[] = [];
-      if (typeof rawArgs === 'string') {
-        try { names = (JSON.parse(rawArgs) as { names?: string[] }).names || []; } catch { /* ignore */ }
-      } else if (rawArgs && typeof rawArgs === 'object') {
-        const parsed = rawArgs as { names?: string[] };
-        if (Array.isArray(parsed.names)) names = parsed.names;
-      }
-      statusLabel = names.length > 0 ? names.join(', ') : 'Loading...';
+      statusLabel = getSkillNamesLabel(item.metadata?.arguments) ?? 'Loading...';
     }
 
     return (

--- a/web/dashboard/src/components/timeline/ToolCallItem.tsx
+++ b/web/dashboard/src/components/timeline/ToolCallItem.tsx
@@ -19,6 +19,16 @@ interface ToolCallItemProps {
 }
 
 /**
+ * Extract skill names from load_skill arguments into a friendly label.
+ * Returns null when the arguments don't match the expected shape.
+ */
+function getSkillNamesLabel(args: Record<string, unknown>): string | null {
+  const names = args?.names;
+  if (!Array.isArray(names) || names.length === 0) return null;
+  return (names as string[]).join(', ');
+}
+
+/**
  * Check if arguments are simple (flat key-value pairs with primitive values)
  */
 const isSimpleArguments = (args: Record<string, unknown> | null): boolean => {
@@ -112,7 +122,11 @@ function ToolCallItem({ item, expandAll = false, searchTerm }: ToolCallItemProps
     [searchTerm],
   );
 
+  const skillNamesLabel = isSkill ? getSkillNamesLabel(toolArguments) : null;
+  const displayName = isSkill ? 'Loaded Skills' : toolName;
+
   const getArgumentsPreview = (): string => {
+    if (skillNamesLabel) return skillNamesLabel;
     if (!toolArguments || typeof toolArguments !== 'object') return '';
     const keys = Object.keys(toolArguments);
     if (keys.length === 0) return '(no arguments)';
@@ -161,7 +175,7 @@ function ToolCallItem({ item, expandAll = false, searchTerm }: ToolCallItemProps
       >
         <StatusIcon sx={(theme) => ({ fontSize: 18, color: theme.palette[accentKey].main })} />
         <Typography variant="body2" sx={(theme) => ({ fontFamily: 'monospace', fontWeight: 600, fontSize: '0.9rem', color: theme.palette[accentKey].main })}>
-          {searchTerm ? highlightSearchTermNodes(toolName, searchTerm) : toolName}
+          {searchTerm ? highlightSearchTermNodes(displayName, searchTerm) : displayName}
         </Typography>
         <Typography variant="caption" color="text.secondary" sx={{ fontSize: '0.8rem', flex: 1, lineHeight: 1.4 }}>
           {getArgumentsPreview()}

--- a/web/dashboard/src/components/timeline/ToolCallItem.tsx
+++ b/web/dashboard/src/components/timeline/ToolCallItem.tsx
@@ -4,7 +4,7 @@ import { ExpandMore, ExpandLess, CheckCircle, Error as ErrorIcon, InfoOutlined, 
 import ReactMarkdown from 'react-markdown';
 import JsonDisplay from '../shared/JsonDisplay';
 import CopyButton from '../shared/CopyButton';
-import { formatDurationMs } from '../../utils/format';
+import { formatDurationMs, getSkillNamesLabel } from '../../utils/format';
 import { highlightSearchTermNodes } from '../../utils/search';
 import { remarkPlugins, thoughtMarkdownComponents } from '../../utils/markdownComponents';
 import { rehypeSearchHighlight } from '../../utils/rehypeSearchHighlight';
@@ -16,16 +16,6 @@ interface ToolCallItemProps {
   item: FlowItem;
   expandAll?: boolean;
   searchTerm?: string;
-}
-
-/**
- * Extract skill names from load_skill arguments into a friendly label.
- * Returns null when the arguments don't match the expected shape.
- */
-function getSkillNamesLabel(args: Record<string, unknown>): string | null {
-  const names = args?.names;
-  if (!Array.isArray(names) || names.length === 0) return null;
-  return (names as string[]).join(', ');
 }
 
 /**

--- a/web/dashboard/src/utils/format.ts
+++ b/web/dashboard/src/utils/format.ts
@@ -122,15 +122,14 @@ export function liveDuration(startIso: string | null | undefined): string {
  * Returns a comma-separated label, or null when the arguments don't contain skill names.
  */
 export function getSkillNamesLabel(rawArgs: unknown): string | null {
-  let parsed: Record<string, unknown>;
+  let parsed: unknown;
   if (typeof rawArgs === 'string') {
-    try { parsed = JSON.parse(rawArgs) as Record<string, unknown>; } catch { return null; }
-  } else if (rawArgs && typeof rawArgs === 'object' && !Array.isArray(rawArgs)) {
-    parsed = rawArgs as Record<string, unknown>;
+    try { parsed = JSON.parse(rawArgs); } catch { return null; }
   } else {
-    return null;
+    parsed = rawArgs;
   }
-  const names = parsed.names;
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+  const names = (parsed as Record<string, unknown>).names;
   if (!Array.isArray(names) || names.length === 0) return null;
   return (names as string[]).join(', ');
 }

--- a/web/dashboard/src/utils/format.ts
+++ b/web/dashboard/src/utils/format.ts
@@ -114,6 +114,28 @@ export function liveDuration(startIso: string | null | undefined): string {
 }
 
 // ────────────────────────────────────────────────────────────
+// Skill names
+// ────────────────────────────────────────────────────────────
+
+/**
+ * Extract skill names from raw load_skill arguments (JSON string or parsed object).
+ * Returns a comma-separated label, or null when the arguments don't contain skill names.
+ */
+export function getSkillNamesLabel(rawArgs: unknown): string | null {
+  let parsed: Record<string, unknown>;
+  if (typeof rawArgs === 'string') {
+    try { parsed = JSON.parse(rawArgs) as Record<string, unknown>; } catch { return null; }
+  } else if (rawArgs && typeof rawArgs === 'object' && !Array.isArray(rawArgs)) {
+    parsed = rawArgs as Record<string, unknown>;
+  } else {
+    return null;
+  }
+  const names = parsed.names;
+  if (!Array.isArray(names) || names.length === 0) return null;
+  return (names as string[]).join(', ');
+}
+
+// ────────────────────────────────────────────────────────────
 // Tokens
 // ────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
<img width="459" height="77" alt="image" src="https://github.com/user-attachments/assets/c695c320-bfc7-4ea0-b3a3-6213dcdb65a1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Display names now distinguish skill operations from other tools for clearer context.
  * Status captions show loaded skill names when available, with a "Loading..." fallback.
  * Argument previews indicate which skills are being processed during execution.

* **Improvements**
  * Tool-type classification refined so timeline entries more accurately reflect skill vs. orchestrator calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->