### PR TITLE
Memory - Phase 2 - Retrieval + Injection (agent uses memory)

### DIFF
--- a/cmd/tarsy/main.go
+++ b/cmd/tarsy/main.go
@@ -268,26 +268,27 @@ func main() {
 		slog.Info("Slack notifications disabled")
 	}
 
-	executor := queue.NewRealSessionExecutor(cfg, dbClient.Client, llmClient, eventPublisher, mcpFactory, runbookService)
-
-	// Initialize memory service if memory extraction is enabled
+	// Initialize memory service if memory is enabled (used by session, chat, and scoring executors)
 	var memoryService *memory.Service
-	if memCfg := config.ResolvedMemoryConfig(cfg.Defaults); memCfg != nil {
-		embedder, embErr := memory.NewEmbedder(memCfg.Embedding)
+	var memCfg *config.MemoryConfig
+	if resolved := config.ResolvedMemoryConfig(cfg.Defaults); resolved != nil {
+		embedder, embErr := memory.NewEmbedder(resolved.Embedding)
 		if embErr != nil {
-			slog.Error("Failed to create embedder — memory extraction disabled", "error", embErr)
+			slog.Error("Failed to create embedder — memory disabled", "error", embErr)
 		} else {
-			memoryService = memory.NewService(dbClient.Client, dbClient.DB(), embedder, memCfg)
+			memoryService = memory.NewService(dbClient.Client, dbClient.DB(), embedder, resolved)
 			if valErr := memoryService.ValidateDimensions(ctx); valErr != nil {
 				slog.Error("Embedding dimension validation failed", "error", valErr)
 				os.Exit(1)
 			}
+			memCfg = resolved
 			slog.Info("Investigation memory enabled",
-				"provider", memCfg.Embedding.Provider, "model", memCfg.Embedding.Model,
-				"dimensions", memCfg.Embedding.Dimensions)
+				"provider", resolved.Embedding.Provider, "model", resolved.Embedding.Model,
+				"dimensions", resolved.Embedding.Dimensions)
 		}
 	}
 
+	executor := queue.NewRealSessionExecutor(cfg, dbClient.Client, llmClient, eventPublisher, mcpFactory, runbookService, memoryService, memCfg)
 	scoringExecutor := queue.NewScoringExecutor(cfg, dbClient.Client, llmClient, eventPublisher, runbookService, memoryService)
 
 	// 6. Start worker pool (before HTTP server)
@@ -311,7 +312,7 @@ func main() {
 			SessionTimeout:    cfg.Queue.SessionTimeout,
 			HeartbeatInterval: cfg.Queue.HeartbeatInterval,
 		},
-		runbookService,
+		runbookService, memoryService, memCfg,
 	)
 	slog.Info("Chat message executor initialized")
 

--- a/deploy/config/tarsy.yaml.example
+++ b/deploy/config/tarsy.yaml.example
@@ -118,6 +118,21 @@ defaults:
   #   llm_provider: "gemini-3-flash"      # Default LLM provider for scoring
   #   llm_backend: "google-native"        # Default LLM backend for scoring
   
+  # Investigation memory — learns from past investigations and injects relevant
+  # memories into future sessions via semantic retrieval (pgvector cosine similarity).
+  # Extraction runs automatically in the scoring stage; no extra infra needed.
+  # Requires pgvector extension and the investigation_memories table (created by migration).
+  # memory:
+  #   enabled: true                              # Enable investigation memory (default: false)
+  #   max_inject: 5                              # Max memories auto-injected into system prompt (default: 5)
+  #   reflector_memory_limit: 20                 # Max existing memories shown to Reflector for dedup (default: 20)
+  #   embedding:                                 # Embedding model for semantic retrieval
+  #     provider: "google"                       # google | openai (default: google)
+  #     model: "gemini-embedding-2-preview"      # Model name (default: gemini-embedding-2-preview)
+  #     api_key_env: "GOOGLE_API_KEY"            # Env var for API key (default: GOOGLE_API_KEY)
+  #     dimensions: 768                          # Output dimensions — must match pgvector column (default: 768)
+  #     # base_url: ""                           # Optional custom endpoint for compatible APIs
+
   # Default alert type for new sessions (used in UI dropdown)
   alert_type: "kubernetes"
   

