### PR TITLE
Include chats in past session search result

### DIFF
--- a/pkg/agent/controller/summarize.go
+++ b/pkg/agent/controller/summarize.go
@@ -97,7 +97,7 @@ func maybeSummarize(
 	userPrompt := execCtx.PromptBuilder.BuildMCPSummarizationUserPrompt(conversationContext, serverID, toolName, truncatedForLLM)
 
 	// 6. Perform summarization LLM call with streaming
-	summary, usage, err := callSummarizationLLM(ctx, execCtx, systemPrompt, userPrompt, serverID, toolName, estimatedTokens, eventSeq, true)
+	summary, usage, err := callSummarizationLLM(ctx, execCtx, systemPrompt, userPrompt, serverID, toolName, estimatedTokens, eventSeq, summarizationStreamTarget{createEvent: true})
 	if err != nil {
 		slog.Warn("Summarization LLM call failed, using raw result",
 			"server", serverID, "tool", toolName, "error", err)
@@ -117,11 +117,21 @@ func maybeSummarize(
 	}, nil
 }
 
+// summarizationStreamTarget configures how summarization streams to the dashboard.
+type summarizationStreamTarget struct {
+	// createEvent creates a new mcp_tool_summary timeline event and streams to it.
+	createEvent bool
+	// existingEventID streams chunks to an existing timeline event (e.g. the
+	// llm_tool_call event for RequiredSummarization). Takes precedence over createEvent.
+	existingEventID string
+}
+
 // callSummarizationLLM performs the summarization LLM call with streaming.
-// When createTimelineEvent is true, creates an mcp_tool_summary timeline event
-// and streams chunks to WebSocket clients. When false, only performs the LLM
-// call and records the interaction (used by RequiredSummarization where the
-// summary is shown directly in the tool call event instead).
+// The streamTarget controls how chunks reach the dashboard:
+//   - createEvent: creates a new mcp_tool_summary event and streams to it
+//   - existingEventID: streams chunks to an already-created event (e.g. llm_tool_call)
+//   - neither: silently collects the stream (no dashboard updates)
+//
 // Always records an LLMInteraction with type "summarization".
 func callSummarizationLLM(
 	ctx context.Context,
@@ -130,7 +140,7 @@ func callSummarizationLLM(
 	serverID, toolName string,
 	estimatedTokens int,
 	eventSeq *int,
-	createTimelineEvent bool,
+	streamTarget summarizationStreamTarget,
 ) (string, *agent.TokenUsage, error) {
 	startTime := time.Now()
 
@@ -148,7 +158,7 @@ func callSummarizationLLM(
 		Backend:     execCtx.Config.LLMBackend,
 	}
 
-	streamed, err := callSummarizationLLMWithStreaming(ctx, execCtx, input, serverID, toolName, estimatedTokens, eventSeq, createTimelineEvent)
+	streamed, err := callSummarizationLLMWithStreaming(ctx, execCtx, input, serverID, toolName, estimatedTokens, eventSeq, streamTarget)
 	metrics.ObserveLLMCall(execCtx.Config.LLMProviderName, execCtx.Config.LLMProvider.Model,
 		time.Since(startTime), metricsTokens(streamed, err), err)
 	if err != nil {
@@ -175,9 +185,11 @@ func callSummarizationLLM(
 // The streaming pattern is identical (create event -> stream chunks -> finalize).
 // Simpler than callLLMWithStreaming: no thinking event (summarization has no thinking stream).
 //
-// When createTimelineEvent is false, the LLM call is still made and the stream
-// collected, but no timeline event is created or streamed. This is used for
-// RequiredSummarization where the summary becomes the tool call event content.
+// streamTarget controls dashboard streaming:
+//   - existingEventID: streams chunks to an already-created event (no new event created,
+//     no finalization — the caller is responsible for completing the event).
+//   - createEvent: creates a new mcp_tool_summary event and streams to it.
+//   - neither: silently collects the stream.
 func callSummarizationLLMWithStreaming(
 	ctx context.Context,
 	execCtx *agent.ExecutionContext,
@@ -185,7 +197,7 @@ func callSummarizationLLMWithStreaming(
 	serverID, toolName string,
 	estimatedTokens int,
 	eventSeq *int,
-	createTimelineEvent bool,
+	streamTarget summarizationStreamTarget,
 ) (*StreamedResponse, error) {
 	llmCtx, llmCancel := context.WithCancel(ctx)
 	defer llmCancel()
@@ -195,10 +207,39 @@ func callSummarizationLLMWithStreaming(
 		return nil, fmt.Errorf("summarization LLM Generate failed: %w", err)
 	}
 
-	if !createTimelineEvent || execCtx.EventPublisher == nil {
-		resp, err := collectStream(stream)
-		if err != nil {
-			return nil, err
+	// Stream to an existing event (e.g. the llm_tool_call for RequiredSummarization).
+	// Only publishes chunks — caller completes the event.
+	if streamTarget.existingEventID != "" && execCtx.EventPublisher != nil {
+		pid := parentExecID(execCtx)
+		callback := func(chunkType string, delta string) {
+			if delta == "" || chunkType != ChunkTypeText {
+				return
+			}
+			if pubErr := execCtx.EventPublisher.PublishStreamChunk(ctx, execCtx.SessionID, events.StreamChunkPayload{
+				BasePayload: events.BasePayload{
+					Type:      events.EventTypeStreamChunk,
+					SessionID: execCtx.SessionID,
+					Timestamp: time.Now().Format(time.RFC3339Nano),
+				},
+				EventID:           streamTarget.existingEventID,
+				ParentExecutionID: pid,
+				Delta:             delta,
+			}); pubErr != nil {
+				slog.Warn("Failed to publish summary stream chunk to existing event",
+					"event_id", streamTarget.existingEventID, "session_id", execCtx.SessionID, "error", pubErr)
+			}
+		}
+		resp, collectErr := collectStreamWithCallback(stream, callback, nil, 0, 0)
+		if collectErr != nil {
+			return nil, collectErr
+		}
+		return &StreamedResponse{LLMResponse: resp}, nil
+	}
+
+	if !streamTarget.createEvent || execCtx.EventPublisher == nil {
+		resp, collectErr := collectStream(stream)
+		if collectErr != nil {
+			return nil, collectErr
 		}
 		return &StreamedResponse{LLMResponse: resp}, nil
 	}

--- a/pkg/agent/controller/tool_execution.go
+++ b/pkg/agent/controller/tool_execution.go
@@ -137,10 +137,15 @@ func executeToolCall(
 	// large results via maybeSummarize (creates a separate mcp_tool_summary).
 	if !result.IsError && result.RequiredSummarization != nil {
 		estimatedTokens := mcp.EstimateTokens(result.Content)
+		var streamEventID string
+		if toolCallEvent != nil {
+			streamEventID = toolCallEvent.ID
+		}
 		summary, sumUsage, sumErr := callSummarizationLLM(ctx, execCtx,
 			result.RequiredSummarization.SystemPrompt,
 			result.RequiredSummarization.UserPrompt,
-			serverID, toolName, estimatedTokens, eventSeq, false)
+			serverID, toolName, estimatedTokens, eventSeq,
+			summarizationStreamTarget{existingEventID: streamEventID})
 		if sumErr != nil {
 			slog.Warn("Required summarization failed",
 				"server", serverID, "tool", toolName, "error", sumErr)

--- a/pkg/memory/service.go
+++ b/pkg/memory/service.go
@@ -836,6 +836,7 @@ func (s *Service) FetchChatExchanges(ctx context.Context, sessionIDs []string) (
 			continue
 		}
 
+		// Chat stages always have exactly one agent execution.
 		var ce ChatExchange
 		for _, evt := range execs[0].Edges.TimelineEvents {
 			switch evt.EventType {

--- a/pkg/memory/service.go
+++ b/pkg/memory/service.go
@@ -11,6 +11,8 @@ import (
 	"github.com/codeready-toolchain/tarsy/ent"
 	"github.com/codeready-toolchain/tarsy/ent/alertsession"
 	"github.com/codeready-toolchain/tarsy/ent/investigationmemory"
+	"github.com/codeready-toolchain/tarsy/ent/stage"
+	"github.com/codeready-toolchain/tarsy/ent/timelineevent"
 	"github.com/codeready-toolchain/tarsy/pkg/config"
 	"github.com/google/uuid"
 )
@@ -792,6 +794,67 @@ func (s *Service) SearchSessions(ctx context.Context, params SessionSearchParams
 		results = append(results, r)
 	}
 	return results, rows.Err()
+}
+
+const maxChatExchangesPerSession = 5
+
+// FetchChatExchanges retrieves follow-up chat Q&A for a set of session IDs.
+// Returns a map from session ID to chat exchanges (question + answer pairs),
+// capped at maxChatExchangesPerSession per session.
+func (s *Service) FetchChatExchanges(ctx context.Context, sessionIDs []string) (map[string][]ChatExchange, error) {
+	if len(sessionIDs) == 0 {
+		return nil, nil
+	}
+
+	stages, err := s.entClient.Stage.Query().
+		Where(
+			stage.SessionIDIn(sessionIDs...),
+			stage.StageTypeEQ(stage.StageTypeChat),
+		).
+		WithAgentExecutions(func(q *ent.AgentExecutionQuery) {
+			q.WithTimelineEvents(func(tq *ent.TimelineEventQuery) {
+				tq.Where(timelineevent.EventTypeIn(
+					timelineevent.EventTypeUserQuestion,
+					timelineevent.EventTypeFinalAnalysis,
+				))
+			})
+		}).
+		Order(ent.Asc(stage.FieldSessionID), ent.Asc(stage.FieldStageIndex)).
+		All(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("query chat stages: %w", err)
+	}
+
+	result := make(map[string][]ChatExchange, len(sessionIDs))
+	for _, stg := range stages {
+		if exchanges := result[stg.SessionID]; len(exchanges) >= maxChatExchangesPerSession {
+			continue
+		}
+
+		execs := stg.Edges.AgentExecutions
+		if len(execs) == 0 {
+			continue
+		}
+
+		var ce ChatExchange
+		for _, evt := range execs[0].Edges.TimelineEvents {
+			switch evt.EventType {
+			case timelineevent.EventTypeUserQuestion:
+				ce.Question = evt.Content
+			case timelineevent.EventTypeFinalAnalysis:
+				ce.Answer = evt.Content
+			}
+		}
+		if ce.Question == "" {
+			continue
+		}
+		if stg.StartedAt != nil {
+			ce.CreatedAt = *stg.StartedAt
+		}
+		result[stg.SessionID] = append(result[stg.SessionID], ce)
+	}
+
+	return result, nil
 }
 
 // formatVector converts a float32 slice to the pgvector string format: [1.0,2.0,3.0]

--- a/pkg/memory/session_search_integration_test.go
+++ b/pkg/memory/session_search_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/codeready-toolchain/tarsy/ent"
 	"github.com/codeready-toolchain/tarsy/pkg/agent"
 	"github.com/codeready-toolchain/tarsy/pkg/config"
 	"github.com/codeready-toolchain/tarsy/pkg/memory"
@@ -25,8 +26,9 @@ func addSessionSearchColumn(t *testing.T, db *stdsql.DB) {
 }
 
 type sessionSearchTestEnv struct {
-	svc *memory.Service
-	db  *stdsql.DB
+	svc       *memory.Service
+	db        *stdsql.DB
+	entClient *ent.Client
 }
 
 func newSessionSearchEnv(t *testing.T) *sessionSearchTestEnv {
@@ -44,7 +46,7 @@ func newSessionSearchEnv(t *testing.T) *sessionSearchTestEnv {
 	}
 	svc := memory.NewService(entClient, db, &fakeEmbedder{vec: []float32{1, 0, 0}}, cfg)
 
-	return &sessionSearchTestEnv{svc: svc, db: db}
+	return &sessionSearchTestEnv{svc: svc, db: db, entClient: entClient}
 }
 
 func (env *sessionSearchTestEnv) createSession(t *testing.T, alertData, alertType, status string, analysis *string) string {
@@ -344,4 +346,220 @@ func TestToolExecutor_SessionSearch_LimitClampedToMax(t *testing.T) {
 	assert.False(t, result.IsError)
 	require.NotNil(t, result.RequiredSummarization)
 	assert.Contains(t, result.RequiredSummarization.UserPrompt, "Matched sessions (10)")
+}
+
+// createChatStage creates a chat stage with an agent execution and timeline
+// events for user_question and final_analysis. Returns the stage ID.
+func (env *sessionSearchTestEnv) createChatStage(t *testing.T, sessionID string, stageIndex int, question, answer string) string {
+	t.Helper()
+	ctx := t.Context()
+
+	stageID := uuid.New().String()
+	stg, err := env.entClient.Stage.Create().
+		SetID(stageID).
+		SetSessionID(sessionID).
+		SetStageName("Chat").
+		SetStageIndex(stageIndex).
+		SetExpectedAgentCount(1).
+		SetStageType("chat").
+		SetStatus("completed").
+		SetStartedAt(time.Now()).
+		Save(ctx)
+	require.NoError(t, err)
+
+	execID := uuid.New().String()
+	exec, err := env.entClient.AgentExecution.Create().
+		SetID(execID).
+		SetStage(stg).
+		SetSessionID(sessionID).
+		SetAgentName("ChatAgent").
+		SetAgentIndex(1).
+		SetStatus("completed").
+		SetLlmBackend("test").
+		Save(ctx)
+	require.NoError(t, err)
+
+	now := time.Now()
+	_, err = env.entClient.TimelineEvent.Create().
+		SetID(uuid.New().String()).
+		SetSessionID(sessionID).
+		SetStageID(stageID).
+		SetExecutionID(execID).
+		SetAgentExecution(exec).
+		SetSequenceNumber(1).
+		SetCreatedAt(now).
+		SetUpdatedAt(now).
+		SetEventType("user_question").
+		SetStatus("completed").
+		SetContent(question).
+		Save(ctx)
+	require.NoError(t, err)
+
+	_, err = env.entClient.TimelineEvent.Create().
+		SetID(uuid.New().String()).
+		SetSessionID(sessionID).
+		SetStageID(stageID).
+		SetExecutionID(execID).
+		SetAgentExecution(exec).
+		SetSequenceNumber(2).
+		SetCreatedAt(now).
+		SetUpdatedAt(now).
+		SetEventType("final_analysis").
+		SetStatus("completed").
+		SetContent(answer).
+		Save(ctx)
+	require.NoError(t, err)
+
+	return stageID
+}
+
+func TestFetchChatExchanges_WithChatStages(t *testing.T) {
+	env := newSessionSearchEnv(t)
+	ctx := t.Context()
+
+	sessionID := env.createSession(t, "Alert: user alice triggered policy violation", "security", "completed", nil)
+	env.createChatStage(t, sessionID, 1, "What namespace was alice active in?", "alice was active in namespace prod")
+	env.createChatStage(t, sessionID, 2, "Any related deployments?", "No deployments found in the last 24h")
+
+	exchanges, err := env.svc.FetchChatExchanges(ctx, []string{sessionID})
+	require.NoError(t, err)
+
+	require.Len(t, exchanges[sessionID], 2)
+	assert.Equal(t, "What namespace was alice active in?", exchanges[sessionID][0].Question)
+	assert.Equal(t, "alice was active in namespace prod", exchanges[sessionID][0].Answer)
+	assert.Equal(t, "Any related deployments?", exchanges[sessionID][1].Question)
+	assert.Equal(t, "No deployments found in the last 24h", exchanges[sessionID][1].Answer)
+}
+
+func TestFetchChatExchanges_NoChatStages(t *testing.T) {
+	env := newSessionSearchEnv(t)
+	ctx := t.Context()
+
+	sessionID := env.createSession(t, "Alert: high CPU on node worker-1", "resource", "completed", nil)
+
+	exchanges, err := env.svc.FetchChatExchanges(ctx, []string{sessionID})
+	require.NoError(t, err)
+	assert.Empty(t, exchanges[sessionID])
+}
+
+func TestFetchChatExchanges_EmptySessionIDs(t *testing.T) {
+	env := newSessionSearchEnv(t)
+	ctx := t.Context()
+
+	exchanges, err := env.svc.FetchChatExchanges(ctx, nil)
+	require.NoError(t, err)
+	assert.Nil(t, exchanges)
+}
+
+func TestFetchChatExchanges_MultipleSessionsMixed(t *testing.T) {
+	env := newSessionSearchEnv(t)
+	ctx := t.Context()
+
+	sess1 := env.createSession(t, "Alert: user bob triggered restart", "security", "completed", nil)
+	env.createChatStage(t, sess1, 1, "What pod restarted?", "Pod nginx-abc restarted 3 times")
+
+	sess2 := env.createSession(t, "Alert: high memory on node-5", "resource", "completed", nil)
+	// sess2 has no chat stages
+
+	exchanges, err := env.svc.FetchChatExchanges(ctx, []string{sess1, sess2})
+	require.NoError(t, err)
+
+	require.Len(t, exchanges[sess1], 1)
+	assert.Equal(t, "What pod restarted?", exchanges[sess1][0].Question)
+	assert.Empty(t, exchanges[sess2])
+}
+
+func TestToolExecutor_SessionSearch_IncludesChatExchanges(t *testing.T) {
+	env := newSessionSearchEnv(t)
+	ctx := t.Context()
+
+	analysis := "User john-doe deployed unauthorized workload"
+	sessionID := env.createSession(t, "Alert: user john-doe triggered policy violation", "security", "completed", &analysis)
+	env.createChatStage(t, sessionID, 1, "What namespace was affected?", "namespace prod was affected with 3 unauthorized pods")
+
+	te := memory.NewToolExecutor(nil, env.svc, "", "default", nil)
+
+	result, err := te.Execute(ctx, sessionSearchToolCall(t, "john-doe", 0))
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	require.NotNil(t, result.RequiredSummarization)
+
+	prompt := result.RequiredSummarization.UserPrompt
+	assert.Contains(t, prompt, "john-doe")
+	assert.Contains(t, prompt, "unauthorized workload")
+	assert.Contains(t, prompt, "Follow-up conversations (1):")
+	assert.Contains(t, prompt, "Q1: What namespace was affected?")
+	assert.Contains(t, prompt, "A1: namespace prod was affected with 3 unauthorized pods")
+}
+
+func TestFetchChatExchanges_CappedAtMaxPerSession(t *testing.T) {
+	env := newSessionSearchEnv(t)
+	ctx := t.Context()
+
+	sessionID := env.createSession(t, "Alert: user eve triggered many follow-ups", "security", "completed", nil)
+	for i := range 7 {
+		env.createChatStage(t, sessionID, i+1,
+			"Question "+uuid.New().String()[:8],
+			"Answer "+uuid.New().String()[:8])
+	}
+
+	exchanges, err := env.svc.FetchChatExchanges(ctx, []string{sessionID})
+	require.NoError(t, err)
+	assert.Len(t, exchanges[sessionID], 5, "should cap at maxChatExchangesPerSession")
+}
+
+func TestFetchChatExchanges_QuestionOnlyNoAnswer(t *testing.T) {
+	env := newSessionSearchEnv(t)
+	ctx := t.Context()
+
+	sessionID := env.createSession(t, "Alert: user dave triggered restart", "security", "completed", nil)
+
+	// Create a chat stage with only a user_question event (no final_analysis).
+	stageID := uuid.New().String()
+	stg, err := env.entClient.Stage.Create().
+		SetID(stageID).
+		SetSessionID(sessionID).
+		SetStageName("Chat").
+		SetStageIndex(1).
+		SetExpectedAgentCount(1).
+		SetStageType("chat").
+		SetStatus("completed").
+		SetStartedAt(time.Now()).
+		Save(ctx)
+	require.NoError(t, err)
+
+	execID := uuid.New().String()
+	exec, err := env.entClient.AgentExecution.Create().
+		SetID(execID).
+		SetStage(stg).
+		SetSessionID(sessionID).
+		SetAgentName("ChatAgent").
+		SetAgentIndex(1).
+		SetStatus("completed").
+		SetLlmBackend("test").
+		Save(ctx)
+	require.NoError(t, err)
+
+	now := time.Now()
+	_, err = env.entClient.TimelineEvent.Create().
+		SetID(uuid.New().String()).
+		SetSessionID(sessionID).
+		SetStageID(stageID).
+		SetExecutionID(execID).
+		SetAgentExecution(exec).
+		SetSequenceNumber(1).
+		SetCreatedAt(now).
+		SetUpdatedAt(now).
+		SetEventType("user_question").
+		SetStatus("completed").
+		SetContent("What happened to the pod?").
+		Save(ctx)
+	require.NoError(t, err)
+
+	exchanges, err := env.svc.FetchChatExchanges(ctx, []string{sessionID})
+	require.NoError(t, err)
+
+	require.Len(t, exchanges[sessionID], 1)
+	assert.Equal(t, "What happened to the pod?", exchanges[sessionID][0].Question)
+	assert.Empty(t, exchanges[sessionID][0].Answer, "answer should be empty when no final_analysis event exists")
 }

--- a/pkg/memory/tool_executor.go
+++ b/pkg/memory/tool_executor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"strings"
 
 	"github.com/codeready-toolchain/tarsy/pkg/agent"
@@ -326,6 +327,18 @@ func (te *ToolExecutor) executeSessionSearch(ctx context.Context, call agent.Too
 		}, nil
 	}
 
+	sessionIDs := make([]string, len(sessions))
+	for i, s := range sessions {
+		sessionIDs[i] = s.SessionID
+	}
+	chatMap, err := te.service.FetchChatExchanges(ctx, sessionIDs)
+	if err != nil {
+		slog.Warn("Failed to fetch chat exchanges for session search", "error", err)
+	}
+	for i := range sessions {
+		sessions[i].ChatExchanges = chatMap[sessions[i].SessionID]
+	}
+
 	userPrompt := buildSessionSummarizationPrompt(args.Query, sessions)
 
 	return &agent.ToolResult{
@@ -346,6 +359,7 @@ Produce a focused digest covering:
 - Whether the searched entity (e.g. user, workload, service, IP) was investigated before
 - What the conclusions were for each matching investigation
 - Any human review corrections or quality assessments
+- Key findings from follow-up conversations (if any)
 - Patterns across multiple investigations of the same entity
 
 Preserve entity identifiers exactly as they appear — do not paraphrase names, namespaces, or IPs. Silently omit sessions that matched coincidentally but involve a different entity than the one queried.
@@ -380,6 +394,18 @@ func buildSessionSummarizationPrompt(query string, sessions []SessionSearchResul
 		}
 		if s.InvestigationFeedback != nil {
 			sb.WriteString(fmt.Sprintf("Human review feedback: %s\n", *s.InvestigationFeedback))
+		}
+
+		if len(s.ChatExchanges) > 0 {
+			sb.WriteString(fmt.Sprintf("Follow-up conversations (%d):\n", len(s.ChatExchanges)))
+			for j, ce := range s.ChatExchanges {
+				sb.WriteString(fmt.Sprintf("  Q%d: %s\n", j+1, ce.Question))
+				answer := ce.Answer
+				if answer == "" {
+					answer = "(no response recorded)"
+				}
+				sb.WriteString(fmt.Sprintf("  A%d: %s\n", j+1, answer))
+			}
 		}
 	}
 

--- a/pkg/memory/tool_executor_test.go
+++ b/pkg/memory/tool_executor_test.go
@@ -248,7 +248,11 @@ func TestBuildSessionSummarizationPrompt(t *testing.T) {
 			FinalAnalysis:         &analysis,
 			QualityRating:         &quality,
 			InvestigationFeedback: &feedback,
-			CreatedAt:             time.Date(2026, 3, 15, 10, 30, 0, 0, time.UTC),
+			ChatExchanges: []ChatExchange{
+				{Question: "What namespace was john-doe active in?", Answer: "john-doe was active in namespace prod with 3 failed deployments"},
+				{Question: "Was this correlated with the outage?", Answer: "No direct correlation found"},
+			},
+			CreatedAt: time.Date(2026, 3, 15, 10, 30, 0, 0, time.UTC),
 		},
 		{
 			SessionID: "sess-002",
@@ -269,6 +273,12 @@ func TestBuildSessionSummarizationPrompt(t *testing.T) {
 	assert.Contains(t, prompt, "Root cause: unauthorized deployment")
 	assert.Contains(t, prompt, "Quality assessment: accurate")
 	assert.Contains(t, prompt, "Human review feedback: Good investigation")
+
+	assert.Contains(t, prompt, "Follow-up conversations (2):")
+	assert.Contains(t, prompt, "Q1: What namespace was john-doe active in?")
+	assert.Contains(t, prompt, "A1: john-doe was active in namespace prod with 3 failed deployments")
+	assert.Contains(t, prompt, "Q2: Was this correlated with the outage?")
+	assert.Contains(t, prompt, "A2: No direct correlation found")
 
 	assert.Contains(t, prompt, "Session 2 (ID: sess-002, 2026-03-14 08:00)")
 	assert.Contains(t, prompt, "Alert type: resource")
@@ -291,6 +301,26 @@ func TestBuildSessionSummarizationPrompt_NilOptionalFields(t *testing.T) {
 	assert.Contains(t, prompt, "(none recorded)")
 	assert.NotContains(t, prompt, "Quality assessment:")
 	assert.NotContains(t, prompt, "Human review feedback:")
+	assert.NotContains(t, prompt, "Follow-up conversations")
+}
+
+func TestBuildSessionSummarizationPrompt_EmptyChatAnswer(t *testing.T) {
+	sessions := []SessionSearchResult{
+		{
+			SessionID: "sess-004",
+			AlertData: "Alert: test",
+			AlertType: "test",
+			ChatExchanges: []ChatExchange{
+				{Question: "Any follow-up?", Answer: ""},
+			},
+			CreatedAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		},
+	}
+
+	prompt := buildSessionSummarizationPrompt("test", sessions)
+
+	assert.Contains(t, prompt, "Q1: Any follow-up?")
+	assert.Contains(t, prompt, "A1: (no response recorded)")
 }
 
 func TestToolExecutor_ExcludeIDs(t *testing.T) {

--- a/pkg/memory/types.go
+++ b/pkg/memory/types.go
@@ -110,7 +110,15 @@ type SessionSearchResult struct {
 	FinalAnalysis         *string
 	QualityRating         *string
 	InvestigationFeedback *string
+	ChatExchanges         []ChatExchange
 	CreatedAt             time.Time
+}
+
+// ChatExchange holds a single follow-up chat question and the agent's answer.
+type ChatExchange struct {
+	Question  string
+	Answer    string
+	CreatedAt time.Time
 }
 
 // ReflectorResult holds the parsed output from a Reflector LLM call.

--- a/test/e2e/memory_test.go
+++ b/test/e2e/memory_test.go
@@ -1065,8 +1065,9 @@ func TestE2E_SearchPastSessionsInChat(t *testing.T) {
 	memSvc, memCfg := setupMemoryService(t, dbClient, 3)
 	ctx := t.Context()
 
-	// Pre-seed a completed session with searchable alert_data and review metadata.
-	// The search_vector column (GENERATED STORED) auto-computes from alert_data.
+	// Pre-seed a completed session with searchable alert_data, review metadata,
+	// and a follow-up chat exchange. The search_vector column (GENERATED STORED)
+	// auto-computes from alert_data.
 	seedSessionID := uuid.New().String()
 	finalAnalysis := "nginx-proxy was restarting due to a misconfigured liveness probe. Fixed by adjusting the probe threshold."
 	feedback := "Good investigation. Probe fix was correct."
@@ -1080,6 +1081,59 @@ func TestE2E_SearchPastSessionsInChat(t *testing.T) {
 		SetFinalAnalysis(finalAnalysis).
 		SetQualityRating(alertsession.QualityRatingAccurate).
 		SetInvestigationFeedback(feedback).
+		Save(ctx)
+	require.NoError(t, err)
+
+	// Seed a follow-up chat stage on the previous session so
+	// FetchChatExchanges includes it in the search results.
+	seedChatStage, err := dbClient.Client.Stage.Create().
+		SetID(uuid.New().String()).
+		SetSessionID(seedSessionID).
+		SetStageName("Chat").
+		SetStageIndex(1).
+		SetExpectedAgentCount(1).
+		SetStageType(stage.StageTypeChat).
+		SetStatus(stage.StatusCompleted).
+		SetStartedAt(time.Now()).
+		Save(ctx)
+	require.NoError(t, err)
+	seedExec, err := dbClient.Client.AgentExecution.Create().
+		SetID(uuid.New().String()).
+		SetStage(seedChatStage).
+		SetSessionID(seedSessionID).
+		SetAgentName("ChatAgent").
+		SetAgentIndex(1).
+		SetStatus(agentexecution.StatusCompleted).
+		SetLlmBackend("test").
+		Save(ctx)
+	require.NoError(t, err)
+	now := time.Now()
+	_, err = dbClient.Client.TimelineEvent.Create().
+		SetID(uuid.New().String()).
+		SetSessionID(seedSessionID).
+		SetStageID(seedChatStage.ID).
+		SetExecutionID(seedExec.ID).
+		SetAgentExecution(seedExec).
+		SetSequenceNumber(1).
+		SetCreatedAt(now).
+		SetUpdatedAt(now).
+		SetEventType("user_question").
+		SetStatus("completed").
+		SetContent("Which namespace was the liveness probe misconfigured in?").
+		Save(ctx)
+	require.NoError(t, err)
+	_, err = dbClient.Client.TimelineEvent.Create().
+		SetID(uuid.New().String()).
+		SetSessionID(seedSessionID).
+		SetStageID(seedChatStage.ID).
+		SetExecutionID(seedExec.ID).
+		SetAgentExecution(seedExec).
+		SetSequenceNumber(2).
+		SetCreatedAt(now).
+		SetUpdatedAt(now).
+		SetEventType("final_analysis").
+		SetStatus("completed").
+		SetContent("The liveness probe was misconfigured in namespace coolify on the nginx-proxy deployment.").
 		Save(ctx)
 	require.NoError(t, err)
 
@@ -1204,6 +1258,12 @@ func TestE2E_SearchPastSessionsInChat(t *testing.T) {
 		"summarization prompt should contain quality_rating")
 	assert.Contains(t, summarizationUserPrompt, "Good investigation",
 		"summarization prompt should contain investigation_feedback")
+	assert.Contains(t, summarizationUserPrompt, "Follow-up conversations (1):",
+		"summarization prompt should contain follow-up chat exchange count")
+	assert.Contains(t, summarizationUserPrompt, "Which namespace was the liveness probe misconfigured in?",
+		"summarization prompt should contain the follow-up question")
+	assert.Contains(t, summarizationUserPrompt, "misconfigured in namespace coolify on the nginx-proxy deployment",
+		"summarization prompt should contain the follow-up answer")
 
 	// A5. Chat iteration 2: search_past_sessions tool result in conversation.
 	chatIter2 := captured[5]

--- a/test/e2e/testdata/golden/memory-session-search/trace_interactions/10_ChatAgent_mcp_search_past_sessions_1.golden
+++ b/test/e2e/testdata/golden/memory-session-search/trace_interactions/10_ChatAgent_mcp_search_past_sessions_1.golden
@@ -14,6 +14,6 @@
 
 === TOOL_RESULT ===
 {
-  "content": "Search query: nginx-proxy\n\nMatched sessions (1):\n\n--- Session 1 (ID: {UUID}, {SHORT_TIMESTAMP}) ---\nAlert type: pod-restart\nAlert data:\nnginx-proxy pod restarting in namespace coolify with CrashLoopBackOff\nInvestigation conclusions:\nnginx-proxy was restarting due to a misconfigured liveness probe. Fixed by adjusting the probe threshold.\nQuality assessment: accurate\nHuman review feedback: Good investigation. Probe fix was correct.\n",
+  "content": "Search query: nginx-proxy\n\nMatched sessions (1):\n\n--- Session 1 (ID: {UUID}, {SHORT_TIMESTAMP}) ---\nAlert type: pod-restart\nAlert data:\nnginx-proxy pod restarting in namespace coolify with CrashLoopBackOff\nInvestigation conclusions:\nnginx-proxy was restarting due to a misconfigured liveness probe. Fixed by adjusting the probe threshold.\nQuality assessment: accurate\nHuman review feedback: Good investigation. Probe fix was correct.\nFollow-up conversations (1):\n  Q1: Which namespace was the liveness probe misconfigured in?\n  A1: The liveness probe was misconfigured in namespace coolify on the nginx-proxy deployment.\n",
   "is_error": false
 }

--- a/test/e2e/testdata/golden/memory-session-search/trace_interactions/11_ChatAgent_llm_summarization_1.golden
+++ b/test/e2e/testdata/golden/memory-session-search/trace_interactions/11_ChatAgent_llm_summarization_1.golden
@@ -24,6 +24,7 @@ Produce a focused digest covering:
 - Whether the searched entity (e.g. user, workload, service, IP) was investigated before
 - What the conclusions were for each matching investigation
 - Any human review corrections or quality assessments
+- Key findings from follow-up conversations (if any)
 - Patterns across multiple investigations of the same entity
 
 Preserve entity identifiers exactly as they appear — do not paraphrase names, namespaces, or IPs. Silently omit sessions that matched coincidentally but involve a different entity than the one queried.
@@ -43,6 +44,9 @@ Investigation conclusions:
 nginx-proxy was restarting due to a misconfigured liveness probe. Fixed by adjusting the probe threshold.
 Quality assessment: accurate
 Human review feedback: Good investigation. Probe fix was correct.
+Follow-up conversations (1):
+  Q1: Which namespace was the liveness probe misconfigured in?
+  A1: The liveness probe was misconfigured in namespace coolify on the nginx-proxy deployment.
 
 
 === MESSAGE: assistant ===

--- a/web/dashboard/src/components/streaming/StreamingContentRenderer.tsx
+++ b/web/dashboard/src/components/streaming/StreamingContentRenderer.tsx
@@ -130,6 +130,41 @@ const ResponseBlock = memo(({ content }: { content: string }) => {
 
 ResponseBlock.displayName = 'ResponseBlock';
 
+// --- StreamingToolContent ---
+// Auto-scrolling markdown block for streamed tool result content (e.g. session search summary).
+
+const StreamingToolContent = memo(({ content }: { content: string }) => {
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    }
+  }, [content]);
+
+  return (
+    <ContentCard ref={scrollRef} maxHeight="150px">
+      <Box sx={{
+        fontSize: '0.85rem',
+        '& p': { my: 0.5, lineHeight: 1.6 },
+        '& ul, & ol': { pl: 2.5, my: 0.5 },
+        '& li': { my: 0.25 },
+        '& h1, & h2, & h3, & h4': { mt: 1, mb: 0.5, fontSize: '0.9rem', fontWeight: 600 },
+      }}>
+        <ReactMarkdown
+          components={thoughtMarkdownComponents}
+          remarkPlugins={remarkPlugins}
+          skipHtml
+        >
+          {content}
+        </ReactMarkdown>
+      </Box>
+    </ContentCard>
+  );
+});
+
+StreamingToolContent.displayName = 'StreamingToolContent';
+
 // --- StreamingContentRenderer ---
 
 /**
@@ -261,51 +296,61 @@ const StreamingContentRenderer = memo(({ item, stageType }: StreamingContentRend
       statusLabel = getSkillNamesLabel(item.metadata?.arguments) ?? 'Loading...';
     }
 
+    const hasStreamedContent = isMemory && item.content && item.content.trim().length > 0;
+
     return (
       <Box sx={{ ml: 4, my: 1, mr: 1 }}>
         <Box
           sx={(theme) => ({
-            display: 'flex',
-            alignItems: 'center',
-            gap: 1.5,
-            px: 1.5,
-            py: 0.75,
-            border: '2px dashed',
-            borderColor: alpha(theme.palette[paletteKey].main, 0.4),
+            border: '1px solid',
+            borderColor: alpha(theme.palette[paletteKey].main, 0.25),
             borderRadius: 1.5,
-            bgcolor: alpha(theme.palette[paletteKey].main, 0.05),
+            bgcolor: alpha(theme.palette[paletteKey].main, 0.04),
           })}
         >
           <Box
-            sx={(theme) => ({
-              width: 18,
-              height: 18,
-              border: '2px solid',
-              borderColor: theme.palette[paletteKey].main,
-              borderTopColor: 'transparent',
-              borderRadius: '50%',
-              flexShrink: 0,
-              animation: 'spin 1s linear infinite',
-              '@keyframes spin': {
-                '0%': { transform: 'rotate(0deg)' },
-                '100%': { transform: 'rotate(360deg)' },
-              },
-            })}
-          />
-          <Typography
-            variant="body2"
-            sx={(theme) => ({
-              fontFamily: 'monospace',
-              fontWeight: 600,
-              fontSize: '0.9rem',
-              color: theme.palette[paletteKey].main,
-            })}
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 1.5,
+              px: 1.5,
+              py: 0.75,
+            }}
           >
-            {displayName}
-          </Typography>
-          <Typography variant="caption" color="text.secondary" sx={{ fontSize: '0.8rem', flex: 1 }}>
-            {statusLabel}
-          </Typography>
+            <Box
+              sx={(theme) => ({
+                width: 18,
+                height: 18,
+                border: '2px solid',
+                borderColor: theme.palette[paletteKey].main,
+                borderTopColor: 'transparent',
+                borderRadius: '50%',
+                flexShrink: 0,
+                animation: 'spin 1s linear infinite',
+                '@keyframes spin': {
+                  '0%': { transform: 'rotate(0deg)' },
+                  '100%': { transform: 'rotate(360deg)' },
+                },
+              })}
+            />
+            <Typography
+              variant="body2"
+              sx={(theme) => ({
+                fontFamily: 'monospace',
+                fontWeight: 600,
+                fontSize: '0.9rem',
+                color: theme.palette[paletteKey].main,
+              })}
+            >
+              {displayName}
+            </Typography>
+            <Typography variant="caption" color="text.secondary" sx={{ fontSize: '0.8rem', flex: 1 }}>
+              {statusLabel}
+            </Typography>
+          </Box>
+          {hasStreamedContent && (
+            <StreamingToolContent content={item.content} />
+          )}
         </Box>
       </Box>
     );

--- a/web/dashboard/src/components/streaming/StreamingContentRenderer.tsx
+++ b/web/dashboard/src/components/streaming/StreamingContentRenderer.tsx
@@ -6,7 +6,7 @@ import ContentCard from '../shared/ContentCard';
 import { TIMELINE_EVENT_TYPES } from '../../constants/eventTypes';
 import { LLM_INTERACTION_TYPE } from '../../constants/interactionTypes';
 import { getFinalAnalysisPresentation } from '../timeline/ResponseItem';
-import { TOOL_TYPE } from '../../constants/toolTypes';
+import { TOOL_TYPE, MEMORY_TOOL_NAME } from '../../constants/toolTypes';
 import { getSkillNamesLabel } from '../../utils/format';
 import { thoughtMarkdownComponents, remarkPlugins } from '../../utils/markdownComponents';
 
@@ -246,7 +246,8 @@ const StreamingContentRenderer = memo(({ item, stageType }: StreamingContentRend
     let displayName = toolName;
     let statusLabel = 'Executing...';
     if (isMemory) {
-      displayName = 'Recalling Insights';
+      const isSessionSearch = toolName === MEMORY_TOOL_NAME.SEARCH_PAST_SESSIONS;
+      displayName = isSessionSearch ? 'Searching Past Sessions' : 'Recalling Insights';
       const query = (() => {
         const raw = item.metadata?.arguments;
         if (!raw) return null;

--- a/web/dashboard/src/components/timeline/ToolCallItem.tsx
+++ b/web/dashboard/src/components/timeline/ToolCallItem.tsx
@@ -12,7 +12,7 @@ import { rehypeSearchHighlight } from '../../utils/rehypeSearchHighlight';
 import InsightsCard from './InsightsCard';
 import type { FlowItem } from '../../utils/timelineParser';
 import { EXECUTION_STATUS } from '../../constants/sessionStatus';
-import { TOOL_TYPE } from '../../constants/toolTypes';
+import { TOOL_TYPE, MEMORY_TOOL_NAME } from '../../constants/toolTypes';
 
 interface ToolCallItemProps {
   item: FlowItem;
@@ -201,7 +201,7 @@ function ToolCallItem({ item, expandAll = false, searchTerm }: ToolCallItemProps
     [searchTerm],
   );
 
-  const isSessionSearch = isMemory && toolName === 'search_past_sessions';
+  const isSessionSearch = isMemory && toolName === MEMORY_TOOL_NAME.SEARCH_PAST_SESSIONS;
 
   // Successful session search — markdown-rendered InsightsCard with history icon
   if (isSessionSearch && !isMcpFailure && !isToolResultError) {
@@ -313,7 +313,7 @@ function ToolCallItem({ item, expandAll = false, searchTerm }: ToolCallItemProps
   }
 
   const skillNamesLabel = isSkill ? getSkillNamesLabel(toolArguments) : null;
-  const displayName = isMemory ? 'Recalled Insights' : isSkill ? 'Loaded Skills' : toolName;
+  const displayName = isSessionSearch ? 'Session Search' : isMemory ? 'Recalled Insights' : isSkill ? 'Loaded Skills' : toolName;
 
   const getArgumentsPreview = (): string => {
     if (isMemory && toolArguments.query) return String(toolArguments.query);

--- a/web/dashboard/src/constants/toolTypes.ts
+++ b/web/dashboard/src/constants/toolTypes.ts
@@ -12,3 +12,13 @@ export const TOOL_TYPE = {
 } as const;
 
 export type ToolType = (typeof TOOL_TYPE)[keyof typeof TOOL_TYPE];
+
+/**
+ * Memory tool name constants.
+ *
+ * Values match the Go backend (pkg/memory/tool_executor.go).
+ */
+export const MEMORY_TOOL_NAME = {
+  RECALL_PAST_INVESTIGATIONS: 'recall_past_investigations',
+  SEARCH_PAST_SESSIONS: 'search_past_sessions',
+} as const;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session search results now include follow-up chat exchanges (Q/A pairs), capped at 5 per session; summaries/prompts show a "Follow-up conversations (N)" section (answers shown as "(no response recorded)" when empty).
  * In-progress memory tool calls display streaming content as rendered markdown with auto-scrolling and updated, lighter styling.
  * UI label changed to "Searching Past Sessions" for session-search tool calls.

* **Tests**
  * Added integration, unit, and end-to-end tests for exchange retrieval, capping, formatting, prompt inclusion, and UI rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->