### PR TITLE
Enhance ReviewCell to restrict review actions to completed session status

### DIFF
--- a/web/dashboard/src/components/dashboard/ReviewCell.tsx
+++ b/web/dashboard/src/components/dashboard/ReviewCell.tsx
@@ -2,6 +2,7 @@ import { TableCell, Tooltip, Chip } from '@mui/material';
 import { ThumbsUpDown } from '@mui/icons-material';
 import { qualityReviewBodySx } from './qualityGroupSx.ts';
 import { getRatingConfig } from '../../constants/ratingConfig.ts';
+import { isTerminalStatus, type SessionStatus } from '../../constants/sessionStatus.ts';
 import type { DashboardSessionItem } from '../../types/session.ts';
 
 const iconOnlyChipSx = {
@@ -20,10 +21,12 @@ interface ReviewCellProps {
  * Shared review cell for both sessions list and triage tables.
  * Shows a colored thumb chip when reviewed, a ghost thumb on hover when not.
  * When onReviewClick is falsy the cell is read-only (no click, no hover affordance).
+ * Review is only available for terminal sessions (completed, failed, cancelled, timed_out).
  */
 export function ReviewCell({ session, onReviewClick }: ReviewCellProps) {
   const cfg = getRatingConfig(session.quality_rating);
-  const interactive = !!onReviewClick;
+  const terminal = isTerminalStatus(session.status as SessionStatus);
+  const interactive = !!onReviewClick && terminal;
 
   return (
     <TableCell sx={qualityReviewBodySx}>

--- a/web/dashboard/src/components/session/ExtractedLearningsCard.tsx
+++ b/web/dashboard/src/components/session/ExtractedLearningsCard.tsx
@@ -40,7 +40,7 @@ export default function ExtractedLearningsCard({ sessionId, hasScore, collapseCo
   const [memories, setMemories] = useState<MemoryItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [fetchError, setFetchError] = useState<Error | null>(null);
-  const [isExpanded, setIsExpanded] = useState(true);
+  const [isExpanded, setIsExpanded] = useState(false);
   const [retryCount, setRetryCount] = useState(0);
 
   useEffect(() => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Review functionality in session cells is now available only when sessions reach a terminal (completed) state
  * Extracted learnings section now starts collapsed by default instead of expanded

<!-- end of auto-generated comment: release notes by coderabbit.ai -->