--- a/docs/proposals/investigation-memory-design.md
+++ b/docs/proposals/investigation-memory-design.md
@@ -736,7 +736,7 @@ Ent auto-generates the join table. Both directions are natural queries: `session
 
 **Result:** Memories are extracted and stored after every scored investigation.
 
-### Phase 2: Retrieval + Injection (agent uses memory)
+### Phase 2: Retrieval + Injection (agent uses memory) - DONE
 
 1. `MemoryRetriever` — pgvector similarity search within project
 2. `MemoryBriefing` on `ExecutionContext`

--- a/pkg/agent/context.go
+++ b/pkg/agent/context.go
@@ -66,6 +66,10 @@ type ExecutionContext struct {
 	// failed to initialize. Used by the prompt builder to warn the LLM.
 	// nil when all servers initialized successfully.
 	FailedServers map[string]string
+
+	// MemoryBriefing holds pre-retrieved memories for Tier 4 prompt injection.
+	// nil when memory is disabled or no relevant memories exist.
+	MemoryBriefing *MemoryBriefing
 }
 
 // ServiceBundle groups all service dependencies needed during execution.
@@ -202,6 +206,21 @@ type SubAgentResultCollector interface {
 	// HasPending returns true if any dispatched sub-agents haven't delivered
 	// results yet.
 	HasPending() bool
+}
+
+// MemoryBriefing carries pre-retrieved memories for auto-injection into the
+// agent's system prompt (Tier 4) and for excluding from tool search results.
+type MemoryBriefing struct {
+	Memories    []MemoryHint
+	InjectedIDs []string
+}
+
+// MemoryHint is a single memory formatted for prompt injection.
+type MemoryHint struct {
+	ID       string
+	Content  string
+	Category string
+	Valence  string
 }
 
 // ChatContext carries chat-specific data for controllers.

--- a/pkg/agent/orchestrator/runner.go
+++ b/pkg/agent/orchestrator/runner.go
@@ -401,6 +401,10 @@ func (r *SubAgentRunner) createSubAgentToolExecutor(
 		executor = skill.NewSkillToolExecutor(executor, r.deps.Config.SkillRegistry, resolvedConfig.OnDemandSkillNameSet())
 	}
 
+	if r.deps.WrapToolExecutor != nil {
+		executor = r.deps.WrapToolExecutor(executor)
+	}
+
 	return executor
 }
 

--- a/pkg/agent/orchestrator/runner.go
+++ b/pkg/agent/orchestrator/runner.go
@@ -255,6 +255,12 @@ func (r *SubAgentRunner) runSubAgent(
 	toolExecutor := r.createSubAgentToolExecutor(ctx, resolvedConfig, logger)
 	defer func() { _ = toolExecutor.Close() }()
 
+	// MemoryBriefing is intentionally omitted: Tier 4 memories are matched
+	// against alert data, not the sub-agent's dynamic task, so injecting them
+	// would add noise. The orchestrator already has the briefing and can
+	// incorporate relevant learnings into task descriptions. Sub-agents still
+	// have the recall_past_investigations tool via WrapToolExecutor for
+	// on-demand retrieval.
 	execCtx := &agent.ExecutionContext{
 		SessionID:      r.sessionID,
 		StageID:        r.stageID,

--- a/pkg/agent/orchestrator/types.go
+++ b/pkg/agent/orchestrator/types.go
@@ -41,6 +41,11 @@ type SubAgentDeps struct {
 	AlertData      string
 	AlertType      string
 	RunbookContent string
+
+	// WrapToolExecutor is an optional function that wraps a ToolExecutor with
+	// additional layers (e.g., memory tool). Called after skill wrapping.
+	// nil when no additional wrapping is needed.
+	WrapToolExecutor func(agent.ToolExecutor) agent.ToolExecutor
 }
 
 // OrchestratorGuardrails holds resolved orchestrator limits

--- a/pkg/agent/prompt/instructions.go
+++ b/pkg/agent/prompt/instructions.go
@@ -111,6 +111,9 @@ func (b *PromptBuilder) ComposeInstructions(execCtx *agent.ExecutionContext) str
 		sections = append(sections, "## Agent-Specific Instructions\n\n"+execCtx.Config.CustomInstructions)
 	}
 
+	// Tier 4: Memory hints from past investigations (investigation sessions only)
+	sections = appendMemorySection(sections, execCtx)
+
 	return strings.Join(sections, "\n\n")
 }
 
@@ -215,6 +218,24 @@ func appendSkillSections(sections []string, execCtx *agent.ExecutionContext) []s
 		sections = append(sections, formatSkillCatalog(execCtx.Config.OnDemandSkills))
 	}
 	return sections
+}
+
+// appendMemorySection adds Tier 4 memory hints from past investigations.
+// Only appended when MemoryBriefing is non-nil and contains memories.
+func appendMemorySection(sections []string, execCtx *agent.ExecutionContext) []string {
+	if execCtx.MemoryBriefing == nil || len(execCtx.MemoryBriefing.Memories) == 0 {
+		return sections
+	}
+
+	var sb strings.Builder
+	sb.WriteString("## Lessons from Past Investigations\n\n")
+	sb.WriteString("The following are learnings from previous investigations of similar alerts.\n")
+	sb.WriteString("Consider them as hints — they may or may not apply to your current investigation.\n")
+	sb.WriteString("Do not treat them as rules.\n")
+	for _, m := range execCtx.MemoryBriefing.Memories {
+		sb.WriteString(fmt.Sprintf("\n- [%s, %s] %s", m.Category, m.Valence, m.Content))
+	}
+	return append(sections, sb.String())
 }
 
 // appendMCPInstructions adds Tier 2 MCP server instructions to a sections slice.

--- a/pkg/agent/prompt/instructions.go
+++ b/pkg/agent/prompt/instructions.go
@@ -222,6 +222,8 @@ func appendSkillSections(sections []string, execCtx *agent.ExecutionContext) []s
 
 // appendMemorySection adds Tier 4 memory hints from past investigations.
 // Only appended when MemoryBriefing is non-nil and contains memories.
+// Content is rendered inside delimiters and treated as untrusted data
+// to mitigate indirect prompt-injection via stored memories.
 func appendMemorySection(sections []string, execCtx *agent.ExecutionContext) []string {
 	if execCtx.MemoryBriefing == nil || len(execCtx.MemoryBriefing.Memories) == 0 {
 		return sections
@@ -231,10 +233,15 @@ func appendMemorySection(sections []string, execCtx *agent.ExecutionContext) []s
 	sb.WriteString("## Lessons from Past Investigations\n\n")
 	sb.WriteString("The following are learnings from previous investigations of similar alerts.\n")
 	sb.WriteString("Consider them as hints — they may or may not apply to your current investigation.\n")
-	sb.WriteString("Do not treat them as rules.\n")
-	for _, m := range execCtx.MemoryBriefing.Memories {
-		sb.WriteString(fmt.Sprintf("\n- [%s, %s] %s", m.Category, m.Valence, m.Content))
+	sb.WriteString("Do not treat them as rules.\n\n")
+	sb.WriteString("<memory_data>\n")
+	for i, m := range execCtx.MemoryBriefing.Memories {
+		if i > 0 {
+			sb.WriteByte('\n')
+		}
+		sb.WriteString(fmt.Sprintf("- [%s, %s] %s\n", m.Category, m.Valence, m.Content))
 	}
+	sb.WriteString("</memory_data>")
 	return append(sections, sb.String())
 }
 

--- a/pkg/agent/prompt/instructions_test.go
+++ b/pkg/agent/prompt/instructions_test.go
@@ -337,6 +337,132 @@ func TestComposeInstructions_MultipleRequiredSkills(t *testing.T) {
 	assert.Less(t, idxFirst, idxSecond, "skills should appear in order")
 }
 
+func TestComposeInstructions_MemoryTier4(t *testing.T) {
+	registry := newTestMCPRegistry(nil)
+	builder := NewPromptBuilder(registry)
+	execCtx := &agent.ExecutionContext{
+		Config: &agent.ResolvedAgentConfig{
+			CustomInstructions: "CUSTOM_TIER3_MARKER",
+		},
+		MemoryBriefing: &agent.MemoryBriefing{
+			Memories: []agent.MemoryHint{
+				{ID: "m1", Content: "Check PgBouncer health first", Category: "procedural", Valence: "positive"},
+				{ID: "m2", Content: "Normal error rate is 200/hr", Category: "semantic", Valence: "neutral"},
+			},
+			InjectedIDs: []string{"m1", "m2"},
+		},
+	}
+
+	result := builder.ComposeInstructions(execCtx)
+
+	assert.Contains(t, result, "Lessons from Past Investigations")
+	assert.Contains(t, result, "[procedural, positive] Check PgBouncer health first")
+	assert.Contains(t, result, "[semantic, neutral] Normal error rate is 200/hr")
+}
+
+func TestComposeInstructions_MemoryTier4Ordering(t *testing.T) {
+	registry := newTestMCPRegistry(nil)
+	builder := NewPromptBuilder(registry)
+	execCtx := &agent.ExecutionContext{
+		Config: &agent.ResolvedAgentConfig{
+			CustomInstructions: "CUSTOM_TIER3_MARKER",
+		},
+		MemoryBriefing: &agent.MemoryBriefing{
+			Memories: []agent.MemoryHint{
+				{ID: "m1", Content: "MEMORY_TIER4_MARKER", Category: "procedural", Valence: "positive"},
+			},
+			InjectedIDs: []string{"m1"},
+		},
+	}
+
+	result := builder.ComposeInstructions(execCtx)
+
+	idxT3 := strings.Index(result, "CUSTOM_TIER3_MARKER")
+	idxT4 := strings.Index(result, "MEMORY_TIER4_MARKER")
+	assert.Greater(t, idxT4, idxT3, "Tier 4 (memory) should come after Tier 3")
+}
+
+func TestComposeInstructions_NoMemoryBriefing(t *testing.T) {
+	registry := newTestMCPRegistry(nil)
+	builder := NewPromptBuilder(registry)
+	execCtx := &agent.ExecutionContext{
+		Config: &agent.ResolvedAgentConfig{},
+	}
+
+	result := builder.ComposeInstructions(execCtx)
+	assert.NotContains(t, result, "Lessons from Past Investigations")
+}
+
+func TestComposeInstructions_EmptyMemoryBriefing(t *testing.T) {
+	registry := newTestMCPRegistry(nil)
+	builder := NewPromptBuilder(registry)
+	execCtx := &agent.ExecutionContext{
+		Config:         &agent.ResolvedAgentConfig{},
+		MemoryBriefing: &agent.MemoryBriefing{},
+	}
+
+	result := builder.ComposeInstructions(execCtx)
+	assert.NotContains(t, result, "Lessons from Past Investigations")
+}
+
+func TestComposeChatInstructions_NoMemoryInjection(t *testing.T) {
+	registry := newTestMCPRegistry(nil)
+	builder := NewPromptBuilder(registry)
+	execCtx := &agent.ExecutionContext{
+		Config: &agent.ResolvedAgentConfig{},
+		MemoryBriefing: &agent.MemoryBriefing{
+			Memories: []agent.MemoryHint{
+				{ID: "m1", Content: "Should not appear in chat", Category: "procedural", Valence: "positive"},
+			},
+			InjectedIDs: []string{"m1"},
+		},
+	}
+
+	result := builder.ComposeChatInstructions(execCtx)
+	assert.NotContains(t, result, "Lessons from Past Investigations")
+	assert.NotContains(t, result, "Should not appear in chat")
+}
+
+func TestComposeInstructions_FullTierOrdering_WithMemory(t *testing.T) {
+	registry := newTestMCPRegistry(map[string]*config.MCPServerConfig{
+		"kubernetes-server": {Instructions: "MCP_TIER2_MARKER"},
+	})
+	builder := NewPromptBuilder(registry)
+	execCtx := &agent.ExecutionContext{
+		Config: &agent.ResolvedAgentConfig{
+			MCPServers:         []string{"kubernetes-server"},
+			CustomInstructions: "CUSTOM_TIER3_MARKER",
+			RequiredSkillContent: []agent.ResolvedSkill{
+				{Name: "k8s-basics", Body: "REQUIRED_SKILL_MARKER"},
+			},
+		},
+		FailedServers: map[string]string{
+			"broken-server": "FAILED_SERVER_MARKER",
+		},
+		MemoryBriefing: &agent.MemoryBriefing{
+			Memories: []agent.MemoryHint{
+				{ID: "m1", Content: "MEMORY_TIER4_MARKER", Category: "procedural", Valence: "positive"},
+			},
+			InjectedIDs: []string{"m1"},
+		},
+	}
+
+	result := builder.ComposeInstructions(execCtx)
+
+	idxT1 := strings.Index(result, "General SRE Agent Instructions")
+	idxT2 := strings.Index(result, "MCP_TIER2_MARKER")
+	idxWarn := strings.Index(result, "FAILED_SERVER_MARKER")
+	idxT25 := strings.Index(result, "REQUIRED_SKILL_MARKER")
+	idxT3 := strings.Index(result, "CUSTOM_TIER3_MARKER")
+	idxT4 := strings.Index(result, "MEMORY_TIER4_MARKER")
+
+	assert.Greater(t, idxT2, idxT1, "Tier 2 should come after Tier 1")
+	assert.Greater(t, idxWarn, idxT2, "Warnings should come after Tier 2")
+	assert.Greater(t, idxT25, idxWarn, "Tier 2.5 should come after warnings")
+	assert.Greater(t, idxT3, idxT25, "Tier 3 should come after Tier 2.5")
+	assert.Greater(t, idxT4, idxT3, "Tier 4 (memory) should come after Tier 3")
+}
+
 func TestComposeInstructions_OnlyOnDemandSkills(t *testing.T) {
 	registry := newTestMCPRegistry(nil)
 	builder := NewPromptBuilder(registry)

--- a/pkg/agent/prompt/instructions_test.go
+++ b/pkg/agent/prompt/instructions_test.go
@@ -356,6 +356,9 @@ func TestComposeInstructions_MemoryTier4(t *testing.T) {
 	result := builder.ComposeInstructions(execCtx)
 
 	assert.Contains(t, result, "Lessons from Past Investigations")
+	assert.Contains(t, result, "<memory_data>")
+	assert.Contains(t, result, "</memory_data>")
+	assert.Contains(t, result, "Consider them as hints")
 	assert.Contains(t, result, "[procedural, positive] Check PgBouncer health first")
 	assert.Contains(t, result, "[semantic, neutral] Normal error rate is 200/hr")
 }

--- a/pkg/memory/tool_executor.go
+++ b/pkg/memory/tool_executor.go
@@ -1,0 +1,200 @@
+package memory
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/codeready-toolchain/tarsy/pkg/agent"
+)
+
+// Compile-time check that ToolExecutor implements agent.ToolExecutor.
+var _ agent.ToolExecutor = (*ToolExecutor)(nil)
+
+// ToolRecallPastInvestigations is the tool name for on-demand memory search.
+const ToolRecallPastInvestigations = "recall_past_investigations"
+
+// IsMemoryTool reports whether name is a known memory tool.
+func IsMemoryTool(name string) bool {
+	return name == ToolRecallPastInvestigations
+}
+
+// recallTool is the tool definition exposed to the LLM.
+var recallTool = agent.ToolDefinition{
+	Name:        ToolRecallPastInvestigations,
+	Description: "Search learnings from past investigations of similar alerts. Use when you suspect a pattern you may have seen before, or want to check if previous investigations found useful context for this type of issue.",
+	ParametersSchema: `{
+  "type": "object",
+  "properties": {
+    "query": {
+      "type": "string",
+      "description": "What you want to recall — describe the situation, pattern, or question"
+    },
+    "limit": {
+      "type": "integer",
+      "description": "Max results to return (default: 10, max: 20)",
+      "default": 10
+    }
+  },
+  "required": ["query"]
+}`,
+}
+
+const (
+	recallDefaultLimit = 10
+	recallMaxLimit     = 20
+)
+
+// ToolExecutor wraps an inner agent.ToolExecutor and intercepts
+// recall_past_investigations calls. Everything else passes through.
+type ToolExecutor struct {
+	inner      agent.ToolExecutor
+	service    *Service
+	project    string
+	alertType  *string
+	chainID    *string
+	excludeIDs map[string]struct{}
+}
+
+// NewToolExecutor creates a memory tool executor.
+// inner may be nil (safely handled). excludeIDs contains memory IDs already
+// auto-injected into the prompt — they are filtered from tool results.
+func NewToolExecutor(
+	inner agent.ToolExecutor,
+	service *Service,
+	project string,
+	alertType *string,
+	chainID *string,
+	excludeIDs map[string]struct{},
+) *ToolExecutor {
+	return &ToolExecutor{
+		inner:      inner,
+		service:    service,
+		project:    project,
+		alertType:  alertType,
+		chainID:    chainID,
+		excludeIDs: excludeIDs,
+	}
+}
+
+// ListTools returns the combined tool set: recall_past_investigations + inner tools.
+func (te *ToolExecutor) ListTools(ctx context.Context) ([]agent.ToolDefinition, error) {
+	tools := []agent.ToolDefinition{recallTool}
+
+	if te.inner != nil {
+		innerTools, err := te.inner.ListTools(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list inner tools: %w", err)
+		}
+		for _, t := range innerTools {
+			if t.Name == ToolRecallPastInvestigations {
+				continue
+			}
+			tools = append(tools, t)
+		}
+	}
+
+	return tools, nil
+}
+
+// Execute routes the call to recall_past_investigations or the inner executor.
+func (te *ToolExecutor) Execute(ctx context.Context, call agent.ToolCall) (*agent.ToolResult, error) {
+	if call.Name == ToolRecallPastInvestigations {
+		return te.executeRecall(ctx, call)
+	}
+	if te.inner != nil {
+		return te.inner.Execute(ctx, call)
+	}
+	return &agent.ToolResult{
+		CallID:  call.ID,
+		Name:    call.Name,
+		Content: fmt.Sprintf("unknown tool: %s", call.Name),
+		IsError: true,
+	}, nil
+}
+
+// Close delegates to the inner executor.
+func (te *ToolExecutor) Close() error {
+	if te.inner != nil {
+		return te.inner.Close()
+	}
+	return nil
+}
+
+func (te *ToolExecutor) executeRecall(ctx context.Context, call agent.ToolCall) (*agent.ToolResult, error) {
+	var args struct {
+		Query string `json:"query"`
+		Limit int    `json:"limit"`
+	}
+	if err := json.Unmarshal([]byte(call.Arguments), &args); err != nil {
+		return &agent.ToolResult{
+			CallID:  call.ID,
+			Name:    call.Name,
+			Content: fmt.Sprintf("invalid arguments: %v", err),
+			IsError: true,
+		}, nil
+	}
+	if args.Query == "" {
+		return &agent.ToolResult{
+			CallID:  call.ID,
+			Name:    call.Name,
+			Content: "'query' is required and must be non-empty",
+			IsError: true,
+		}, nil
+	}
+
+	limit := args.Limit
+	if limit <= 0 {
+		limit = recallDefaultLimit
+	}
+	if limit > recallMaxLimit {
+		limit = recallMaxLimit
+	}
+
+	// Fetch extra candidates so we can filter out already-injected IDs
+	fetchLimit := limit + len(te.excludeIDs)
+	memories, err := te.service.FindSimilarWithBoosts(
+		ctx, te.project, args.Query, te.alertType, te.chainID, fetchLimit,
+	)
+	if err != nil {
+		return &agent.ToolResult{
+			CallID:  call.ID,
+			Name:    call.Name,
+			Content: fmt.Sprintf("memory search failed: %v", err),
+			IsError: true,
+		}, nil
+	}
+
+	// Filter out already-injected memories and apply limit
+	var filtered []Memory
+	for _, m := range memories {
+		if _, excluded := te.excludeIDs[m.ID]; excluded {
+			continue
+		}
+		filtered = append(filtered, m)
+		if len(filtered) >= limit {
+			break
+		}
+	}
+
+	if len(filtered) == 0 {
+		return &agent.ToolResult{
+			CallID:  call.ID,
+			Name:    call.Name,
+			Content: "No relevant memories found for this query.",
+		}, nil
+	}
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("Found %d relevant memories:\n", len(filtered)))
+	for i, m := range filtered {
+		sb.WriteString(fmt.Sprintf("\n%d. [%s, %s] %s", i+1, m.Category, m.Valence, m.Content))
+	}
+
+	return &agent.ToolResult{
+		CallID:  call.ID,
+		Name:    call.Name,
+		Content: sb.String(),
+	}, nil
+}

--- a/pkg/memory/tool_executor_integration_test.go
+++ b/pkg/memory/tool_executor_integration_test.go
@@ -1,0 +1,174 @@
+package memory_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/codeready-toolchain/tarsy/pkg/agent"
+	"github.com/codeready-toolchain/tarsy/pkg/memory"
+	_ "github.com/jackc/pgx/v5/stdlib"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func recallToolCall(t *testing.T, query string, limit int) agent.ToolCall {
+	t.Helper()
+	args := map[string]any{"query": query}
+	if limit > 0 {
+		args["limit"] = limit
+	}
+	b, err := json.Marshal(args)
+	require.NoError(t, err)
+	return agent.ToolCall{
+		ID:        "call-1",
+		Name:      memory.ToolRecallPastInvestigations,
+		Arguments: string(b),
+	}
+}
+
+func TestToolExecutor_Recall_FormattedResults(t *testing.T) {
+	svc, sessionID := newTestService(t, []float32{1, 0, 0})
+	ctx := t.Context()
+
+	err := svc.ApplyReflectorActions(ctx, "default", sessionID, nil, nil, 80,
+		&memory.ReflectorResult{Create: []memory.ReflectorCreateAction{
+			{Content: "Check PgBouncer health first", Category: "procedural", Valence: "positive"},
+			{Content: "OOMKill uses working_set_bytes", Category: "episodic", Valence: "neutral"},
+		}})
+	require.NoError(t, err)
+
+	te := memory.NewToolExecutor(nil, svc, "default", nil, nil, nil)
+	result, err := te.Execute(ctx, recallToolCall(t, "check health", 10))
+	require.NoError(t, err)
+
+	assert.False(t, result.IsError)
+	assert.Equal(t, "call-1", result.CallID)
+	assert.Contains(t, result.Content, "Found 2 relevant memories")
+	assert.Contains(t, result.Content, "[procedural, positive] Check PgBouncer health first")
+	assert.Contains(t, result.Content, "[episodic, neutral] OOMKill uses working_set_bytes")
+}
+
+func TestToolExecutor_Recall_ExcludesInjectedIDs(t *testing.T) {
+	svc, sessionID := newTestService(t, []float32{1, 0, 0})
+	ctx := t.Context()
+
+	err := svc.ApplyReflectorActions(ctx, "default", sessionID, nil, nil, 80,
+		&memory.ReflectorResult{Create: []memory.ReflectorCreateAction{
+			{Content: "Memory A", Category: "procedural", Valence: "positive"},
+			{Content: "Memory B", Category: "semantic", Valence: "neutral"},
+		}})
+	require.NoError(t, err)
+
+	all, err := svc.FindSimilar(ctx, "default", "anything", 10)
+	require.NoError(t, err)
+	require.Len(t, all, 2)
+
+	excludeIDs := map[string]struct{}{all[0].ID: {}}
+	te := memory.NewToolExecutor(nil, svc, "default", nil, nil, excludeIDs)
+
+	result, err := te.Execute(ctx, recallToolCall(t, "anything", 10))
+	require.NoError(t, err)
+
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Content, "Found 1 relevant memories")
+	assert.Contains(t, result.Content, all[1].Content)
+	assert.NotContains(t, result.Content, all[0].Content)
+}
+
+func TestToolExecutor_Recall_AllExcluded(t *testing.T) {
+	svc, sessionID := newTestService(t, []float32{1, 0, 0})
+	ctx := t.Context()
+
+	err := svc.ApplyReflectorActions(ctx, "default", sessionID, nil, nil, 80,
+		&memory.ReflectorResult{Create: []memory.ReflectorCreateAction{
+			{Content: "Only memory", Category: "procedural", Valence: "positive"},
+		}})
+	require.NoError(t, err)
+
+	all, err := svc.FindSimilar(ctx, "default", "anything", 10)
+	require.NoError(t, err)
+	require.Len(t, all, 1)
+
+	excludeIDs := map[string]struct{}{all[0].ID: {}}
+	te := memory.NewToolExecutor(nil, svc, "default", nil, nil, excludeIDs)
+
+	result, err := te.Execute(ctx, recallToolCall(t, "anything", 10))
+	require.NoError(t, err)
+
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Content, "No relevant memories found")
+}
+
+func TestToolExecutor_Recall_LimitApplied(t *testing.T) {
+	svc, sessionID := newTestService(t, []float32{1, 0, 0})
+	ctx := t.Context()
+
+	err := svc.ApplyReflectorActions(ctx, "default", sessionID, nil, nil, 80,
+		&memory.ReflectorResult{Create: []memory.ReflectorCreateAction{
+			{Content: "Memory 1", Category: "procedural", Valence: "positive"},
+			{Content: "Memory 2", Category: "procedural", Valence: "positive"},
+			{Content: "Memory 3", Category: "procedural", Valence: "positive"},
+			{Content: "Memory 4", Category: "procedural", Valence: "positive"},
+			{Content: "Memory 5", Category: "procedural", Valence: "positive"},
+		}})
+	require.NoError(t, err)
+
+	te := memory.NewToolExecutor(nil, svc, "default", nil, nil, nil)
+
+	result, err := te.Execute(ctx, recallToolCall(t, "test", 2))
+	require.NoError(t, err)
+
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Content, "Found 2 relevant memories")
+}
+
+func TestToolExecutor_Recall_NoMemoriesInDB(t *testing.T) {
+	svc, _ := newTestService(t, []float32{1, 0, 0})
+
+	te := memory.NewToolExecutor(nil, svc, "default", nil, nil, nil)
+
+	result, err := te.Execute(t.Context(), recallToolCall(t, "nothing matches", 0))
+	require.NoError(t, err)
+
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Content, "No relevant memories found")
+}
+
+func TestToolExecutor_Recall_DefaultLimit(t *testing.T) {
+	svc, sessionID := newTestService(t, []float32{1, 0, 0})
+	ctx := t.Context()
+
+	// Seed 3 memories, request with no limit → default 10 → returns all 3.
+	err := svc.ApplyReflectorActions(ctx, "default", sessionID, nil, nil, 80,
+		&memory.ReflectorResult{Create: []memory.ReflectorCreateAction{
+			{Content: "A", Category: "procedural", Valence: "positive"},
+			{Content: "B", Category: "semantic", Valence: "neutral"},
+			{Content: "C", Category: "episodic", Valence: "negative"},
+		}})
+	require.NoError(t, err)
+
+	te := memory.NewToolExecutor(nil, svc, "default", nil, nil, nil)
+
+	result, err := te.Execute(ctx, recallToolCall(t, "test", 0))
+	require.NoError(t, err)
+
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Content, "Found 3 relevant memories")
+}
+
+func TestToolExecutor_Recall_DelegatesNonRecallToInner(t *testing.T) {
+	svc, _ := newTestService(t, []float32{1, 0, 0})
+	inner := agent.NewStubToolExecutor([]agent.ToolDefinition{
+		{Name: "server1.read_file", Description: "Reads a file"},
+	})
+	te := memory.NewToolExecutor(inner, svc, "default", nil, nil, nil)
+
+	result, err := te.Execute(t.Context(), agent.ToolCall{
+		ID:        "call-2",
+		Name:      "server1.read_file",
+		Arguments: `{"path": "/etc/hosts"}`,
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Equal(t, "call-2", result.CallID)
+}

--- a/pkg/memory/tool_executor_test.go
+++ b/pkg/memory/tool_executor_test.go
@@ -1,0 +1,159 @@
+package memory
+
+import (
+	"testing"
+
+	"github.com/codeready-toolchain/tarsy/pkg/agent"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsMemoryTool(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{"recall_past_investigations", true},
+		{"load_skill", false},
+		{"dispatch_agent", false},
+		{"kubernetes.get_pods", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsMemoryTool(tt.name))
+		})
+	}
+}
+
+func TestToolExecutor_ListTools_PrependToInner(t *testing.T) {
+	inner := agent.NewStubToolExecutor([]agent.ToolDefinition{
+		{Name: "server1.read_file", Description: "Reads a file"},
+		{Name: "server1.write_file", Description: "Writes a file"},
+	})
+	te := NewToolExecutor(inner, nil, "default", nil, nil, nil)
+
+	tools, err := te.ListTools(t.Context())
+	require.NoError(t, err)
+
+	assert.Len(t, tools, 3)
+	assert.Equal(t, ToolRecallPastInvestigations, tools[0].Name)
+	assert.Equal(t, "server1.read_file", tools[1].Name)
+	assert.Equal(t, "server1.write_file", tools[2].Name)
+}
+
+func TestToolExecutor_ListTools_NilInner(t *testing.T) {
+	te := NewToolExecutor(nil, nil, "default", nil, nil, nil)
+
+	tools, err := te.ListTools(t.Context())
+	require.NoError(t, err)
+
+	assert.Len(t, tools, 1)
+	assert.Equal(t, ToolRecallPastInvestigations, tools[0].Name)
+}
+
+func TestToolExecutor_ListTools_DeduplicatesInner(t *testing.T) {
+	inner := agent.NewStubToolExecutor([]agent.ToolDefinition{
+		{Name: ToolRecallPastInvestigations, Description: "should be filtered out"},
+		{Name: "server1.read_file", Description: "Reads a file"},
+	})
+	te := NewToolExecutor(inner, nil, "default", nil, nil, nil)
+
+	tools, err := te.ListTools(t.Context())
+	require.NoError(t, err)
+
+	assert.Len(t, tools, 2)
+	assert.Equal(t, ToolRecallPastInvestigations, tools[0].Name)
+	assert.NotEqual(t, "should be filtered out", tools[0].Description)
+}
+
+func TestToolExecutor_Execute_DelegatesToInner(t *testing.T) {
+	inner := agent.NewStubToolExecutor(nil)
+	te := NewToolExecutor(inner, nil, "default", nil, nil, nil)
+
+	result, err := te.Execute(t.Context(), agent.ToolCall{
+		ID:        "call-1",
+		Name:      "server1.read_file",
+		Arguments: `{"path": "/etc/config"}`,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "call-1", result.CallID)
+	assert.False(t, result.IsError)
+}
+
+func TestToolExecutor_Execute_UnknownToolNilInner(t *testing.T) {
+	te := NewToolExecutor(nil, nil, "default", nil, nil, nil)
+
+	result, err := te.Execute(t.Context(), agent.ToolCall{
+		ID:   "call-1",
+		Name: "nonexistent_tool",
+	})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Content, "unknown tool")
+}
+
+func TestToolExecutor_Execute_RecallEmptyQuery(t *testing.T) {
+	te := NewToolExecutor(nil, nil, "default", nil, nil, nil)
+
+	result, err := te.Execute(t.Context(), agent.ToolCall{
+		ID:        "call-1",
+		Name:      ToolRecallPastInvestigations,
+		Arguments: `{"query": ""}`,
+	})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Content, "'query' is required")
+}
+
+func TestToolExecutor_Execute_RecallInvalidJSON(t *testing.T) {
+	te := NewToolExecutor(nil, nil, "default", nil, nil, nil)
+
+	result, err := te.Execute(t.Context(), agent.ToolCall{
+		ID:        "call-1",
+		Name:      ToolRecallPastInvestigations,
+		Arguments: `not-json`,
+	})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Content, "invalid arguments")
+}
+
+func TestToolExecutor_Close_DelegatesToInner(t *testing.T) {
+	inner := agent.NewStubToolExecutor(nil)
+	te := NewToolExecutor(inner, nil, "default", nil, nil, nil)
+	assert.NoError(t, te.Close())
+}
+
+func TestToolExecutor_Close_NilInner(t *testing.T) {
+	te := NewToolExecutor(nil, nil, "default", nil, nil, nil)
+	assert.NoError(t, te.Close())
+}
+
+func TestToolExecutor_ListTools_RecallToolDefinition(t *testing.T) {
+	te := NewToolExecutor(nil, nil, "default", nil, nil, nil)
+
+	tools, err := te.ListTools(t.Context())
+	require.NoError(t, err)
+	require.Len(t, tools, 1)
+
+	assert.Equal(t, ToolRecallPastInvestigations, tools[0].Name)
+	assert.Contains(t, tools[0].Description, "Search learnings from past investigations")
+	assert.Contains(t, tools[0].ParametersSchema, `"query"`)
+	assert.Contains(t, tools[0].ParametersSchema, `"limit"`)
+}
+
+func TestToolExecutor_ExcludeIDs(t *testing.T) {
+	excludeIDs := map[string]struct{}{
+		"mem-1": {},
+		"mem-3": {},
+	}
+	te := NewToolExecutor(nil, nil, "default", nil, nil, excludeIDs)
+
+	// Verify exclude IDs are stored
+	assert.Len(t, te.excludeIDs, 2)
+	_, has1 := te.excludeIDs["mem-1"]
+	assert.True(t, has1)
+	_, has3 := te.excludeIDs["mem-3"]
+	assert.True(t, has3)
+}

--- a/pkg/queue/chat_executor.go
+++ b/pkg/queue/chat_executor.go
@@ -23,6 +23,7 @@ import (
 	"github.com/codeready-toolchain/tarsy/pkg/config"
 	"github.com/codeready-toolchain/tarsy/pkg/events"
 	"github.com/codeready-toolchain/tarsy/pkg/mcp"
+	"github.com/codeready-toolchain/tarsy/pkg/memory"
 	"github.com/codeready-toolchain/tarsy/pkg/models"
 	"github.com/codeready-toolchain/tarsy/pkg/runbook"
 	"github.com/codeready-toolchain/tarsy/pkg/services"
@@ -66,6 +67,8 @@ type ChatMessageExecutor struct {
 	promptBuilder  *prompt.PromptBuilder
 	execConfig     ChatMessageExecutorConfig
 	runbookService *runbook.Service
+	memoryService  *memory.Service
+	memoryConfig   *config.MemoryConfig
 
 	// Services
 	timelineService    *services.TimelineService
@@ -83,6 +86,7 @@ type ChatMessageExecutor struct {
 
 // NewChatMessageExecutor creates a new ChatMessageExecutor.
 // runbookService may be nil (uses config default runbook content).
+// memoryService and memoryConfig may be nil (memory disabled).
 func NewChatMessageExecutor(
 	cfg *config.Config,
 	dbClient *ent.Client,
@@ -91,6 +95,8 @@ func NewChatMessageExecutor(
 	eventPublisher agent.EventPublisher,
 	execConfig ChatMessageExecutorConfig,
 	runbookService *runbook.Service,
+	memoryService *memory.Service,
+	memoryConfig *config.MemoryConfig,
 ) *ChatMessageExecutor {
 	controllerFactory := controller.NewFactory()
 	msgService := services.NewMessageService(dbClient)
@@ -104,6 +110,8 @@ func NewChatMessageExecutor(
 		promptBuilder:      prompt.NewPromptBuilder(cfg.MCPServerRegistry),
 		execConfig:         execConfig,
 		runbookService:     runbookService,
+		memoryService:      memoryService,
+		memoryConfig:       memoryConfig,
 		timelineService:    services.NewTimelineService(dbClient),
 		stageService:       services.NewStageService(dbClient),
 		chatService:        services.NewChatService(dbClient),
@@ -340,6 +348,18 @@ func (e *ChatMessageExecutor) execute(parentCtx context.Context, input ChatExecu
 	// Wrap with skill tool executor if on-demand skills are configured
 	if len(resolvedConfig.OnDemandSkills) > 0 && e.cfg.SkillRegistry != nil {
 		toolExecutor = skill.NewSkillToolExecutor(toolExecutor, e.cfg.SkillRegistry, resolvedConfig.OnDemandSkillNameSet())
+	}
+
+	// Wrap with memory tool executor (chat gets the tool but no auto-injection)
+	if e.memoryService != nil && e.memoryConfig != nil {
+		var alertTypePtr *string
+		if input.Session.AlertType != "" {
+			alertTypePtr = &input.Session.AlertType
+		}
+		toolExecutor = memory.NewToolExecutor(
+			toolExecutor, e.memoryService, "default",
+			alertTypePtr, &input.Session.ChainID, nil,
+		)
 	}
 
 	// 8. Build ExecutionContext (with ChatContext populated)

--- a/pkg/queue/chat_executor_integration_test.go
+++ b/pkg/queue/chat_executor_integration_test.go
@@ -101,7 +101,7 @@ func TestChatExecutor_FirstMessage_ExecutesThroughAgentFramework(t *testing.T) {
 			SessionTimeout:    30 * time.Second,
 			HeartbeatInterval: 5 * time.Second,
 		},
-		nil,
+		nil, nil, nil,
 	)
 	defer chatExecutor.Stop()
 
@@ -265,7 +265,7 @@ func TestChatExecutor_ContextAccumulation(t *testing.T) {
 			SessionTimeout:    30 * time.Second,
 			HeartbeatInterval: 5 * time.Second,
 		},
-		nil,
+		nil, nil, nil,
 	)
 	defer chatExecutor.Stop()
 
@@ -437,7 +437,7 @@ func TestChatExecutor_OneAtATimeEnforcement(t *testing.T) {
 			SessionTimeout:    30 * time.Second,
 			HeartbeatInterval: 5 * time.Second,
 		},
-		nil,
+		nil, nil, nil,
 	)
 	defer chatExecutor.Stop()
 
@@ -551,7 +551,7 @@ func TestChatExecutor_CancellationEndToEnd(t *testing.T) {
 			SessionTimeout:    30 * time.Second,
 			HeartbeatInterval: 5 * time.Second,
 		},
-		nil,
+		nil, nil, nil,
 	)
 	defer chatExecutor.Stop()
 
@@ -667,7 +667,7 @@ func TestChatExecutor_AcceptsInProgressSession(t *testing.T) {
 			SessionTimeout:    30 * time.Second,
 			HeartbeatInterval: 5 * time.Second,
 		},
-		nil,
+		nil, nil, nil,
 	)
 	defer chatExecutor.Stop()
 
@@ -744,7 +744,7 @@ func TestChatExecutor_CancelBySessionID(t *testing.T) {
 			SessionTimeout:    30 * time.Second,
 			HeartbeatInterval: 5 * time.Second,
 		},
-		nil,
+		nil, nil, nil,
 	)
 	defer chatExecutor.Stop()
 

--- a/pkg/queue/chat_executor_integration_test.go
+++ b/pkg/queue/chat_executor_integration_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/codeready-toolchain/tarsy/pkg/agent"
 	"github.com/codeready-toolchain/tarsy/pkg/config"
 	"github.com/codeready-toolchain/tarsy/pkg/events"
+	"github.com/codeready-toolchain/tarsy/pkg/memory"
 	"github.com/codeready-toolchain/tarsy/pkg/models"
 	"github.com/codeready-toolchain/tarsy/pkg/services"
 	"github.com/stretchr/testify/assert"
@@ -222,6 +223,142 @@ func TestChatExecutor_FirstMessage_ExecutesThroughAgentFramework(t *testing.T) {
 	}
 	publisher.mu.Unlock()
 	assert.True(t, foundUserQuestionWS, "user_question must be published via WS for dashboard rendering")
+}
+
+func TestChatExecutor_MemoryEnabled_RecallToolPresent_NoAutoInjection(t *testing.T) {
+	entClient, db := util.SetupTestDatabase(t)
+	ctx := context.Background()
+
+	_, err := db.ExecContext(ctx, `ALTER TABLE investigation_memories ADD COLUMN IF NOT EXISTS embedding vector(3)`)
+	require.NoError(t, err)
+
+	memCfg := &config.MemoryConfig{
+		Enabled:   true,
+		MaxInject: 5,
+		Embedding: config.EmbeddingConfig{Dimensions: 3},
+	}
+	embedder := &fixedEmbedder{vec: []float32{1, 0, 0}}
+	memSvc := memory.NewService(entClient, db, embedder, memCfg)
+
+	chainID := "mem-chat-chain"
+	chain := &config.ChainConfig{
+		AlertTypes: []string{"test-alert"},
+		Stages: []config.StageConfig{
+			{
+				Name:   "investigation",
+				Agents: []config.StageAgentConfig{{Name: "TestAgent"}},
+			},
+		},
+		Chat: &config.ChatConfig{Enabled: true},
+	}
+
+	// Seed a memory so the recall tool would have results.
+	sourceSession, err := entClient.AlertSession.Create().
+		SetID("mem-chat-source").
+		SetAlertData("historical alert").
+		SetAgentType("test").
+		SetAlertType("test-alert").
+		SetChainID(chainID).
+		SetStatus(alertsession.StatusCompleted).
+		SetAuthor("test").
+		Save(ctx)
+	require.NoError(t, err)
+
+	alertType := "test-alert"
+	err = memSvc.ApplyReflectorActions(ctx, "default", sourceSession.ID, &alertType, &chainID, 80,
+		&memory.ReflectorResult{Create: []memory.ReflectorCreateAction{
+			{Content: "Check PgBouncer connection pool health", Category: "procedural", Valence: "positive"},
+		}})
+	require.NoError(t, err)
+
+	llm := &mockLLMClient{
+		capture: true,
+		responses: []mockLLMResponse{
+			{chunks: []agent.Chunk{
+				&agent.TextChunk{Content: "Thought: I see the investigation context.\nFinal Answer: The pod was OOM killed due to a memory leak."},
+			}},
+		},
+	}
+
+	cfg := chatTestConfig(chainID, chain)
+	publisher := &testEventPublisher{}
+
+	chatExecutor := NewChatMessageExecutor(cfg, entClient, llm, nil, publisher,
+		ChatMessageExecutorConfig{
+			SessionTimeout:    30 * time.Second,
+			HeartbeatInterval: 5 * time.Second,
+		},
+		nil, memSvc, memCfg,
+	)
+	defer chatExecutor.Stop()
+
+	session, err := entClient.AlertSession.Create().
+		SetID("session-mem-chat-1").
+		SetAlertData("Pod-1 OOMKilled").
+		SetAgentType("kubernetes").
+		SetAlertType("test-alert").
+		SetChainID(chainID).
+		SetStatus(alertsession.StatusCompleted).
+		SetAuthor("test").
+		Save(ctx)
+	require.NoError(t, err)
+
+	_, err = entClient.Stage.Create().
+		SetID("mem-chat-inv-stage").
+		SetSessionID(session.ID).
+		SetStageName("investigation").
+		SetStageIndex(1).
+		SetExpectedAgentCount(1).
+		SetStatus(stage.StatusCompleted).
+		Save(ctx)
+	require.NoError(t, err)
+
+	chatService := services.NewChatService(entClient)
+	chatObj, err := chatService.CreateChat(ctx, models.CreateChatRequest{
+		SessionID: session.ID,
+		CreatedBy: "test@example.com",
+	})
+	require.NoError(t, err)
+
+	msg, err := chatService.AddChatMessage(ctx, models.AddChatMessageRequest{
+		ChatID:  chatObj.ID,
+		Content: "What caused the OOM?",
+		Author:  "test@example.com",
+	})
+	require.NoError(t, err)
+
+	_, err = chatExecutor.Submit(ctx, ChatExecuteInput{
+		Chat:    chatObj,
+		Message: msg,
+		Session: session,
+	})
+	require.NoError(t, err)
+
+	chatExecutor.wg.Wait()
+
+	// Verify: recall_past_investigations tool is in the LLM's tool list.
+	llm.mu.Lock()
+	require.NotEmpty(t, llm.capturedInputs, "LLM should have been called at least once")
+	firstInput := llm.capturedInputs[0]
+	llm.mu.Unlock()
+
+	var hasRecallTool bool
+	for _, tool := range firstInput.Tools {
+		if tool.Name == memory.ToolRecallPastInvestigations {
+			hasRecallTool = true
+			break
+		}
+	}
+	assert.True(t, hasRecallTool, "chat executor with memory enabled must expose recall_past_investigations tool")
+
+	// Verify: no Tier 4 auto-injection in system prompt (chat never auto-injects).
+	for _, m := range firstInput.Messages {
+		if m.Role == agent.RoleSystem {
+			assert.NotContains(t, m.Content, "Lessons from Past Investigations",
+				"chat prompt must not auto-inject Tier 4 memories")
+			break
+		}
+	}
 }
 
 func TestChatExecutor_ContextAccumulation(t *testing.T) {

--- a/pkg/queue/executor.go
+++ b/pkg/queue/executor.go
@@ -19,6 +19,7 @@ import (
 	"github.com/codeready-toolchain/tarsy/pkg/config"
 	"github.com/codeready-toolchain/tarsy/pkg/events"
 	"github.com/codeready-toolchain/tarsy/pkg/mcp"
+	"github.com/codeready-toolchain/tarsy/pkg/memory"
 	"github.com/codeready-toolchain/tarsy/pkg/models"
 	"github.com/codeready-toolchain/tarsy/pkg/runbook"
 	"github.com/codeready-toolchain/tarsy/pkg/services"
@@ -35,13 +36,16 @@ type RealSessionExecutor struct {
 	mcpFactory       *mcp.ClientFactory
 	runbookService   *runbook.Service
 	subAgentRegistry *config.SubAgentRegistry
+	memoryService    *memory.Service
+	memoryConfig     *config.MemoryConfig
 }
 
 // NewRealSessionExecutor creates a new session executor.
 // eventPublisher may be nil (streaming disabled).
 // mcpFactory may be nil (MCP disabled — uses stub tool executor).
 // runbookService may be nil (uses config default runbook content).
-func NewRealSessionExecutor(cfg *config.Config, dbClient *ent.Client, llmClient agent.LLMClient, eventPublisher agent.EventPublisher, mcpFactory *mcp.ClientFactory, runbookService *runbook.Service) *RealSessionExecutor {
+// memoryService and memoryConfig may be nil (memory disabled).
+func NewRealSessionExecutor(cfg *config.Config, dbClient *ent.Client, llmClient agent.LLMClient, eventPublisher agent.EventPublisher, mcpFactory *mcp.ClientFactory, runbookService *runbook.Service, memoryService *memory.Service, memoryConfig *config.MemoryConfig) *RealSessionExecutor {
 	controllerFactory := controller.NewFactory()
 	return &RealSessionExecutor{
 		cfg:              cfg,
@@ -53,6 +57,8 @@ func NewRealSessionExecutor(cfg *config.Config, dbClient *ent.Client, llmClient 
 		mcpFactory:       mcpFactory,
 		runbookService:   runbookService,
 		subAgentRegistry: config.BuildSubAgentRegistry(cfg.AgentRegistry.GetAll()),
+		memoryService:    memoryService,
+		memoryConfig:     memoryConfig,
 	}
 }
 
@@ -624,6 +630,20 @@ func (e *RealSessionExecutor) executeAgent(
 	toolExecutor, failedServers := createToolExecutor(ctx, e.mcpFactory, serverIDs, toolFilter, logger)
 	defer func() { _ = toolExecutor.Close() }()
 
+	// Retrieve memories for auto-injection into system prompt (all parallel agents
+	// get the same briefing — retrieval is deterministic for the same alert data).
+	var memoryBriefing *agent.MemoryBriefing
+	if e.memoryService != nil && e.memoryConfig != nil {
+		memoryBriefing = e.retrieveMemories(ctx, input.session, logger)
+		if memoryBriefing != nil {
+			if edgeErr := e.dbClient.AlertSession.UpdateOneID(input.session.ID).
+				AddInjectedMemoryIDs(memoryBriefing.InjectedIDs...).
+				Exec(ctx); edgeErr != nil {
+				logger.Warn("Failed to record injected memory IDs", "error", edgeErr)
+			}
+		}
+	}
+
 	// Build execution context
 	execCtx := &agent.ExecutionContext{
 		SessionID:      input.session.ID,
@@ -640,6 +660,7 @@ func (e *RealSessionExecutor) executeAgent(
 		EventPublisher: e.eventPublisher,
 		PromptBuilder:  e.promptBuilder,
 		FailedServers:  failedServers,
+		MemoryBriefing: memoryBriefing,
 		Services: &agent.ServiceBundle{
 			Timeline:    input.timelineService,
 			Message:     input.messageService,
@@ -687,6 +708,7 @@ func (e *RealSessionExecutor) executeAgent(
 			AlertData:          input.session.AlertData,
 			AlertType:          input.session.AlertType,
 			RunbookContent:     input.runbookContent,
+			WrapToolExecutor:   e.memoryToolWrapper(input.session),
 		}
 
 		runner := orchestrator.NewSubAgentRunner(ctx, deps, exec.ID, input.session.ID, stg.ID, registry, guardrails, subAgentRefs)
@@ -695,9 +717,22 @@ func (e *RealSessionExecutor) executeAgent(
 		execCtx.SubAgentCatalog = registry.Entries()
 	}
 
-	// Wrap with skill tool executor (outermost layer, after orchestrator)
+	// Wrap with skill tool executor (after orchestrator)
 	if len(resolvedConfig.OnDemandSkills) > 0 && e.cfg.SkillRegistry != nil {
 		toolExecutor = skill.NewSkillToolExecutor(toolExecutor, e.cfg.SkillRegistry, resolvedConfig.OnDemandSkillNameSet())
+	}
+
+	// Wrap with memory tool executor (outermost layer)
+	if e.memoryService != nil && e.memoryConfig != nil {
+		var alertTypePtr *string
+		if input.session.AlertType != "" {
+			alertTypePtr = &input.session.AlertType
+		}
+		excludeIDs := memoryExcludeIDs(memoryBriefing)
+		toolExecutor = memory.NewToolExecutor(
+			toolExecutor, e.memoryService, "default",
+			alertTypePtr, &input.session.ChainID, excludeIDs,
+		)
 	}
 
 	execCtx.ToolExecutor = toolExecutor

--- a/pkg/queue/executor.go
+++ b/pkg/queue/executor.go
@@ -630,10 +630,10 @@ func (e *RealSessionExecutor) executeAgent(
 	toolExecutor, failedServers := createToolExecutor(ctx, e.mcpFactory, serverIDs, toolFilter, logger)
 	defer func() { _ = toolExecutor.Close() }()
 
-	// Retrieve memories for auto-injection into system prompt (all parallel agents
-	// get the same briefing — retrieval is deterministic for the same alert data).
+	// Retrieve memories for auto-injection into system prompt (only for agent types
+	// whose prompts consume MemoryBriefing — investigation, action, orchestrator).
 	var memoryBriefing *agent.MemoryBriefing
-	if e.memoryService != nil && e.memoryConfig != nil {
+	if e.memoryService != nil && e.memoryConfig != nil && agentTypeSupportsMemory(resolvedConfig.Type) {
 		memoryBriefing = e.retrieveMemories(ctx, input.session, logger)
 		if memoryBriefing != nil {
 			if edgeErr := e.dbClient.AlertSession.UpdateOneID(input.session.ID).
@@ -722,8 +722,8 @@ func (e *RealSessionExecutor) executeAgent(
 		toolExecutor = skill.NewSkillToolExecutor(toolExecutor, e.cfg.SkillRegistry, resolvedConfig.OnDemandSkillNameSet())
 	}
 
-	// Wrap with memory tool executor (outermost layer)
-	if e.memoryService != nil && e.memoryConfig != nil {
+	// Wrap with memory tool executor (outermost layer — same agent-type guard)
+	if e.memoryService != nil && e.memoryConfig != nil && agentTypeSupportsMemory(resolvedConfig.Type) {
 		var alertTypePtr *string
 		if input.session.AlertType != "" {
 			alertTypePtr = &input.session.AlertType

--- a/pkg/queue/executor_integration_test.go
+++ b/pkg/queue/executor_integration_test.go
@@ -263,7 +263,7 @@ func TestExecutor_SingleStageChain(t *testing.T) {
 
 	cfg := testConfig("test-chain", chain)
 	publisher := &testEventPublisher{}
-	executor := NewRealSessionExecutor(cfg, entClient, llm, publisher, nil, nil)
+	executor := NewRealSessionExecutor(cfg, entClient, llm, publisher, nil, nil, nil, nil)
 	session := createExecutorTestSession(t, entClient, "test-chain")
 
 	result := executor.Execute(context.Background(), session)
@@ -331,7 +331,7 @@ func TestExecutor_MultiStageChain(t *testing.T) {
 
 	cfg := testConfig("test-chain", chain)
 	publisher := &testEventPublisher{}
-	executor := NewRealSessionExecutor(cfg, entClient, llm, publisher, nil, nil)
+	executor := NewRealSessionExecutor(cfg, entClient, llm, publisher, nil, nil, nil, nil)
 	session := createExecutorTestSession(t, entClient, "test-chain")
 
 	result := executor.Execute(context.Background(), session)
@@ -397,7 +397,7 @@ func TestExecutor_FailFast(t *testing.T) {
 
 	cfg := testConfig("test-chain", chain)
 	publisher := &testEventPublisher{}
-	executor := NewRealSessionExecutor(cfg, entClient, llm, publisher, nil, nil)
+	executor := NewRealSessionExecutor(cfg, entClient, llm, publisher, nil, nil, nil, nil)
 	session := createExecutorTestSession(t, entClient, "test-chain")
 
 	result := executor.Execute(context.Background(), session)
@@ -471,7 +471,7 @@ func TestExecutor_CancellationBetweenStages(t *testing.T) {
 
 			cfg := testConfig("test-chain", chain)
 			publisher := &testEventPublisher{}
-			executor := NewRealSessionExecutor(cfg, entClient, llm, publisher, nil, nil)
+			executor := NewRealSessionExecutor(cfg, entClient, llm, publisher, nil, nil, nil, nil)
 			session := createExecutorTestSession(t, entClient, "test-chain")
 
 			ctx, cancel := context.WithCancel(context.Background())
@@ -548,7 +548,7 @@ func TestExecutor_ExecutiveSummaryGenerated(t *testing.T) {
 
 	cfg := testConfig("test-chain", chain)
 	publisher := &testEventPublisher{}
-	executor := NewRealSessionExecutor(cfg, entClient, llm, publisher, nil, nil)
+	executor := NewRealSessionExecutor(cfg, entClient, llm, publisher, nil, nil, nil, nil)
 	session := createExecutorTestSession(t, entClient, "test-chain")
 
 	result := executor.Execute(context.Background(), session)
@@ -630,7 +630,7 @@ func TestExecutor_ExecutiveSummaryNoLegacyTimelineEvent(t *testing.T) {
 	}
 
 	cfg := testConfig("test-chain", chain)
-	executor := NewRealSessionExecutor(cfg, entClient, llm, nil, nil, nil)
+	executor := NewRealSessionExecutor(cfg, entClient, llm, nil, nil, nil, nil, nil)
 	session := createExecutorTestSession(t, entClient, "test-chain")
 
 	result := executor.Execute(context.Background(), session)
@@ -674,7 +674,7 @@ func TestExecutor_ExecutiveSummaryFailOpen(t *testing.T) {
 	}
 
 	cfg := testConfig("test-chain", chain)
-	executor := NewRealSessionExecutor(cfg, entClient, llm, nil, nil, nil)
+	executor := NewRealSessionExecutor(cfg, entClient, llm, nil, nil, nil, nil, nil)
 	session := createExecutorTestSession(t, entClient, "test-chain")
 
 	result := executor.Execute(context.Background(), session)
@@ -725,7 +725,7 @@ func TestExecutor_MultiAgentAllSucceed(t *testing.T) {
 
 	cfg := testConfig("test-chain", chain)
 	publisher := &testEventPublisher{}
-	executor := NewRealSessionExecutor(cfg, entClient, llm, publisher, nil, nil)
+	executor := NewRealSessionExecutor(cfg, entClient, llm, publisher, nil, nil, nil, nil)
 	session := createExecutorTestSession(t, entClient, "test-chain")
 
 	result := executor.Execute(context.Background(), session)
@@ -836,7 +836,7 @@ func TestExecutor_MultiAgentOneFailsPolicyAll(t *testing.T) {
 
 	cfg := testConfig("test-chain", chain)
 	publisher := &testEventPublisher{}
-	executor := NewRealSessionExecutor(cfg, entClient, llm, publisher, nil, nil)
+	executor := NewRealSessionExecutor(cfg, entClient, llm, publisher, nil, nil, nil, nil)
 	session := createExecutorTestSession(t, entClient, "test-chain")
 
 	result := executor.Execute(context.Background(), session)
@@ -913,7 +913,7 @@ func TestExecutor_MultiAgentOneFailsPolicyAny(t *testing.T) {
 	}
 
 	cfg := testConfig("test-chain", chain)
-	executor := NewRealSessionExecutor(cfg, entClient, llm, nil, nil, nil)
+	executor := NewRealSessionExecutor(cfg, entClient, llm, nil, nil, nil, nil, nil)
 	session := createExecutorTestSession(t, entClient, "test-chain")
 
 	result := executor.Execute(context.Background(), session)
@@ -954,7 +954,7 @@ func TestExecutor_NilEventPublisher(t *testing.T) {
 
 	cfg := testConfig("test-chain", chain)
 	// nil eventPublisher — should not panic
-	executor := NewRealSessionExecutor(cfg, entClient, llm, nil, nil, nil)
+	executor := NewRealSessionExecutor(cfg, entClient, llm, nil, nil, nil, nil, nil)
 	session := createExecutorTestSession(t, entClient, "test-chain")
 
 	result := executor.Execute(context.Background(), session)
@@ -1000,7 +1000,7 @@ func TestExecutor_ReplicaAllSucceed(t *testing.T) {
 
 	cfg := testConfig("test-chain", chain)
 	publisher := &testEventPublisher{}
-	executor := NewRealSessionExecutor(cfg, entClient, llm, publisher, nil, nil)
+	executor := NewRealSessionExecutor(cfg, entClient, llm, publisher, nil, nil, nil, nil)
 	session := createExecutorTestSession(t, entClient, "test-chain")
 
 	result := executor.Execute(context.Background(), session)
@@ -1047,7 +1047,7 @@ func TestExecutor_EmptyChainStages(t *testing.T) {
 
 	llm := &mockLLMClient{}
 	cfg := testConfig("test-chain", chain)
-	executor := NewRealSessionExecutor(cfg, entClient, llm, nil, nil, nil)
+	executor := NewRealSessionExecutor(cfg, entClient, llm, nil, nil, nil, nil, nil)
 	session := createExecutorTestSession(t, entClient, "test-chain")
 
 	result := executor.Execute(context.Background(), session)
@@ -1095,7 +1095,7 @@ func TestExecutor_ContextPassedBetweenStages(t *testing.T) {
 	}
 
 	cfg := testConfig("test-chain", chain)
-	executor := NewRealSessionExecutor(cfg, entClient, llm, nil, nil, nil)
+	executor := NewRealSessionExecutor(cfg, entClient, llm, nil, nil, nil, nil, nil)
 	session := createExecutorTestSession(t, entClient, "test-chain")
 
 	result := executor.Execute(context.Background(), session)
@@ -1169,7 +1169,7 @@ func TestExecutor_StageEventsHaveCorrectIndex(t *testing.T) {
 
 	cfg := testConfig("test-chain", chain)
 	publisher := &testEventPublisher{}
-	executor := NewRealSessionExecutor(cfg, entClient, llm, publisher, nil, nil)
+	executor := NewRealSessionExecutor(cfg, entClient, llm, publisher, nil, nil, nil, nil)
 	session := createExecutorTestSession(t, entClient, "test-chain")
 
 	result := executor.Execute(context.Background(), session)
@@ -1229,7 +1229,7 @@ func TestExecutor_SynthesisSkippedForSingleAgent(t *testing.T) {
 	}
 
 	cfg := testConfig("test-chain", chain)
-	executor := NewRealSessionExecutor(cfg, entClient, llm, nil, nil, nil)
+	executor := NewRealSessionExecutor(cfg, entClient, llm, nil, nil, nil, nil, nil)
 	session := createExecutorTestSession(t, entClient, "test-chain")
 
 	result := executor.Execute(context.Background(), session)
@@ -1282,7 +1282,7 @@ func TestExecutor_SynthesisFailure(t *testing.T) {
 
 	cfg := testConfig("test-chain", chain)
 	publisher := &testEventPublisher{}
-	executor := NewRealSessionExecutor(cfg, entClient, llm, publisher, nil, nil)
+	executor := NewRealSessionExecutor(cfg, entClient, llm, publisher, nil, nil, nil, nil)
 	session := createExecutorTestSession(t, entClient, "test-chain")
 
 	result := executor.Execute(context.Background(), session)
@@ -1339,7 +1339,7 @@ func TestExecutor_SynthesisWithDefaults(t *testing.T) {
 	}
 
 	cfg := testConfig("test-chain", chain)
-	executor := NewRealSessionExecutor(cfg, entClient, llm, nil, nil, nil)
+	executor := NewRealSessionExecutor(cfg, entClient, llm, nil, nil, nil, nil, nil)
 	session := createExecutorTestSession(t, entClient, "test-chain")
 
 	result := executor.Execute(context.Background(), session)
@@ -1439,7 +1439,7 @@ func TestExecutor_AgentExecutionStoresResolvedBackend(t *testing.T) {
 	}
 
 	publisher := &testEventPublisher{}
-	executor := NewRealSessionExecutor(cfg, entClient, llm, publisher, nil, nil)
+	executor := NewRealSessionExecutor(cfg, entClient, llm, publisher, nil, nil, nil, nil)
 	session := createExecutorTestSession(t, entClient, "test-chain")
 
 	result := executor.Execute(context.Background(), session)
@@ -1534,7 +1534,7 @@ func TestExecutor_MultiAgentThenSingleAgent(t *testing.T) {
 
 	cfg := testConfig("test-chain", chain)
 	publisher := &testEventPublisher{}
-	executor := NewRealSessionExecutor(cfg, entClient, llm, publisher, nil, nil)
+	executor := NewRealSessionExecutor(cfg, entClient, llm, publisher, nil, nil, nil, nil)
 	session := createExecutorTestSession(t, entClient, "test-chain")
 
 	result := executor.Execute(context.Background(), session)
@@ -1763,7 +1763,7 @@ func TestExecutor_ReplicaMixedResultsPolicyAny(t *testing.T) {
 	}
 
 	cfg := testConfig("test-chain", chain)
-	executor := NewRealSessionExecutor(cfg, entClient, llm, nil, nil, nil)
+	executor := NewRealSessionExecutor(cfg, entClient, llm, nil, nil, nil, nil, nil)
 	session := createExecutorTestSession(t, entClient, "test-chain")
 
 	result := executor.Execute(context.Background(), session)
@@ -1807,7 +1807,7 @@ func TestExecutor_ContextIsolation(t *testing.T) {
 	}
 
 	cfg := testConfig("test-chain", chain)
-	executor := NewRealSessionExecutor(cfg, entClient, llm, nil, nil, nil)
+	executor := NewRealSessionExecutor(cfg, entClient, llm, nil, nil, nil, nil, nil)
 	session := createExecutorTestSession(t, entClient, "test-chain")
 
 	result := executor.Execute(context.Background(), session)
@@ -2105,7 +2105,7 @@ func TestExecutor_MCPSelectionFailureEmitsTerminalStatus(t *testing.T) {
 	// Registry is non-nil but empty, so any server reference in the override
 	// will fail the Has() check inside resolveMCPSelection.
 	publisher := &testEventPublisher{}
-	executor := NewRealSessionExecutor(cfg, entClient, llm, publisher, nil, nil)
+	executor := NewRealSessionExecutor(cfg, entClient, llm, publisher, nil, nil, nil, nil)
 
 	// Create session with an MCP override referencing a non-existent server.
 	sessionID := uuid.New().String()
@@ -2196,7 +2196,7 @@ func TestExecutor_AgentCreationFailureEmitsTerminalStatus(t *testing.T) {
 	}
 
 	publisher := &testEventPublisher{}
-	executor := NewRealSessionExecutor(cfg, entClient, llm, publisher, nil, nil)
+	executor := NewRealSessionExecutor(cfg, entClient, llm, publisher, nil, nil, nil, nil)
 	session := createExecutorTestSession(t, entClient, "test-chain")
 
 	result := executor.Execute(context.Background(), session)
@@ -2379,7 +2379,7 @@ func TestExecutor_OrchestratorDispatchesSubAgent(t *testing.T) {
 	}
 
 	publisher := &testEventPublisher{}
-	executor := NewRealSessionExecutor(cfg, entClient, llm, publisher, nil, nil)
+	executor := NewRealSessionExecutor(cfg, entClient, llm, publisher, nil, nil, nil, nil)
 	session := createExecutorTestSession(t, entClient, "test-chain")
 
 	result := executor.Execute(context.Background(), session)
@@ -2515,7 +2515,7 @@ func TestExecutor_ActionStageChain(t *testing.T) {
 	}
 
 	publisher := &testEventPublisher{}
-	executor := NewRealSessionExecutor(cfg, entClient, llm, publisher, nil, nil)
+	executor := NewRealSessionExecutor(cfg, entClient, llm, publisher, nil, nil, nil, nil)
 	session := createExecutorTestSession(t, entClient, "test-chain")
 
 	result := executor.Execute(context.Background(), session)
@@ -2675,7 +2675,7 @@ func TestExecutor_ActionStageNoActionsTaken(t *testing.T) {
 	}
 
 	publisher := &testEventPublisher{}
-	executor := NewRealSessionExecutor(cfg, entClient, llm, publisher, nil, nil)
+	executor := NewRealSessionExecutor(cfg, entClient, llm, publisher, nil, nil, nil, nil)
 	session := createExecutorTestSession(t, entClient, "test-chain")
 
 	result := executor.Execute(context.Background(), session)

--- a/pkg/queue/executor_integration_test.go
+++ b/pkg/queue/executor_integration_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/codeready-toolchain/tarsy/pkg/agent"
 	"github.com/codeready-toolchain/tarsy/pkg/config"
 	"github.com/codeready-toolchain/tarsy/pkg/events"
+	"github.com/codeready-toolchain/tarsy/pkg/memory"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -173,6 +174,15 @@ func (p *testEventPublisher) filterExecutionStatuses(status string) []events.Exe
 		}
 	}
 	return filtered
+}
+
+// fixedEmbedder always returns the same vector — used for deterministic memory tests.
+type fixedEmbedder struct {
+	vec []float32
+}
+
+func (f *fixedEmbedder) Embed(_ context.Context, _ string, _ memory.EmbeddingTask) ([]float32, error) {
+	return f.vec, nil
 }
 
 // ────────────────────────────────────────────────────────────
@@ -2707,4 +2717,130 @@ func TestExecutor_ActionStageNoActionsTaken(t *testing.T) {
 		assert.NotRegexp(t, `(?m)^\s*(YES|NO)\s*$`, evt.Content,
 			"action stage %s timeline event should have YES/NO marker stripped", evt.EventType)
 	}
+}
+
+func TestExecutor_MemoryEnabled_BriefingAndRecallTool(t *testing.T) {
+	entClient, db := util.SetupTestDatabase(t)
+	ctx := context.Background()
+
+	_, err := db.ExecContext(ctx, `ALTER TABLE investigation_memories ADD COLUMN IF NOT EXISTS embedding vector(3)`)
+	require.NoError(t, err)
+
+	memCfg := &config.MemoryConfig{
+		Enabled:   true,
+		MaxInject: 5,
+		Embedding: config.EmbeddingConfig{Dimensions: 3},
+	}
+	embedder := &fixedEmbedder{vec: []float32{1, 0, 0}}
+	memSvc := memory.NewService(entClient, db, embedder, memCfg)
+
+	chainID := "mem-exec-chain"
+	chain := &config.ChainConfig{
+		AlertTypes: []string{"test-alert"},
+		Stages: []config.StageConfig{
+			{
+				Name:   "investigation",
+				Agents: []config.StageAgentConfig{{Name: "TestAgent"}},
+			},
+		},
+	}
+
+	// Seed a memory via a source session so FindSimilarWithBoosts can find it.
+	sourceSession, err := entClient.AlertSession.Create().
+		SetID(uuid.New().String()).
+		SetAlertData("historical alert").
+		SetAgentType("test").
+		SetAlertType("test-alert").
+		SetChainID(chainID).
+		SetStatus(alertsession.StatusCompleted).
+		SetAuthor("test").
+		Save(ctx)
+	require.NoError(t, err)
+
+	alertType := "test-alert"
+	err = memSvc.ApplyReflectorActions(ctx, "default", sourceSession.ID, &alertType, &chainID, 80,
+		&memory.ReflectorResult{Create: []memory.ReflectorCreateAction{
+			{Content: "Check PgBouncer connection pool health", Category: "procedural", Valence: "positive"},
+		}})
+	require.NoError(t, err)
+
+	// Two LLM calls: investigation agent (1 iteration) + exec_summary.
+	llm := &mockLLMClient{
+		capture: true,
+		responses: []mockLLMResponse{
+			{chunks: []agent.Chunk{
+				&agent.TextChunk{Content: "Everything looks healthy."},
+			}},
+			{chunks: []agent.Chunk{
+				&agent.TextChunk{Content: "Summary: all good."},
+			}},
+		},
+	}
+
+	cfg := testConfig(chainID, chain)
+	publisher := &testEventPublisher{}
+	executor := NewRealSessionExecutor(cfg, entClient, llm, publisher, nil, nil, memSvc, memCfg)
+	session := createExecutorTestSession(t, entClient, chainID)
+
+	result := executor.Execute(context.Background(), session)
+
+	require.NotNil(t, result)
+	assert.Equal(t, alertsession.StatusCompleted, result.Status)
+	assert.Nil(t, result.Error)
+
+	// The investigation agent (call 0) should have Tier 4 memory injection.
+	llm.mu.Lock()
+	require.GreaterOrEqual(t, len(llm.capturedInputs), 2, "expected at least 2 LLM calls (investigation + exec_summary)")
+	investigationInput := llm.capturedInputs[0]
+	execSummaryInput := llm.capturedInputs[1]
+	llm.mu.Unlock()
+
+	// Verify: investigation system prompt includes Tier 4 memories.
+	var investigationSystemPrompt string
+	for _, m := range investigationInput.Messages {
+		if m.Role == agent.RoleSystem {
+			investigationSystemPrompt = m.Content
+			break
+		}
+	}
+	assert.Contains(t, investigationSystemPrompt, "Lessons from Past Investigations",
+		"investigation agent must have Tier 4 memory injection")
+	assert.Contains(t, investigationSystemPrompt, "Check PgBouncer connection pool health")
+
+	// Verify: recall tool is available to the investigation agent.
+	var hasRecallTool bool
+	for _, tool := range investigationInput.Tools {
+		if tool.Name == memory.ToolRecallPastInvestigations {
+			hasRecallTool = true
+			break
+		}
+	}
+	assert.True(t, hasRecallTool, "investigation agent must expose recall_past_investigations tool")
+
+	// Verify: exec_summary agent does NOT get Tier 4 injection or recall tool.
+	var execSummarySystemPrompt string
+	for _, m := range execSummaryInput.Messages {
+		if m.Role == agent.RoleSystem {
+			execSummarySystemPrompt = m.Content
+			break
+		}
+	}
+	assert.NotContains(t, execSummarySystemPrompt, "Lessons from Past Investigations",
+		"exec_summary agent must NOT have Tier 4 memory injection")
+
+	var execSummaryHasRecall bool
+	for _, tool := range execSummaryInput.Tools {
+		if tool.Name == memory.ToolRecallPastInvestigations {
+			execSummaryHasRecall = true
+			break
+		}
+	}
+	assert.False(t, execSummaryHasRecall, "exec_summary agent must NOT have recall_past_investigations tool")
+
+	// Verify: injected memory IDs are recorded on the session.
+	updatedSession, err := entClient.AlertSession.Get(ctx, session.ID)
+	require.NoError(t, err)
+	injectedIDs, err := updatedSession.QueryInjectedMemories().IDs(ctx)
+	require.NoError(t, err)
+	assert.NotEmpty(t, injectedIDs, "session should have injected memory IDs recorded via Ent edge")
 }

--- a/pkg/queue/executor_memory.go
+++ b/pkg/queue/executor_memory.go
@@ -1,0 +1,78 @@
+package queue
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/codeready-toolchain/tarsy/ent"
+	"github.com/codeready-toolchain/tarsy/pkg/agent"
+	"github.com/codeready-toolchain/tarsy/pkg/memory"
+)
+
+// memoryToolWrapper returns a ToolExecutor wrapping function for the memory tool.
+// Returns nil when memory is disabled (no wrapping needed).
+func (e *RealSessionExecutor) memoryToolWrapper(session *ent.AlertSession) func(agent.ToolExecutor) agent.ToolExecutor {
+	if e.memoryService == nil || e.memoryConfig == nil {
+		return nil
+	}
+	var alertTypePtr *string
+	if session.AlertType != "" {
+		alertTypePtr = &session.AlertType
+	}
+	chainID := session.ChainID
+	return func(inner agent.ToolExecutor) agent.ToolExecutor {
+		return memory.NewToolExecutor(inner, e.memoryService, "default", alertTypePtr, &chainID, nil)
+	}
+}
+
+// memoryExcludeIDs builds a set of memory IDs to exclude from tool search results.
+// Returns nil when briefing is nil (no exclusions).
+func memoryExcludeIDs(briefing *agent.MemoryBriefing) map[string]struct{} {
+	if briefing == nil || len(briefing.InjectedIDs) == 0 {
+		return nil
+	}
+	ids := make(map[string]struct{}, len(briefing.InjectedIDs))
+	for _, id := range briefing.InjectedIDs {
+		ids[id] = struct{}{}
+	}
+	return ids
+}
+
+// retrieveMemories fetches the top memories for auto-injection into the agent prompt.
+// Returns nil if retrieval fails (best-effort — never blocks the investigation).
+func (e *RealSessionExecutor) retrieveMemories(ctx context.Context, session *ent.AlertSession, logger *slog.Logger) *agent.MemoryBriefing {
+	project := "default"
+
+	var alertTypePtr *string
+	if session.AlertType != "" {
+		alertTypePtr = &session.AlertType
+	}
+	chainIDPtr := &session.ChainID
+
+	memories, err := e.memoryService.FindSimilarWithBoosts(
+		ctx, project, session.AlertData, alertTypePtr, chainIDPtr, e.memoryConfig.MaxInject,
+	)
+	if err != nil {
+		logger.Warn("Failed to retrieve memories for injection", "error", err)
+		return nil
+	}
+	if len(memories) == 0 {
+		return nil
+	}
+
+	briefing := &agent.MemoryBriefing{
+		Memories:    make([]agent.MemoryHint, len(memories)),
+		InjectedIDs: make([]string, len(memories)),
+	}
+	for i, m := range memories {
+		briefing.Memories[i] = agent.MemoryHint{
+			ID:       m.ID,
+			Content:  m.Content,
+			Category: m.Category,
+			Valence:  m.Valence,
+		}
+		briefing.InjectedIDs[i] = m.ID
+	}
+	logger.Info("Retrieved memories for injection", "count", len(memories))
+	return briefing
+}

--- a/pkg/queue/executor_memory.go
+++ b/pkg/queue/executor_memory.go
@@ -6,8 +6,24 @@ import (
 
 	"github.com/codeready-toolchain/tarsy/ent"
 	"github.com/codeready-toolchain/tarsy/pkg/agent"
+	"github.com/codeready-toolchain/tarsy/pkg/config"
 	"github.com/codeready-toolchain/tarsy/pkg/memory"
 )
+
+// agentTypeSupportsMemory returns true for agent types whose prompts
+// consume MemoryBriefing (Tier 4 injection) and/or benefit from the
+// recall_past_investigations tool. Single-shot agents (synthesis,
+// exec_summary, scoring) use fixed prompt templates that ignore
+// MemoryBriefing, so retrieving memories would be wasteful and would
+// spuriously record injected IDs.
+func agentTypeSupportsMemory(agentType config.AgentType) bool {
+	switch agentType {
+	case config.AgentTypeDefault, config.AgentTypeAction, config.AgentTypeOrchestrator:
+		return true
+	default:
+		return false
+	}
+}
 
 // memoryToolWrapper returns a ToolExecutor wrapping function for the memory tool.
 // Returns nil when memory is disabled (no wrapping needed).

--- a/pkg/queue/executor_memory_test.go
+++ b/pkg/queue/executor_memory_test.go
@@ -4,8 +4,37 @@ import (
 	"testing"
 
 	"github.com/codeready-toolchain/tarsy/pkg/agent"
+	"github.com/codeready-toolchain/tarsy/pkg/config"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestAgentTypeSupportsMemory(t *testing.T) {
+	supported := []config.AgentType{
+		config.AgentTypeDefault,
+		config.AgentTypeAction,
+		config.AgentTypeOrchestrator,
+	}
+	for _, at := range supported {
+		name := string(at)
+		if name == "" {
+			name = "(default)"
+		}
+		t.Run(name+"_supported", func(t *testing.T) {
+			assert.True(t, agentTypeSupportsMemory(at))
+		})
+	}
+
+	unsupported := []config.AgentType{
+		config.AgentTypeSynthesis,
+		config.AgentTypeExecSummary,
+		config.AgentTypeScoring,
+	}
+	for _, at := range unsupported {
+		t.Run(string(at)+"_unsupported", func(t *testing.T) {
+			assert.False(t, agentTypeSupportsMemory(at))
+		})
+	}
+}
 
 func TestMemoryExcludeIDs(t *testing.T) {
 	tests := []struct {

--- a/pkg/queue/executor_memory_test.go
+++ b/pkg/queue/executor_memory_test.go
@@ -1,0 +1,53 @@
+package queue
+
+import (
+	"testing"
+
+	"github.com/codeready-toolchain/tarsy/pkg/agent"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMemoryExcludeIDs(t *testing.T) {
+	tests := []struct {
+		name     string
+		briefing *agent.MemoryBriefing
+		want     map[string]struct{}
+	}{
+		{
+			name:     "nil briefing",
+			briefing: nil,
+			want:     nil,
+		},
+		{
+			name:     "empty IDs",
+			briefing: &agent.MemoryBriefing{InjectedIDs: nil},
+			want:     nil,
+		},
+		{
+			name: "multiple IDs",
+			briefing: &agent.MemoryBriefing{
+				InjectedIDs: []string{"mem-1", "mem-2", "mem-3"},
+			},
+			want: map[string]struct{}{
+				"mem-1": {},
+				"mem-2": {},
+				"mem-3": {},
+			},
+		},
+		{
+			name: "single ID",
+			briefing: &agent.MemoryBriefing{
+				InjectedIDs: []string{"mem-1"},
+			},
+			want: map[string]struct{}{
+				"mem-1": {},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := memoryExcludeIDs(tt.briefing)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/test/e2e/harness.go
+++ b/test/e2e/harness.go
@@ -229,7 +229,7 @@ func NewTestApp(t *testing.T, opts ...TestAppOption) *TestApp {
 	// 8a. Scoring executor — created when any chain has scoring enabled.
 	var scoringExecutor *queue.ScoringExecutor
 	if hasScoringEnabled(tc.cfg) {
-		scoringExecutor = queue.NewScoringExecutor(tc.cfg, entClient, tc.llmClient, eventPublisher, nil, tc.memoryService)
+		scoringExecutor = queue.NewScoringExecutor(tc.cfg, entClient, tc.llmClient, eventPublisher, runbookService, tc.memoryService)
 	}
 
 	// 9. Worker pool.

--- a/test/e2e/harness.go
+++ b/test/e2e/harness.go
@@ -156,6 +156,11 @@ func NewTestApp(t *testing.T, opts ...TestAppOption) *TestApp {
 		tc.maxConcurrentSessions = tc.workerCount
 	}
 
+	// Guard: memory service requires a shared DB so both use the same schema.
+	if tc.memoryService != nil && tc.dbClient == nil {
+		t.Fatal("WithMemoryService requires WithDBClient using the same database")
+	}
+
 	// Default config if not provided.
 	if tc.cfg == nil {
 		tc.cfg = defaultTestConfig()

--- a/test/e2e/harness.go
+++ b/test/e2e/harness.go
@@ -18,6 +18,7 @@ import (
 	"github.com/codeready-toolchain/tarsy/pkg/database"
 	"github.com/codeready-toolchain/tarsy/pkg/events"
 	"github.com/codeready-toolchain/tarsy/pkg/mcp"
+	"github.com/codeready-toolchain/tarsy/pkg/memory"
 	"github.com/codeready-toolchain/tarsy/pkg/queue"
 	"github.com/codeready-toolchain/tarsy/pkg/runbook"
 	"github.com/codeready-toolchain/tarsy/pkg/services"
@@ -65,6 +66,8 @@ type testAppConfig struct {
 	dbClient              *database.Client    // injected DB client (for multi-replica tests)
 	podID                 string              // custom pod ID (for multi-replica tests)
 	slackService          *tarsyslack.Service // optional Slack service (for Slack notification tests)
+	memoryService         *memory.Service     // optional memory service (for memory injection tests)
+	memoryConfig          *config.MemoryConfig
 }
 
 // TestAppOption configures the test app.
@@ -124,6 +127,15 @@ func WithPodID(id string) TestAppOption {
 // Used for testing Slack integration with a mock API server.
 func WithSlackService(svc *tarsyslack.Service) TestAppOption {
 	return func(c *testAppConfig) { c.slackService = svc }
+}
+
+// WithMemoryService injects a pre-created memory service for memory injection
+// and recall tests. Must be paired with WithDBClient using the same database.
+func WithMemoryService(svc *memory.Service, cfg *config.MemoryConfig) TestAppOption {
+	return func(c *testAppConfig) {
+		c.memoryService = svc
+		c.memoryConfig = cfg
+	}
 }
 
 // NewTestApp creates and starts a full TARSy test instance.
@@ -207,7 +219,7 @@ func NewTestApp(t *testing.T, opts ...TestAppOption) *TestApp {
 	runbookService := runbook.NewService(tc.cfg.Runbooks, "", tc.cfg.Defaults.Runbook)
 
 	// 8. Session executor.
-	sessionExecutor := queue.NewRealSessionExecutor(tc.cfg, entClient, tc.llmClient, eventPublisher, mcpFactory, runbookService, nil, nil)
+	sessionExecutor := queue.NewRealSessionExecutor(tc.cfg, entClient, tc.llmClient, eventPublisher, mcpFactory, runbookService, tc.memoryService, tc.memoryConfig)
 
 	// 8a. Scoring executor — created when any chain has scoring enabled.
 	var scoringExecutor *queue.ScoringExecutor
@@ -230,7 +242,7 @@ func NewTestApp(t *testing.T, opts ...TestAppOption) *TestApp {
 			SessionTimeout:    tc.chatTimeout,
 			HeartbeatInterval: tc.cfg.Queue.HeartbeatInterval,
 		},
-		runbookService, nil, nil,
+		runbookService, tc.memoryService, tc.memoryConfig,
 	)
 
 	// 11. HTTP server on random port.

--- a/test/e2e/harness.go
+++ b/test/e2e/harness.go
@@ -224,7 +224,7 @@ func NewTestApp(t *testing.T, opts ...TestAppOption) *TestApp {
 	// 8a. Scoring executor — created when any chain has scoring enabled.
 	var scoringExecutor *queue.ScoringExecutor
 	if hasScoringEnabled(tc.cfg) {
-		scoringExecutor = queue.NewScoringExecutor(tc.cfg, entClient, tc.llmClient, eventPublisher, nil, nil)
+		scoringExecutor = queue.NewScoringExecutor(tc.cfg, entClient, tc.llmClient, eventPublisher, nil, tc.memoryService)
 	}
 
 	// 9. Worker pool.

--- a/test/e2e/harness.go
+++ b/test/e2e/harness.go
@@ -207,7 +207,7 @@ func NewTestApp(t *testing.T, opts ...TestAppOption) *TestApp {
 	runbookService := runbook.NewService(tc.cfg.Runbooks, "", tc.cfg.Defaults.Runbook)
 
 	// 8. Session executor.
-	sessionExecutor := queue.NewRealSessionExecutor(tc.cfg, entClient, tc.llmClient, eventPublisher, mcpFactory, runbookService)
+	sessionExecutor := queue.NewRealSessionExecutor(tc.cfg, entClient, tc.llmClient, eventPublisher, mcpFactory, runbookService, nil, nil)
 
 	// 8a. Scoring executor — created when any chain has scoring enabled.
 	var scoringExecutor *queue.ScoringExecutor
@@ -230,7 +230,7 @@ func NewTestApp(t *testing.T, opts ...TestAppOption) *TestApp {
 			SessionTimeout:    tc.chatTimeout,
 			HeartbeatInterval: tc.cfg.Queue.HeartbeatInterval,
 		},
-		runbookService,
+		runbookService, nil, nil,
 	)
 
 	// 11. HTTP server on random port.

--- a/test/e2e/memory_test.go
+++ b/test/e2e/memory_test.go
@@ -1,0 +1,447 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/codeready-toolchain/tarsy/pkg/agent"
+	"github.com/codeready-toolchain/tarsy/pkg/config"
+	"github.com/codeready-toolchain/tarsy/pkg/database"
+	"github.com/codeready-toolchain/tarsy/pkg/memory"
+	testdb "github.com/codeready-toolchain/tarsy/test/database"
+	"github.com/codeready-toolchain/tarsy/test/e2e/testdata/configs"
+)
+
+// ────────────────────────────────────────────────────────────
+// TestE2E_MemoryInjectionAndRecall — comprehensive memory E2E test.
+//
+// Single-stage investigation chain + chat follow-up:
+//   1. investigation (MemoryInvestigator) — tool call + final answer
+//   + Chat: recall_past_investigations tool call
+//
+// Pre-seeds memories in the DB, then verifies:
+//   - Tier 4 memory hints auto-injected into investigation prompt
+//   - recall_past_investigations tool in tool list
+//   - Injected memory IDs recorded in DB (Ent edge)
+//   - Chat prompt does NOT get Tier 4 auto-injection
+//   - Chat CAN use recall_past_investigations tool
+//   - recall tool result is formatted correctly
+//
+// Designed for Phase 3 extensibility: scoring + reflector extraction
+// can be layered on by enabling scoring in the config and adding
+// reflector LLM script entries after the investigation completes.
+// ────────────────────────────────────────────────────────────
+
+// fakeEmbedder returns a fixed vector for all embedding calls.
+// Dimension 3 keeps the test database setup lightweight.
+type fakeEmbedder struct {
+	vec []float32
+}
+
+func (f *fakeEmbedder) Embed(_ context.Context, _ string, _ memory.EmbeddingTask) ([]float32, error) {
+	return f.vec, nil
+}
+
+// setupMemoryService creates a memory.Service backed by the test DB with a
+// fixed-vector embedder. Adds the pgvector column that Ent doesn't manage.
+func setupMemoryService(t *testing.T, dbClient *database.Client, dims int) (*memory.Service, *config.MemoryConfig) {
+	t.Helper()
+	ctx := t.Context()
+
+	vec := make([]float32, dims)
+	vec[0] = 1 // deterministic unit vector along first axis
+
+	_, err := dbClient.DB().ExecContext(ctx,
+		`ALTER TABLE investigation_memories ADD COLUMN IF NOT EXISTS embedding vector(3)`)
+	require.NoError(t, err)
+
+	memCfg := &config.MemoryConfig{
+		Enabled:   true,
+		MaxInject: 5,
+		Embedding: config.EmbeddingConfig{Dimensions: dims},
+	}
+	svc := memory.NewService(dbClient.Client, dbClient.DB(), &fakeEmbedder{vec: vec}, memCfg)
+	return svc, memCfg
+}
+
+func TestE2E_MemoryInjectionAndRecall(t *testing.T) {
+	// ── Setup: DB + memory service + seed memories ──
+
+	dbClient := testdb.NewTestClient(t)
+	memSvc, memCfg := setupMemoryService(t, dbClient, 3)
+	ctx := t.Context()
+
+	// Create a source session for FK references (memories need a source_session_id).
+	sourceSession, err := dbClient.Client.AlertSession.Create().
+		SetID(uuid.New().String()).
+		SetAlertData("historical alert").
+		SetAgentType("test").
+		SetChainID("memory-chain").
+		SetStatus("completed").
+		Save(ctx)
+	require.NoError(t, err)
+
+	alertType := "memory-test"
+	chainID := "memory-chain"
+
+	// Seed memories that will be found by the investigation's similarity search.
+	err = memSvc.ApplyReflectorActions(ctx, "default", sourceSession.ID, &alertType, &chainID, 80,
+		&memory.ReflectorResult{Create: []memory.ReflectorCreateAction{
+			{Content: "Check PgBouncer connection pool health before investigating query latency", Category: "procedural", Valence: "positive"},
+			{Content: "Normal error rate for batch-processor during 2-4am is ~200/hr", Category: "semantic", Valence: "neutral"},
+		}})
+	require.NoError(t, err)
+
+	// Also seed a memory that won't be auto-injected (limit=5 but only 2 seeded)
+	// but can be found via the recall tool.
+	err = memSvc.ApplyReflectorActions(ctx, "default", sourceSession.ID, &alertType, &chainID, 80,
+		&memory.ReflectorResult{Create: []memory.ReflectorCreateAction{
+			{Content: "container_memory_rss metric does not exist in this setup", Category: "procedural", Valence: "negative"},
+		}})
+	require.NoError(t, err)
+
+	// ── Script LLM responses ──
+
+	llm := NewScriptedLLMClient()
+
+	// Stage 1 — investigation: tool call → final answer.
+	llm.AddSequential(LLMScriptEntry{
+		Chunks: []agent.Chunk{
+			&agent.ThinkingChunk{Content: "Let me check the pods."},
+			&agent.TextChunk{Content: "Checking pod status."},
+			&agent.ToolCallChunk{CallID: "call-1", Name: "test-mcp__get_pods", Arguments: `{"namespace":"default"}`},
+			&agent.UsageChunk{InputTokens: 100, OutputTokens: 30, TotalTokens: 130},
+		},
+	})
+	llm.AddSequential(LLMScriptEntry{
+		Chunks: []agent.Chunk{
+			&agent.ThinkingChunk{Content: "Pods look fine. Investigation complete."},
+			&agent.TextChunk{Content: "Investigation complete: all pods healthy."},
+			&agent.UsageChunk{InputTokens: 200, OutputTokens: 50, TotalTokens: 250},
+		},
+	})
+
+	// Executive summary.
+	llm.AddSequential(LLMScriptEntry{Text: "All pods healthy. No issues found."})
+
+	// Chat — iteration 1: agent calls recall_past_investigations.
+	llm.AddSequential(LLMScriptEntry{
+		Chunks: []agent.Chunk{
+			&agent.ThinkingChunk{Content: "Let me check past investigations for similar patterns."},
+			&agent.TextChunk{Content: "Searching past investigations."},
+			&agent.ToolCallChunk{
+				CallID:    "recall-1",
+				Name:      "recall_past_investigations",
+				Arguments: `{"query":"pod health check patterns","limit":10}`,
+			},
+			&agent.UsageChunk{InputTokens: 100, OutputTokens: 30, TotalTokens: 130},
+		},
+	})
+	// Chat — iteration 2: final answer after seeing recall results.
+	llm.AddSequential(LLMScriptEntry{
+		Chunks: []agent.Chunk{
+			&agent.ThinkingChunk{Content: "Past investigations suggest checking PgBouncer."},
+			&agent.TextChunk{Content: "Based on past investigations, check PgBouncer connection pool health."},
+			&agent.UsageChunk{InputTokens: 200, OutputTokens: 40, TotalTokens: 240},
+		},
+	})
+
+	// ── Boot TestApp ──
+
+	podsResult := `[{"name":"pod-1","status":"Running","restarts":0}]`
+	app := NewTestApp(t,
+		WithConfig(configs.Load(t, "memory")),
+		WithDBClient(dbClient),
+		WithLLMClient(llm),
+		WithMemoryService(memSvc, memCfg),
+		WithMCPServers(map[string]map[string]mcpsdk.ToolHandler{
+			"test-mcp": {
+				"get_pods": StaticToolHandler(podsResult),
+			},
+		}),
+	)
+
+	// ── Submit alert and wait for completion ──
+
+	resp := app.SubmitAlert(t, "memory-test", "Pod latency alert in production")
+	sessionID := resp["session_id"].(string)
+	require.NotEmpty(t, sessionID)
+
+	app.WaitForSessionStatus(t, sessionID, "completed")
+
+	// ── Chat follow-up ──
+
+	chatResp := app.SendChatMessage(t, sessionID, "What patterns have we seen before?")
+	chatStageID := chatResp["stage_id"].(string)
+	require.NotEmpty(t, chatStageID)
+	app.WaitForStageStatus(t, chatStageID, "completed")
+
+	// ════════════════════════════════════════════════════════════
+	// A. Quick behavioral assertions (via CapturedInputs)
+	// ════════════════════════════════════════════════════════════
+
+	captured := llm.CapturedInputs()
+	// Investigation: 2 (tool call + answer) + exec_summary: 1 + chat: 2 (recall + answer) = 5
+	require.Equal(t, 5, llm.CallCount(), "expected 5 LLM calls total")
+
+	// A1. Investigation first call: Tier 4 memory hints in system prompt.
+	investigatorInput := captured[0]
+	assertSystemPromptContains(t, investigatorInput,
+		"Lessons from Past Investigations",
+		"Tier 4 memory section should be in investigation system prompt")
+	assertSystemPromptContains(t, investigatorInput,
+		"[procedural, positive] Check PgBouncer connection pool health",
+		"seeded procedural memory should be in investigation prompt")
+	assertHasTool(t, investigatorInput, "recall_past_investigations")
+
+	// A2. Chat first call: NO Tier 4 auto-injection, but recall tool available.
+	chatInput := captured[3]
+	assertSystemPromptNotContains(t, chatInput,
+		"Lessons from Past Investigations",
+		"Tier 4 memory section should NOT be in chat system prompt")
+	assertHasTool(t, chatInput, "recall_past_investigations")
+
+	// A3. Chat iteration 2: recall tool result in conversation.
+	chatIter2 := captured[4]
+	recallResult := findToolResultMessage(chatIter2, "recall_past_investigations")
+	require.NotNil(t, recallResult, "chat iter 2 should have recall_past_investigations tool result")
+	assert.Contains(t, recallResult.Content, "relevant memories",
+		"recall result should contain formatted memories")
+
+	// ════════════════════════════════════════════════════════════
+	// B. DB state: injected memory IDs recorded via Ent edge
+	// ════════════════════════════════════════════════════════════
+
+	session, err := app.EntClient.AlertSession.Get(ctx, sessionID)
+	require.NoError(t, err)
+	injectedMemories, err := session.QueryInjectedMemories().All(ctx)
+	require.NoError(t, err)
+	assert.Len(t, injectedMemories, 3, "all 3 seeded memories should be recorded as injected")
+
+	var injectedContents []string
+	for _, m := range injectedMemories {
+		injectedContents = append(injectedContents, m.Content)
+	}
+	assert.Contains(t, injectedContents, "Check PgBouncer connection pool health before investigating query latency")
+	assert.Contains(t, injectedContents, "Normal error rate for batch-processor during 2-4am is ~200/hr")
+
+	// ════════════════════════════════════════════════════════════
+	// C. Normalizer setup (shared by timeline + trace golden assertions)
+	// ════════════════════════════════════════════════════════════
+
+	traceList := app.GetTraceList(t, sessionID)
+	traceStages, ok := traceList["stages"].([]interface{})
+	require.True(t, ok, "stages should be an array")
+	require.NotEmpty(t, traceStages)
+
+	normalizer := NewNormalizer(sessionID)
+	for _, rawStage := range traceStages {
+		stg, _ := rawStage.(map[string]interface{})
+		stageID, _ := stg["stage_id"].(string)
+		normalizer.RegisterStageID(stageID)
+
+		executions, _ := stg["executions"].([]interface{})
+		for _, rawExec := range executions {
+			exec, _ := rawExec.(map[string]interface{})
+			execID, _ := exec["execution_id"].(string)
+			normalizer.RegisterExecutionID(execID)
+
+			for _, rawLI := range exec["llm_interactions"].([]interface{}) {
+				li, _ := rawLI.(map[string]interface{})
+				if id, ok := li["id"].(string); ok {
+					normalizer.RegisterInteractionID(id)
+				}
+			}
+			for _, rawMI := range exec["mcp_interactions"].([]interface{}) {
+				mi, _ := rawMI.(map[string]interface{})
+				if id, ok := mi["id"].(string); ok {
+					normalizer.RegisterInteractionID(id)
+				}
+			}
+		}
+	}
+
+	traceSessionInteractions, _ := traceList["session_interactions"].([]interface{})
+	for _, rawLI := range traceSessionInteractions {
+		li, _ := rawLI.(map[string]interface{})
+		normalizer.RegisterInteractionID(li["id"].(string))
+	}
+
+	// ════════════════════════════════════════════════════════════
+	// D. Timeline golden file
+	// ════════════════════════════════════════════════════════════
+
+	execs := app.QueryExecutions(t, sessionID)
+	agentIndex := BuildAgentNameIndex(execs)
+
+	timeline := app.QueryTimeline(t, sessionID)
+	projectedTimeline := make([]map[string]interface{}, len(timeline))
+	for i, te := range timeline {
+		projectedTimeline[i] = ProjectTimelineForGolden(te)
+	}
+	AnnotateTimelineWithAgent(projectedTimeline, timeline, agentIndex)
+	SortTimelineProjection(projectedTimeline)
+	AssertGoldenJSON(t, GoldenPath("memory", "timeline.golden"), projectedTimeline, normalizer)
+
+	// ════════════════════════════════════════════════════════════
+	// E. Trace golden files: exact LLM + MCP interaction verification
+	// ════════════════════════════════════════════════════════════
+
+	AssertGoldenJSON(t, GoldenPath("memory", "trace_list.golden"), traceList, normalizer)
+
+	type interactionEntry struct {
+		Kind       string
+		ID         string
+		AgentName  string
+		CreatedAt  string
+		Label      string
+		ServerName string
+	}
+
+	var allInteractions []interactionEntry
+	for _, rawStage := range traceStages {
+		stg, _ := rawStage.(map[string]interface{})
+		for _, rawExec := range stg["executions"].([]interface{}) {
+			exec, _ := rawExec.(map[string]interface{})
+			agentName, _ := exec["agent_name"].(string)
+
+			var execInteractions []interactionEntry
+			for _, rawLI := range exec["llm_interactions"].([]interface{}) {
+				li, _ := rawLI.(map[string]interface{})
+				execInteractions = append(execInteractions, interactionEntry{
+					Kind:      "llm",
+					ID:        li["id"].(string),
+					AgentName: agentName,
+					CreatedAt: li["created_at"].(string),
+					Label:     li["interaction_type"].(string),
+				})
+			}
+			for _, rawMI := range exec["mcp_interactions"].([]interface{}) {
+				mi, _ := rawMI.(map[string]interface{})
+				label := mi["interaction_type"].(string)
+				if tn, ok := mi["tool_name"].(string); ok && tn != "" {
+					label = tn
+				}
+				sn, _ := mi["server_name"].(string)
+				execInteractions = append(execInteractions, interactionEntry{
+					Kind:       "mcp",
+					ID:         mi["id"].(string),
+					AgentName:  agentName,
+					CreatedAt:  mi["created_at"].(string),
+					Label:      label,
+					ServerName: sn,
+				})
+			}
+			sort.SliceStable(execInteractions, func(i, j int) bool {
+				a, b := execInteractions[i], execInteractions[j]
+				if a.CreatedAt != b.CreatedAt {
+					return a.CreatedAt < b.CreatedAt
+				}
+				return a.ServerName < b.ServerName
+			})
+			allInteractions = append(allInteractions, execInteractions...)
+		}
+	}
+
+	for _, rawLI := range traceSessionInteractions {
+		li, _ := rawLI.(map[string]interface{})
+		allInteractions = append(allInteractions, interactionEntry{
+			Kind:      "llm",
+			ID:        li["id"].(string),
+			AgentName: "Session",
+			CreatedAt: li["created_at"].(string),
+			Label:     li["interaction_type"].(string),
+		})
+	}
+
+	iterationCounters := make(map[string]int)
+	for idx, entry := range allInteractions {
+		counterKey := entry.AgentName + "_" + entry.Label
+		iterationCounters[counterKey]++
+		count := iterationCounters[counterKey]
+
+		label := strings.ReplaceAll(entry.Label, " ", "_")
+		filename := fmt.Sprintf("%02d_%s_%s_%s_%d.golden", idx+1, entry.AgentName, entry.Kind, label, count)
+		goldenPath := GoldenPath("memory", filepath.Join("trace_interactions", filename))
+
+		if entry.Kind == "llm" {
+			detail := app.GetLLMInteractionDetail(t, sessionID, entry.ID)
+			AssertGoldenLLMInteraction(t, goldenPath, detail, normalizer)
+		} else {
+			detail := app.GetMCPInteractionDetail(t, sessionID, entry.ID)
+			AssertGoldenMCPInteraction(t, goldenPath, detail, normalizer)
+		}
+	}
+}
+
+// TestE2E_MemoryDisabled verifies that when memory is not configured,
+// sessions complete normally without memory injection or the recall tool.
+func TestE2E_MemoryDisabled(t *testing.T) {
+	llm := NewScriptedLLMClient()
+
+	// Single-iteration investigation.
+	llm.AddSequential(LLMScriptEntry{
+		Chunks: []agent.Chunk{
+			&agent.ThinkingChunk{Content: "Quick check."},
+			&agent.TextChunk{Content: "Investigation complete."},
+			&agent.UsageChunk{InputTokens: 100, OutputTokens: 30, TotalTokens: 130},
+		},
+	})
+	// Executive summary.
+	llm.AddSequential(LLMScriptEntry{Text: "No issues found."})
+
+	app := NewTestApp(t,
+		WithConfig(configs.Load(t, "memory")),
+		WithLLMClient(llm),
+		// No WithMemoryService — memory is disabled despite config saying enabled.
+	)
+
+	resp := app.SubmitAlert(t, "memory-test", "Test alert")
+	sessionID := resp["session_id"].(string)
+	app.WaitForSessionStatus(t, sessionID, "completed")
+
+	captured := llm.CapturedInputs()
+	require.GreaterOrEqual(t, len(captured), 1)
+
+	// No Tier 4 section.
+	assertSystemPromptNotContains(t, captured[0],
+		"Lessons from Past Investigations",
+		"should not have memory section when memory service is nil")
+
+	// recall_past_investigations tool should NOT be in the tool list.
+	assertDoesNotHaveTool(t, captured[0], "recall_past_investigations")
+}
+
+// ────────────────────────────────────────────────────────────
+// Test helpers (memory-specific)
+// ────────────────────────────────────────────────────────────
+
+func assertSystemPromptNotContains(t *testing.T, input *agent.GenerateInput, substr, msg string) {
+	t.Helper()
+	for _, m := range input.Messages {
+		if m.Role == agent.RoleSystem && strings.Contains(m.Content, substr) {
+			t.Errorf("%s: system message should NOT contain %q", msg, substr)
+			return
+		}
+	}
+}
+
+func assertDoesNotHaveTool(t *testing.T, input *agent.GenerateInput, toolName string) {
+	t.Helper()
+	for _, tool := range input.Tools {
+		if tool.Name == toolName {
+			t.Errorf("tool list should NOT contain %q", toolName)
+			return
+		}
+	}
+}

--- a/test/e2e/memory_test.go
+++ b/test/e2e/memory_test.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -14,6 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/codeready-toolchain/tarsy/ent/stage"
 	"github.com/codeready-toolchain/tarsy/pkg/agent"
 	"github.com/codeready-toolchain/tarsy/pkg/config"
 	"github.com/codeready-toolchain/tarsy/pkg/database"
@@ -381,6 +383,122 @@ func TestE2E_MemoryInjectionAndRecall(t *testing.T) {
 			detail := app.GetMCPInteractionDetail(t, sessionID, entry.ID)
 			AssertGoldenMCPInteraction(t, goldenPath, detail, normalizer)
 		}
+	}
+}
+
+// TestE2E_MemoryReflectorCreation verifies the full memory creation pipeline:
+// investigation → scoring → reflector extracts learnings → memories stored in DB.
+//
+// LLM call sequence:
+//  1. Investigation: tool call + final answer (2 calls)
+//  2. Executive summary (1 call)
+//  3. Scoring: score evaluation + tool improvement (2 calls)
+//  4. Reflector: extracts learnings → returns JSON with create actions (1 call)
+func TestE2E_MemoryReflectorCreation(t *testing.T) {
+	dbClient := testdb.NewTestClient(t)
+	memSvc, memCfg := setupMemoryService(t, dbClient, 3)
+	ctx := t.Context()
+
+	llm := NewScriptedLLMClient()
+
+	// Investigation: tool call + final answer.
+	llm.AddSequential(LLMScriptEntry{
+		Chunks: []agent.Chunk{
+			&agent.ThinkingChunk{Content: "Let me check the pod status."},
+			&agent.TextChunk{Content: "Checking pods."},
+			&agent.ToolCallChunk{CallID: "call-1", Name: "test-mcp__get_pods", Arguments: `{"namespace":"default"}`},
+			&agent.UsageChunk{InputTokens: 80, OutputTokens: 20, TotalTokens: 100},
+		},
+	})
+	llm.AddSequential(LLMScriptEntry{
+		Chunks: []agent.Chunk{
+			&agent.ThinkingChunk{Content: "Pod is OOMKilled."},
+			&agent.TextChunk{Content: "Investigation complete: pod-1 is OOMKilled with 5 restarts."},
+			&agent.UsageChunk{InputTokens: 100, OutputTokens: 30, TotalTokens: 130},
+		},
+	})
+
+	// Executive summary.
+	llm.AddSequential(LLMScriptEntry{Text: "Pod-1 OOMKilled due to memory pressure. Recommend increasing memory limit."})
+
+	// Scoring turn 1: score evaluation.
+	llm.AddSequential(LLMScriptEntry{
+		Chunks: []agent.Chunk{
+			&agent.TextChunk{Content: "## Dimension Assessments\n\n" +
+				"**Investigation Outcome:** Correct conclusion.\n\n" +
+				"**Evidence Gathering:** incomplete_evidence — no memory metrics checked.\n\n" +
+				"## Overall Assessment\n\n" +
+				"Correct conclusion with gaps in evidence.\n\n70"},
+			&agent.UsageChunk{InputTokens: 400, OutputTokens: 80, TotalTokens: 480},
+		},
+	})
+	// Scoring turn 2: tool improvement report.
+	llm.AddSequential(LLMScriptEntry{
+		Chunks: []agent.Chunk{
+			&agent.TextChunk{Content: "## Missing Tools\n\n1. **get_memory_metrics** — Fetch memory usage time series."},
+			&agent.UsageChunk{InputTokens: 500, OutputTokens: 60, TotalTokens: 560},
+		},
+	})
+
+	// Reflector: returns JSON with memory create actions.
+	llm.AddSequential(LLMScriptEntry{
+		Chunks: []agent.Chunk{
+			&agent.TextChunk{Content: `{"create":[` +
+				`{"content":"When investigating OOMKilled pods, always check memory metrics and resource limits before concluding","category":"procedural","valence":"positive"},` +
+				`{"content":"Pod restarts above 3 in a short window strongly correlate with OOM kills","category":"semantic","valence":"neutral"}` +
+				`],"reinforce":[],"deprecate":[]}`},
+			&agent.UsageChunk{InputTokens: 600, OutputTokens: 100, TotalTokens: 700},
+		},
+	})
+
+	podsResult := `[{"name":"pod-1","status":"OOMKilled","restarts":5}]`
+	app := NewTestApp(t,
+		WithConfig(configs.Load(t, "memory-reflector")),
+		WithDBClient(dbClient),
+		WithLLMClient(llm),
+		WithMemoryService(memSvc, memCfg),
+		WithMCPServers(map[string]map[string]mcpsdk.ToolHandler{
+			"test-mcp": {
+				"get_pods": StaticToolHandler(podsResult),
+			},
+		}),
+	)
+
+	resp := app.SubmitAlert(t, "test-memory-reflector", "Pod OOMKilled in production")
+	sessionID := resp["session_id"].(string)
+	require.NotEmpty(t, sessionID)
+
+	app.WaitForSessionStatus(t, sessionID, "completed")
+
+	// Wait for the scoring stage to complete (includes reflector extraction).
+	require.Eventually(t, func() bool {
+		stgs, qErr := app.EntClient.Stage.Query().
+			Where(stage.SessionIDEQ(sessionID), stage.StageTypeEQ(stage.StageTypeScoring)).
+			All(context.Background())
+		if qErr != nil || len(stgs) == 0 {
+			return false
+		}
+		return stgs[0].Status == stage.StatusCompleted
+	}, 30*time.Second, 200*time.Millisecond, "scoring stage did not complete")
+
+	// Verify: memories were created in the DB by the reflector.
+	memories, err := app.EntClient.InvestigationMemory.Query().All(ctx)
+	require.NoError(t, err)
+	require.Len(t, memories, 2, "reflector should have created 2 memories")
+
+	contents := make([]string, len(memories))
+	for i, m := range memories {
+		contents[i] = m.Content
+	}
+	sort.Strings(contents)
+	assert.Equal(t, "Pod restarts above 3 in a short window strongly correlate with OOM kills", contents[0])
+	assert.Equal(t, "When investigating OOMKilled pods, always check memory metrics and resource limits before concluding", contents[1])
+
+	// Verify memory metadata.
+	for _, m := range memories {
+		assert.Equal(t, "default", m.Project)
+		assert.Equal(t, sessionID, m.SourceSessionID, "memory source_session_id should point to the scored session")
+		assert.False(t, m.Deprecated)
 	}
 }
 

--- a/test/e2e/testdata/configs/loader.go
+++ b/test/e2e/testdata/configs/loader.go
@@ -27,7 +27,7 @@ func configsDir() string {
 // tarsy.yaml and llm-providers.yaml.
 //
 // Available configs: pipeline, full-flow, two-stage-fail-fast,
-// parallel-any, parallel-all, replica, chat, forced-conclusion.
+// parallel-any, parallel-all, replica, chat, forced-conclusion, memory.
 func Load(t *testing.T, name string) *config.Config {
 	t.Helper()
 	dir := filepath.Join(configsDir(), name)

--- a/test/e2e/testdata/configs/memory-reflector/llm-providers.yaml
+++ b/test/e2e/testdata/configs/memory-reflector/llm-providers.yaml
@@ -1,0 +1,5 @@
+llm_providers:
+  test-provider:
+    type: google
+    model: test-model
+    max_tool_result_tokens: 10000

--- a/test/e2e/testdata/configs/memory-reflector/tarsy.yaml
+++ b/test/e2e/testdata/configs/memory-reflector/tarsy.yaml
@@ -1,0 +1,29 @@
+defaults:
+  llm_provider: "test-provider"
+  llm_backend: "google-native"
+  max_iterations: 3
+  memory:
+    enabled: true
+    max_inject: 5
+
+mcp_servers:
+  test-mcp:
+    transport:
+      type: stdio
+      command: mock
+
+agents:
+  Investigator:
+    mcp_servers: [test-mcp]
+    custom_instructions: "You are Investigator, gathering evidence about the alert."
+
+agent_chains:
+  memory-reflector-chain:
+    alert_types: [test-memory-reflector]
+    executive_summary_provider: "test-provider"
+    scoring:
+      enabled: true
+    stages:
+      - name: investigation
+        agents:
+          - name: Investigator

--- a/test/e2e/testdata/configs/memory/llm-providers.yaml
+++ b/test/e2e/testdata/configs/memory/llm-providers.yaml
@@ -1,0 +1,5 @@
+llm_providers:
+  test-provider:
+    type: google
+    model: test-model
+    max_tool_result_tokens: 10000

--- a/test/e2e/testdata/configs/memory/tarsy.yaml
+++ b/test/e2e/testdata/configs/memory/tarsy.yaml
@@ -1,0 +1,31 @@
+defaults:
+  llm_provider: "test-provider"
+  llm_backend: "google-native"
+  memory:
+    enabled: true
+    max_inject: 5
+
+mcp_servers:
+  test-mcp:
+    transport:
+      type: stdio
+      command: mock
+
+agents:
+  MemoryInvestigator:
+    mcp_servers: [test-mcp]
+    custom_instructions: "You are MemoryInvestigator, investigating infrastructure alerts."
+
+agent_chains:
+  memory-chain:
+    alert_types: [memory-test]
+    llm_provider: "test-provider"
+    llm_backend: "google-native"
+    chat:
+      enabled: true
+      agent: "ChatAgent"
+      llm_backend: "google-native"
+    stages:
+      - name: investigation
+        agents:
+          - name: MemoryInvestigator

--- a/test/e2e/testdata/golden/memory/timeline.golden
+++ b/test/e2e/testdata/golden/memory/timeline.golden
@@ -1,0 +1,136 @@
+[
+  {
+    "agent": "ChatAgent",
+    "content": "What patterns have we seen before?",
+    "event_type": "user_question",
+    "metadata": {
+      "author": "api-client"
+    },
+    "sequence": 7,
+    "status": "completed"
+  },
+  {
+    "agent": "ChatAgent",
+    "content": "Let me check past investigations for similar patterns.",
+    "event_type": "llm_thinking",
+    "metadata": {
+      "source": "native"
+    },
+    "sequence": 8,
+    "status": "completed"
+  },
+  {
+    "agent": "ChatAgent",
+    "content": "Searching past investigations.",
+    "event_type": "llm_response",
+    "sequence": 9,
+    "status": "completed"
+  },
+  {
+    "agent": "ChatAgent",
+    "content": "Found 3 relevant memories:\n\n1. [procedural, positive] Check PgBouncer connection pool health before investigating query latency\n2. [semantic, neutral] Normal error rate for batch-processor during 2-4am is ~200/hr\n3. [procedural, negative] container_memory_rss metric does not exist in this setup",
+    "event_type": "llm_tool_call",
+    "metadata": {
+      "arguments": "{\"query\":\"pod health check patterns\",\"limit\":10}",
+      "is_error": false,
+      "server_name": "",
+      "tool_name": "recall_past_investigations",
+      "tool_type": "mcp"
+    },
+    "sequence": 10,
+    "status": "completed"
+  },
+  {
+    "agent": "ChatAgent",
+    "content": "Past investigations suggest checking PgBouncer.",
+    "event_type": "llm_thinking",
+    "metadata": {
+      "source": "native"
+    },
+    "sequence": 11,
+    "status": "completed"
+  },
+  {
+    "agent": "ChatAgent",
+    "content": "Based on past investigations, check PgBouncer connection pool health.",
+    "event_type": "llm_response",
+    "sequence": 12,
+    "status": "completed"
+  },
+  {
+    "agent": "ChatAgent",
+    "content": "Based on past investigations, check PgBouncer connection pool health.",
+    "event_type": "final_analysis",
+    "sequence": 13,
+    "status": "completed"
+  },
+  {
+    "agent": "ExecSummaryAgent",
+    "content": "All pods healthy. No issues found.",
+    "event_type": "llm_response",
+    "sequence": 1,
+    "status": "completed"
+  },
+  {
+    "agent": "ExecSummaryAgent",
+    "content": "All pods healthy. No issues found.",
+    "event_type": "final_analysis",
+    "sequence": 2,
+    "status": "completed"
+  },
+  {
+    "agent": "MemoryInvestigator",
+    "content": "Let me check the pods.",
+    "event_type": "llm_thinking",
+    "metadata": {
+      "source": "native"
+    },
+    "sequence": 1,
+    "status": "completed"
+  },
+  {
+    "agent": "MemoryInvestigator",
+    "content": "Checking pod status.",
+    "event_type": "llm_response",
+    "sequence": 2,
+    "status": "completed"
+  },
+  {
+    "agent": "MemoryInvestigator",
+    "content": "[{\"name\":\"pod-1\",\"status\":\"Running\",\"restarts\":0}]",
+    "event_type": "llm_tool_call",
+    "metadata": {
+      "arguments": "{\"namespace\":\"default\"}",
+      "is_error": false,
+      "server_name": "test-mcp",
+      "tool_name": "get_pods",
+      "tool_type": "mcp"
+    },
+    "sequence": 3,
+    "status": "completed"
+  },
+  {
+    "agent": "MemoryInvestigator",
+    "content": "Pods look fine. Investigation complete.",
+    "event_type": "llm_thinking",
+    "metadata": {
+      "source": "native"
+    },
+    "sequence": 4,
+    "status": "completed"
+  },
+  {
+    "agent": "MemoryInvestigator",
+    "content": "Investigation complete: all pods healthy.",
+    "event_type": "llm_response",
+    "sequence": 5,
+    "status": "completed"
+  },
+  {
+    "agent": "MemoryInvestigator",
+    "content": "Investigation complete: all pods healthy.",
+    "event_type": "final_analysis",
+    "sequence": 6,
+    "status": "completed"
+  }
+]

--- a/test/e2e/testdata/golden/memory/trace_interactions/01_MemoryInvestigator_mcp_tool_list_1.golden
+++ b/test/e2e/testdata/golden/memory/trace_interactions/01_MemoryInvestigator_mcp_tool_list_1.golden
@@ -1,0 +1,14 @@
+{
+  "created_at": "{TIMESTAMP}",
+  "id": "{INTERACTION_ID_3}",
+  "interaction_type": "tool_list",
+  "server_name": ""
+}
+
+=== AVAILABLE_TOOLS ===
+[
+  {
+    "description": "Search learnings from past investigations of similar alerts. Use when you suspect a pattern you may have seen before, or want to check if previous investigations found useful context for this type of issue.",
+    "name": "recall_past_investigations"
+  }
+]

--- a/test/e2e/testdata/golden/memory/trace_interactions/02_MemoryInvestigator_mcp_tool_list_2.golden
+++ b/test/e2e/testdata/golden/memory/trace_interactions/02_MemoryInvestigator_mcp_tool_list_2.golden
@@ -1,0 +1,14 @@
+{
+  "created_at": "{TIMESTAMP}",
+  "id": "{INTERACTION_ID_4}",
+  "interaction_type": "tool_list",
+  "server_name": "test-mcp"
+}
+
+=== AVAILABLE_TOOLS ===
+[
+  {
+    "description": "test tool: get_pods",
+    "name": "get_pods"
+  }
+]

--- a/test/e2e/testdata/golden/memory/trace_interactions/03_MemoryInvestigator_llm_iteration_1.golden
+++ b/test/e2e/testdata/golden/memory/trace_interactions/03_MemoryInvestigator_llm_iteration_1.golden
@@ -56,9 +56,13 @@ The following are learnings from previous investigations of similar alerts.
 Consider them as hints — they may or may not apply to your current investigation.
 Do not treat them as rules.
 
+<memory_data>
 - [procedural, positive] Check PgBouncer connection pool health before investigating query latency
+
 - [semantic, neutral] Normal error rate for batch-processor during 2-4am is ~200/hr
+
 - [procedural, negative] container_memory_rss metric does not exist in this setup
+</memory_data>
 
 Focus on investigation and providing recommendations for human operators to execute.
 

--- a/test/e2e/testdata/golden/memory/trace_interactions/03_MemoryInvestigator_llm_iteration_1.golden
+++ b/test/e2e/testdata/golden/memory/trace_interactions/03_MemoryInvestigator_llm_iteration_1.golden
@@ -1,0 +1,97 @@
+{
+  "created_at": "{TIMESTAMP}",
+  "duration_ms": {DURATION_MS},
+  "id": "{INTERACTION_ID_1}",
+  "input_tokens": 100,
+  "interaction_type": "iteration",
+  "llm_request": {
+    "iteration": 1,
+    "messages_count": 2
+  },
+  "llm_response": {
+    "text_length": 20,
+    "tool_calls_count": 1
+  },
+  "model_name": "test-model",
+  "output_tokens": 30,
+  "thinking_content": "Let me check the pods.",
+  "total_tokens": 130
+}
+
+=== MESSAGE: system ===
+## General SRE Agent Instructions
+
+You are an expert Site Reliability Engineer (SRE) with deep knowledge of:
+- Kubernetes and container orchestration
+- Cloud infrastructure and services
+- Incident response and troubleshooting
+- System monitoring and alerting
+- GitOps and deployment practices
+
+Analyze alerts thoroughly and provide actionable insights based on:
+1. Alert information and context
+2. Associated runbook procedures
+3. Real-time system data from available tools
+
+Always be specific, reference actual data, and provide clear next steps.
+Focus on root cause analysis and sustainable solutions.
+
+## Evidence Transparency
+
+Your conclusions MUST be grounded in evidence you actually gathered, not assumptions:
+
+- **Distinguish data sources**: Clearly separate what you learned from tool results vs. what was already in the alert data. Never present alert metadata as if it were independently verified.
+- **Report tool failures honestly**: If a tool call fails, returns empty results, or returns errors — say so explicitly. Do not silently proceed as if you have the data.
+- **Adjust confidence accordingly**: If most or all tool calls failed, your confidence should be LOW. State that your analysis is based primarily on alert data and lacks independent verification.
+- **Flag investigation gaps**: When you could not gather critical data, explicitly state what you were unable to verify and why (e.g., "Tool X returned an error, so I could not confirm Y").
+- **Never fabricate evidence**: Do not invent details, metrics, or observations that did not appear in tool results or the alert data.
+
+## Agent-Specific Instructions
+
+You are MemoryInvestigator, investigating infrastructure alerts.
+
+## Lessons from Past Investigations
+
+The following are learnings from previous investigations of similar alerts.
+Consider them as hints — they may or may not apply to your current investigation.
+Do not treat them as rules.
+
+- [procedural, positive] Check PgBouncer connection pool health before investigating query latency
+- [semantic, neutral] Normal error rate for batch-processor during 2-4am is ~200/hr
+- [procedural, negative] container_memory_rss metric does not exist in this setup
+
+Focus on investigation and providing recommendations for human operators to execute.
+
+=== MESSAGE: user ===
+## Alert Details
+
+### Alert Metadata
+**Alert Type:** memory-test
+
+### Alert Data
+<!-- ALERT_DATA_START -->
+Pod latency alert in production
+<!-- ALERT_DATA_END -->
+
+## Runbook Content
+No runbook available.
+
+## Previous Stage Data
+No previous stage data is available for this alert. This is the first stage of analysis.
+
+## Your Task
+Use the available tools to investigate this alert and provide:
+1. Root cause analysis
+2. Current system state assessment
+3. Specific remediation steps for human operators
+4. Prevention recommendations
+
+Be thorough in your investigation before providing the final answer.
+
+For each factual finding about the current state of the system, reference where the data came from (e.g., which tool call, which log entry, which metric). General SRE knowledge does not need citations, but any claim about what is happening in this specific environment must be traceable to a tool result or the alert data.
+
+=== MESSAGE: assistant ===
+Checking pod status.
+--- TOOL_CALLS ---
+[call-1] test-mcp__get_pods({"namespace":"default"})
+

--- a/test/e2e/testdata/golden/memory/trace_interactions/04_MemoryInvestigator_mcp_get_pods_1.golden
+++ b/test/e2e/testdata/golden/memory/trace_interactions/04_MemoryInvestigator_mcp_get_pods_1.golden
@@ -1,0 +1,19 @@
+{
+  "created_at": "{TIMESTAMP}",
+  "duration_ms": {DURATION_MS},
+  "id": "{INTERACTION_ID_5}",
+  "interaction_type": "tool_call",
+  "server_name": "test-mcp",
+  "tool_name": "get_pods"
+}
+
+=== TOOL_ARGUMENTS ===
+{
+  "namespace": "default"
+}
+
+=== TOOL_RESULT ===
+{
+  "content": "[{\"name\":\"pod-1\",\"status\":\"Running\",\"restarts\":0}]",
+  "is_error": false
+}

--- a/test/e2e/testdata/golden/memory/trace_interactions/05_MemoryInvestigator_llm_iteration_2.golden
+++ b/test/e2e/testdata/golden/memory/trace_interactions/05_MemoryInvestigator_llm_iteration_2.golden
@@ -56,9 +56,13 @@ The following are learnings from previous investigations of similar alerts.
 Consider them as hints — they may or may not apply to your current investigation.
 Do not treat them as rules.
 
+<memory_data>
 - [procedural, positive] Check PgBouncer connection pool health before investigating query latency
+
 - [semantic, neutral] Normal error rate for batch-processor during 2-4am is ~200/hr
+
 - [procedural, negative] container_memory_rss metric does not exist in this setup
+</memory_data>
 
 Focus on investigation and providing recommendations for human operators to execute.
 

--- a/test/e2e/testdata/golden/memory/trace_interactions/05_MemoryInvestigator_llm_iteration_2.golden
+++ b/test/e2e/testdata/golden/memory/trace_interactions/05_MemoryInvestigator_llm_iteration_2.golden
@@ -1,0 +1,103 @@
+{
+  "created_at": "{TIMESTAMP}",
+  "duration_ms": {DURATION_MS},
+  "id": "{INTERACTION_ID_2}",
+  "input_tokens": 200,
+  "interaction_type": "iteration",
+  "llm_request": {
+    "iteration": 2,
+    "messages_count": 4
+  },
+  "llm_response": {
+    "text_length": 41,
+    "tool_calls_count": 0
+  },
+  "model_name": "test-model",
+  "output_tokens": 50,
+  "thinking_content": "Pods look fine. Investigation complete.",
+  "total_tokens": 250
+}
+
+=== MESSAGE: system ===
+## General SRE Agent Instructions
+
+You are an expert Site Reliability Engineer (SRE) with deep knowledge of:
+- Kubernetes and container orchestration
+- Cloud infrastructure and services
+- Incident response and troubleshooting
+- System monitoring and alerting
+- GitOps and deployment practices
+
+Analyze alerts thoroughly and provide actionable insights based on:
+1. Alert information and context
+2. Associated runbook procedures
+3. Real-time system data from available tools
+
+Always be specific, reference actual data, and provide clear next steps.
+Focus on root cause analysis and sustainable solutions.
+
+## Evidence Transparency
+
+Your conclusions MUST be grounded in evidence you actually gathered, not assumptions:
+
+- **Distinguish data sources**: Clearly separate what you learned from tool results vs. what was already in the alert data. Never present alert metadata as if it were independently verified.
+- **Report tool failures honestly**: If a tool call fails, returns empty results, or returns errors — say so explicitly. Do not silently proceed as if you have the data.
+- **Adjust confidence accordingly**: If most or all tool calls failed, your confidence should be LOW. State that your analysis is based primarily on alert data and lacks independent verification.
+- **Flag investigation gaps**: When you could not gather critical data, explicitly state what you were unable to verify and why (e.g., "Tool X returned an error, so I could not confirm Y").
+- **Never fabricate evidence**: Do not invent details, metrics, or observations that did not appear in tool results or the alert data.
+
+## Agent-Specific Instructions
+
+You are MemoryInvestigator, investigating infrastructure alerts.
+
+## Lessons from Past Investigations
+
+The following are learnings from previous investigations of similar alerts.
+Consider them as hints — they may or may not apply to your current investigation.
+Do not treat them as rules.
+
+- [procedural, positive] Check PgBouncer connection pool health before investigating query latency
+- [semantic, neutral] Normal error rate for batch-processor during 2-4am is ~200/hr
+- [procedural, negative] container_memory_rss metric does not exist in this setup
+
+Focus on investigation and providing recommendations for human operators to execute.
+
+=== MESSAGE: user ===
+## Alert Details
+
+### Alert Metadata
+**Alert Type:** memory-test
+
+### Alert Data
+<!-- ALERT_DATA_START -->
+Pod latency alert in production
+<!-- ALERT_DATA_END -->
+
+## Runbook Content
+No runbook available.
+
+## Previous Stage Data
+No previous stage data is available for this alert. This is the first stage of analysis.
+
+## Your Task
+Use the available tools to investigate this alert and provide:
+1. Root cause analysis
+2. Current system state assessment
+3. Specific remediation steps for human operators
+4. Prevention recommendations
+
+Be thorough in your investigation before providing the final answer.
+
+For each factual finding about the current state of the system, reference where the data came from (e.g., which tool call, which log entry, which metric). General SRE knowledge does not need citations, but any claim about what is happening in this specific environment must be traceable to a tool result or the alert data.
+
+=== MESSAGE: assistant ===
+Checking pod status.
+--- TOOL_CALLS ---
+[call-1] test-mcp__get_pods({"namespace":"default"})
+
+=== MESSAGE: tool (call-1, test-mcp__get_pods) ===
+[{"name":"pod-1","status":"Running","restarts":0}]
+
+=== MESSAGE: assistant ===
+Investigation complete: all pods healthy.
+

--- a/test/e2e/testdata/golden/memory/trace_interactions/06_ExecSummaryAgent_llm_executive_summary_1.golden
+++ b/test/e2e/testdata/golden/memory/trace_interactions/06_ExecSummaryAgent_llm_executive_summary_1.golden
@@ -1,0 +1,42 @@
+{
+  "created_at": "{TIMESTAMP}",
+  "duration_ms": {DURATION_MS},
+  "id": "{INTERACTION_ID_6}",
+  "input_tokens": 10,
+  "interaction_type": "executive_summary",
+  "llm_request": {
+    "iteration": 1,
+    "messages_count": 2
+  },
+  "llm_response": {
+    "text_length": 34,
+    "tool_calls_count": 0
+  },
+  "model_name": "test-model",
+  "output_tokens": 5,
+  "total_tokens": 15
+}
+
+=== MESSAGE: system ===
+You are an expert Site Reliability Engineer assistant that creates concise 1-4 line executive summaries of incident analyses for alert notifications. Focus on clarity, brevity, and actionable information.
+
+=== MESSAGE: user ===
+Generate a 1-4 line executive summary of this incident analysis.
+
+CRITICAL RULES:
+- Only summarize what is EXPLICITLY stated in the analysis
+- Do NOT infer future actions or recommendations not mentioned
+- Do NOT add your own conclusions
+- Focus on: what happened, current status, and ONLY stated next steps
+
+Analysis to summarize:
+
+=================================================================================
+Investigation complete: all pods healthy.
+=================================================================================
+
+Executive Summary (1-4 lines, facts only):
+
+=== MESSAGE: assistant ===
+All pods healthy. No issues found.
+

--- a/test/e2e/testdata/golden/memory/trace_interactions/07_ChatAgent_mcp_tool_list_1.golden
+++ b/test/e2e/testdata/golden/memory/trace_interactions/07_ChatAgent_mcp_tool_list_1.golden
@@ -1,0 +1,14 @@
+{
+  "created_at": "{TIMESTAMP}",
+  "id": "{INTERACTION_ID_9}",
+  "interaction_type": "tool_list",
+  "server_name": ""
+}
+
+=== AVAILABLE_TOOLS ===
+[
+  {
+    "description": "Search learnings from past investigations of similar alerts. Use when you suspect a pattern you may have seen before, or want to check if previous investigations found useful context for this type of issue.",
+    "name": "recall_past_investigations"
+  }
+]

--- a/test/e2e/testdata/golden/memory/trace_interactions/08_ChatAgent_mcp_tool_list_2.golden
+++ b/test/e2e/testdata/golden/memory/trace_interactions/08_ChatAgent_mcp_tool_list_2.golden
@@ -1,0 +1,14 @@
+{
+  "created_at": "{TIMESTAMP}",
+  "id": "{INTERACTION_ID_10}",
+  "interaction_type": "tool_list",
+  "server_name": "test-mcp"
+}
+
+=== AVAILABLE_TOOLS ===
+[
+  {
+    "description": "test tool: get_pods",
+    "name": "get_pods"
+  }
+]

--- a/test/e2e/testdata/golden/memory/trace_interactions/09_ChatAgent_llm_iteration_1.golden
+++ b/test/e2e/testdata/golden/memory/trace_interactions/09_ChatAgent_llm_iteration_1.golden
@@ -1,0 +1,109 @@
+{
+  "created_at": "{TIMESTAMP}",
+  "duration_ms": {DURATION_MS},
+  "id": "{INTERACTION_ID_7}",
+  "input_tokens": 100,
+  "interaction_type": "iteration",
+  "llm_request": {
+    "iteration": 1,
+    "messages_count": 2
+  },
+  "llm_response": {
+    "text_length": 30,
+    "tool_calls_count": 1
+  },
+  "model_name": "test-model",
+  "output_tokens": 30,
+  "thinking_content": "Let me check past investigations for similar patterns.",
+  "total_tokens": 130
+}
+
+=== MESSAGE: system ===
+## Chat Assistant Instructions
+
+You are an expert Site Reliability Engineer (SRE) assistant helping with follow-up questions about a completed alert investigation.
+
+The user has reviewed the investigation results and has follow-up questions. Your role is to:
+- Provide clear, actionable answers based on the investigation history
+- Use available tools to gather fresh, real-time data when needed
+- Reference specific findings from the original investigation when relevant
+- Maintain the same professional SRE communication style
+- Be concise but thorough in your responses
+
+You have access to the same tools and systems that were used in the original investigation.
+
+## Response Guidelines
+
+1. **Context Awareness**: Reference the investigation history when it provides relevant context
+2. **Fresh Data**: Use tools to gather current system state if the question requires up-to-date information
+3. **Clarity**: If the question is ambiguous or unclear, ask for clarification in your Final Answer
+4. **Specificity**: Always reference actual data and observations, not assumptions
+5. **Brevity**: Be concise but complete - users have already read the full investigation
+
+Focus on answering follow-up questions about a completed investigation for human operators to execute.
+
+=== MESSAGE: user ===
+## Alert Details
+
+### Alert Metadata
+**Alert Type:** memory-test
+
+### Alert Data
+<!-- ALERT_DATA_START -->
+Pod latency alert in production
+<!-- ALERT_DATA_END -->
+
+## Runbook Content
+No runbook available.
+
+═══════════════════════════════════════════════════════════════════════════════
+📋 INVESTIGATION HISTORY
+═══════════════════════════════════════════════════════════════════════════════
+
+## Stage 1: investigation
+
+**Agent:** MemoryInvestigator (google-native, test-provider)
+**Status**: completed
+
+**Internal Reasoning:**
+
+Let me check the pods.
+
+**Agent Response:**
+
+Checking pod status.
+
+**Tool Call:** test-mcp.get_pods({"namespace":"default"})
+**Result:**
+
+[{"name":"pod-1","status":"Running","restarts":0}]
+
+**Internal Reasoning:**
+
+Pods look fine. Investigation complete.
+
+**Agent Response:**
+
+Investigation complete: all pods healthy.
+
+
+═══════════════════════════════════════════════════════════════════════════════
+🎯 CURRENT TASK
+═══════════════════════════════════════════════════════════════════════════════
+
+**Question:** What patterns have we seen before?
+
+**Your Task:**
+Answer the user's question based on the investigation context above.
+- Reference investigation history when relevant
+- Use tools to get fresh data if needed
+- Provide clear, actionable responses
+
+Begin your response:
+
+
+=== MESSAGE: assistant ===
+Searching past investigations.
+--- TOOL_CALLS ---
+[recall-1] recall_past_investigations({"query":"pod health check patterns","limit":10})
+

--- a/test/e2e/testdata/golden/memory/trace_interactions/10_ChatAgent_mcp_recall_past_investigations_1.golden
+++ b/test/e2e/testdata/golden/memory/trace_interactions/10_ChatAgent_mcp_recall_past_investigations_1.golden
@@ -1,0 +1,20 @@
+{
+  "created_at": "{TIMESTAMP}",
+  "duration_ms": {DURATION_MS},
+  "id": "{INTERACTION_ID_11}",
+  "interaction_type": "tool_call",
+  "server_name": "",
+  "tool_name": "recall_past_investigations"
+}
+
+=== TOOL_ARGUMENTS ===
+{
+  "limit": 10,
+  "query": "pod health check patterns"
+}
+
+=== TOOL_RESULT ===
+{
+  "content": "Found 3 relevant memories:\n\n1. [procedural, positive] Check PgBouncer connection pool health before investigating query latency\n2. [semantic, neutral] Normal error rate for batch-processor during 2-4am is ~200/hr\n3. [procedural, negative] container_memory_rss metric does not exist in this setup",
+  "is_error": false
+}

--- a/test/e2e/testdata/golden/memory/trace_interactions/11_ChatAgent_llm_iteration_2.golden
+++ b/test/e2e/testdata/golden/memory/trace_interactions/11_ChatAgent_llm_iteration_2.golden
@@ -1,0 +1,119 @@
+{
+  "created_at": "{TIMESTAMP}",
+  "duration_ms": {DURATION_MS},
+  "id": "{INTERACTION_ID_8}",
+  "input_tokens": 200,
+  "interaction_type": "iteration",
+  "llm_request": {
+    "iteration": 2,
+    "messages_count": 4
+  },
+  "llm_response": {
+    "text_length": 69,
+    "tool_calls_count": 0
+  },
+  "model_name": "test-model",
+  "output_tokens": 40,
+  "thinking_content": "Past investigations suggest checking PgBouncer.",
+  "total_tokens": 240
+}
+
+=== MESSAGE: system ===
+## Chat Assistant Instructions
+
+You are an expert Site Reliability Engineer (SRE) assistant helping with follow-up questions about a completed alert investigation.
+
+The user has reviewed the investigation results and has follow-up questions. Your role is to:
+- Provide clear, actionable answers based on the investigation history
+- Use available tools to gather fresh, real-time data when needed
+- Reference specific findings from the original investigation when relevant
+- Maintain the same professional SRE communication style
+- Be concise but thorough in your responses
+
+You have access to the same tools and systems that were used in the original investigation.
+
+## Response Guidelines
+
+1. **Context Awareness**: Reference the investigation history when it provides relevant context
+2. **Fresh Data**: Use tools to gather current system state if the question requires up-to-date information
+3. **Clarity**: If the question is ambiguous or unclear, ask for clarification in your Final Answer
+4. **Specificity**: Always reference actual data and observations, not assumptions
+5. **Brevity**: Be concise but complete - users have already read the full investigation
+
+Focus on answering follow-up questions about a completed investigation for human operators to execute.
+
+=== MESSAGE: user ===
+## Alert Details
+
+### Alert Metadata
+**Alert Type:** memory-test
+
+### Alert Data
+<!-- ALERT_DATA_START -->
+Pod latency alert in production
+<!-- ALERT_DATA_END -->
+
+## Runbook Content
+No runbook available.
+
+═══════════════════════════════════════════════════════════════════════════════
+📋 INVESTIGATION HISTORY
+═══════════════════════════════════════════════════════════════════════════════
+
+## Stage 1: investigation
+
+**Agent:** MemoryInvestigator (google-native, test-provider)
+**Status**: completed
+
+**Internal Reasoning:**
+
+Let me check the pods.
+
+**Agent Response:**
+
+Checking pod status.
+
+**Tool Call:** test-mcp.get_pods({"namespace":"default"})
+**Result:**
+
+[{"name":"pod-1","status":"Running","restarts":0}]
+
+**Internal Reasoning:**
+
+Pods look fine. Investigation complete.
+
+**Agent Response:**
+
+Investigation complete: all pods healthy.
+
+
+═══════════════════════════════════════════════════════════════════════════════
+🎯 CURRENT TASK
+═══════════════════════════════════════════════════════════════════════════════
+
+**Question:** What patterns have we seen before?
+
+**Your Task:**
+Answer the user's question based on the investigation context above.
+- Reference investigation history when relevant
+- Use tools to get fresh data if needed
+- Provide clear, actionable responses
+
+Begin your response:
+
+
+=== MESSAGE: assistant ===
+Searching past investigations.
+--- TOOL_CALLS ---
+[recall-1] recall_past_investigations({"query":"pod health check patterns","limit":10})
+
+=== MESSAGE: tool (recall-1, recall_past_investigations) ===
+Found 3 relevant memories:
+
+1. [procedural, positive] Check PgBouncer connection pool health before investigating query latency
+2. [semantic, neutral] Normal error rate for batch-processor during 2-4am is ~200/hr
+3. [procedural, negative] container_memory_rss metric does not exist in this setup
+
+=== MESSAGE: assistant ===
+Based on past investigations, check PgBouncer connection pool health.
+

--- a/test/e2e/testdata/golden/memory/trace_list.golden
+++ b/test/e2e/testdata/golden/memory/trace_list.golden
@@ -1,0 +1,139 @@
+{
+  "session_interactions": [],
+  "stages": [
+    {
+      "executions": [
+        {
+          "agent_name": "MemoryInvestigator",
+          "execution_id": "{EXEC_ID_1}",
+          "llm_interactions": [
+            {
+              "created_at": "{TIMESTAMP}",
+              "duration_ms": {DURATION_MS},
+              "id": "{INTERACTION_ID_1}",
+              "input_tokens": 100,
+              "interaction_type": "iteration",
+              "model_name": "test-model",
+              "output_tokens": 30,
+              "total_tokens": 130
+            },
+            {
+              "created_at": "{TIMESTAMP}",
+              "duration_ms": {DURATION_MS},
+              "id": "{INTERACTION_ID_2}",
+              "input_tokens": 200,
+              "interaction_type": "iteration",
+              "model_name": "test-model",
+              "output_tokens": 50,
+              "total_tokens": 250
+            }
+          ],
+          "mcp_interactions": [
+            {
+              "created_at": "{TIMESTAMP}",
+              "id": "{INTERACTION_ID_3}",
+              "interaction_type": "tool_list",
+              "server_name": ""
+            },
+            {
+              "created_at": "{TIMESTAMP}",
+              "id": "{INTERACTION_ID_4}",
+              "interaction_type": "tool_list",
+              "server_name": "test-mcp"
+            },
+            {
+              "created_at": "{TIMESTAMP}",
+              "duration_ms": {DURATION_MS},
+              "id": "{INTERACTION_ID_5}",
+              "interaction_type": "tool_call",
+              "server_name": "test-mcp",
+              "tool_name": "get_pods"
+            }
+          ]
+        }
+      ],
+      "stage_id": "{STAGE_ID_1}",
+      "stage_name": "investigation",
+      "stage_type": "investigation"
+    },
+    {
+      "executions": [
+        {
+          "agent_name": "ExecSummaryAgent",
+          "execution_id": "{EXEC_ID_2}",
+          "llm_interactions": [
+            {
+              "created_at": "{TIMESTAMP}",
+              "duration_ms": {DURATION_MS},
+              "id": "{INTERACTION_ID_6}",
+              "input_tokens": 10,
+              "interaction_type": "executive_summary",
+              "model_name": "test-model",
+              "output_tokens": 5,
+              "total_tokens": 15
+            }
+          ],
+          "mcp_interactions": []
+        }
+      ],
+      "stage_id": "{STAGE_ID_2}",
+      "stage_name": "Executive Summary",
+      "stage_type": "exec_summary"
+    },
+    {
+      "executions": [
+        {
+          "agent_name": "ChatAgent",
+          "execution_id": "{EXEC_ID_3}",
+          "llm_interactions": [
+            {
+              "created_at": "{TIMESTAMP}",
+              "duration_ms": {DURATION_MS},
+              "id": "{INTERACTION_ID_7}",
+              "input_tokens": 100,
+              "interaction_type": "iteration",
+              "model_name": "test-model",
+              "output_tokens": 30,
+              "total_tokens": 130
+            },
+            {
+              "created_at": "{TIMESTAMP}",
+              "duration_ms": {DURATION_MS},
+              "id": "{INTERACTION_ID_8}",
+              "input_tokens": 200,
+              "interaction_type": "iteration",
+              "model_name": "test-model",
+              "output_tokens": 40,
+              "total_tokens": 240
+            }
+          ],
+          "mcp_interactions": [
+            {
+              "created_at": "{TIMESTAMP}",
+              "id": "{INTERACTION_ID_9}",
+              "interaction_type": "tool_list",
+              "server_name": ""
+            },
+            {
+              "created_at": "{TIMESTAMP}",
+              "id": "{INTERACTION_ID_10}",
+              "interaction_type": "tool_list",
+              "server_name": "test-mcp"
+            },
+            {
+              "created_at": "{TIMESTAMP}",
+              "duration_ms": {DURATION_MS},
+              "id": "{INTERACTION_ID_11}",
+              "interaction_type": "tool_call",
+              "server_name": "",
+              "tool_name": "recall_past_investigations"
+            }
+          ]
+        }
+      ],
+      "stage_id": "{STAGE_ID_3}",
+      "stage_name": "Chat",
+      "stage_type": "chat"
+    }
+  ]
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agents can recall past investigations via a built-in recall tool; investigation prompts auto-include a "Lessons from Past Investigations" section when relevant memories exist, while chat exposes the recall tool without auto-injecting that section.
  * Injected memory IDs are recorded on sessions to avoid duplicate recalls.

* **Tests**
  * Added unit, integration, and end-to-end tests and golden fixtures covering recall, injection, exclusion, prompt composition, and tool behavior.

* **Documentation**
  * Marked retrieval+injection phase done and added an example memory config in the sample YAML.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->