### PR TITLE
Add implicit orchestrator design proposal

### DIFF
--- a/.cursor/commands/commit.md
+++ b/.cursor/commands/commit.md
@@ -26,7 +26,14 @@ Ask the user:
 > 1. Commit to this branch
 > 2. Create a new branch from `<default-branch>`
 
-If the user picks option 2, follow the same branch creation steps as above.
+If the user picks option 2, explicitly branch from `<default-branch>`:
+
+1. If there are uncommitted changes that would prevent checkout, ask the user whether to stash them first or abort.
+2. `git fetch origin`
+3. `git checkout <default-branch>`
+4. `git pull --ff-only`
+5. Re-apply stashed changes if applicable (`git stash pop`).
+6. Analyze the changes (see Step 3) and create a branch: `git checkout -b <branch-name>`.
 
 ## Step 3: Analyze changes
 

--- a/.cursor/commands/commit.md
+++ b/.cursor/commands/commit.md
@@ -1,0 +1,108 @@
+# Commit Changes
+
+Analyze uncommitted changes, create a branch if needed, and commit with a well-structured message.
+
+---
+
+## Step 1: Detect the default branch
+
+Run `git remote show origin` (or fall back to checking which of `main`/`master` exists locally) to determine the default branch name.
+
+## Step 2: Branch management
+
+### If currently on the default branch
+
+All uncommitted changes belong to a new feature/fix. **Create a new branch** before committing:
+
+1. Analyze the changes (see Step 3) to understand their purpose.
+2. Create a descriptive branch name: `<type>/<short-slug>` where type is `feat`, `fix`, `refactor`, `docs`, `chore`, `test`, etc.
+3. Run `git checkout -b <branch-name>`.
+
+### If currently on a non-default branch
+
+Ask the user:
+
+> You're on branch `<current-branch>`. Do you want to:
+> 1. Commit to this branch
+> 2. Create a new branch from `<default-branch>`
+
+If the user picks option 2, follow the same branch creation steps as above.
+
+## Step 3: Analyze changes
+
+Run these commands in parallel to understand the full picture:
+
+- `git status` — see all tracked/untracked changes
+- `git diff` — unstaged changes
+- `git diff --cached` — staged changes
+- `git diff HEAD` — combined view of all uncommitted changes
+Also run `git log --oneline -10` to glance at recent commit style. If the existing messages are well-structured and consistent, adopt their conventions (prefix style, tense, etc.) alongside the format rules below. If they are messy or inconsistent, ignore them and follow this command's format exclusively.
+
+Review all changes carefully. Understand **what** changed and **why** before writing the commit message.
+
+## Step 4: Stage and commit
+
+1. **Pre-flight check** — Before staging, review every file in the changeset for suspicious content:
+   - Secrets or credentials (API keys, tokens, passwords, `.env` files, private keys)
+   - Debug leftovers (console.log dumps, TODO/HACK/FIXME hacks, hardcoded localhost URLs, test data)
+   - Files that likely belong in `.gitignore` (build artifacts, editor configs, OS files like `.DS_Store`, vendor dirs, `node_modules`, `__pycache__`)
+   - Accidentally included large or binary files
+   - **Unrelated changes** — If some files appear thematically unrelated to the main body of changes (e.g., different feature, tooling config mixed with feature code, changes likely made by a parallel agent session), list them and ask the user whether to:
+     (a) Include everything in this commit with an adjusted message
+     (b) Exclude the unrelated files (leave unstaged for a separate commit)
+     (c) Create a separate commit for the unrelated files first
+     Do NOT silently include or exclude unrelated files — always ask.
+
+   **If anything suspicious or unrelated is found, STOP and ask the user** before proceeding. List the flagged files/lines and suggest whether to exclude them, add them to `.gitignore`, or confirm they're intentional.
+
+2. Stage all relevant files (`git add` — be selective based on the above review).
+3. Commit using `--signoff` and a HEREDOC for proper formatting:
+
+```bash
+git commit --signoff -m "$(cat <<'EOF'
+<title>
+
+<body>
+EOF
+)"
+```
+
+### Commit message format
+
+**Title** (first line):
+- Brief, imperative mood ("Add X", "Fix Y", "Refactor Z")
+- Describes **what the commit achieves** at a high level
+- No implementation details — someone should understand the purpose without reading the diff
+- Max ~60 characters
+- If the repo already uses Conventional Commits prefixes (`feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `chore:`, etc.) based on the `git log` check, adopt the same convention. Otherwise, don't add them — a clear imperative verb already conveys the type.
+
+**Body** (after blank line):
+- Key changes as concise bullet points
+- Focus on **important decisions and notable changes**, not a line-by-line changelog
+- Mention new files/packages only if they represent significant additions
+- Omit trivial or obvious details
+
+**Good example:**
+```
+Add hybrid memory retrieval for investigations
+
+- Combine semantic search (pgvector) with keyword matching (ts_query)
+- Merge results via reciprocal rank fusion (RRF)
+- Add configurable weight and limit parameters
+- Index investigation summaries on insert/update
+```
+
+**Bad example:**
+```
+Update memory.go, add search.go, modify config.yaml, fix tests
+
+- Changed MemoryService struct to add SearchEngine field
+- Added NewSearchEngine() constructor in search.go
+- Updated config.yaml to include memory.search section
+- Fixed TestMemoryService to pass new required param
+- Ran goimports on 3 files
+```
+
+## Step 5: Verify
+
+Run `git status` after committing to confirm success. Show the user the commit hash and summary.

--- a/docs/proposals/implicit-orchestrator-design.md
+++ b/docs/proposals/implicit-orchestrator-design.md
@@ -18,9 +18,9 @@ This proposal makes orchestration an **additive capability**: any agent that res
 ## Design Principles
 
 - **Orchestration is a capability, not an identity.** An investigation agent with sub-agents is still an investigation agent. A chat agent with sub-agents is still a chat agent. They just gain orchestrator tools and instructions.
-- **Single trigger.** The orchestrator wiring is gated on exactly one condition: `len(resolvedSubAgents) > 0`. This applies uniformly across all execution paths.
+- **Single trigger.** The orchestrator wiring is gated on exactly one condition: the filtered sub-agent catalog is non-empty after resolving refs and intersecting with the registry. Raw `sub_agents` refs that resolve to zero runnable agents do not trigger orchestration. This applies uniformly across all execution paths.
 - **Additive injection.** Orchestrator prompt sections (behavioral strategy, agent catalog, result delivery rules) are appended to the agent's existing system prompt. No separate prompt path.
-- **Minimal config migration.** Existing configs with `sub_agents` continue to work after removing `type: orchestrator` from agent definitions (the only required config change). All other YAML syntax is unchanged.
+- **Minimal config migration.** Existing configs require two changes: (1) remove `type: orchestrator` from agent definitions, and (2) replace references to the built-in `Orchestrator` agent with a suitable agent (e.g., `KubernetesAgent` or a custom agent) — orchestration is injected automatically when `sub_agents` are present. All other YAML syntax is unchanged.
 - **Convention over configuration.** Sub-agents present = orchestrator mode. One source of truth.
 
 ## Architecture
@@ -36,9 +36,10 @@ resolvedConfig.Type == AgentTypeOrchestrator?
 
 **After:**
 ```
-resolveSubAgents(chain, stage, agentConfig)
-  len(refs) > 0 → build SubAgentRunner, wrap tools, inject orchestrator prompt sections
-  len(refs) == 0 → plain agent
+refs := resolveSubAgents(chain, stage, agentConfig)
+catalog := registry.Filter(refs.Names())
+  catalog non-empty → build SubAgentRunner, wrap tools, inject orchestrator prompt sections
+  catalog empty     → plain agent
 ```
 
 ### Prompt injection model
@@ -68,15 +69,16 @@ The `orchestrator:` config block (max_concurrent_agents, agent_timeout, max_budg
 
 ### Circularity prevention
 
-No explicit prevention needed. Sub-agents run via `SubAgentRunner` with `execCtx.SubAgent` set, which gives them a task-only prompt and no orchestrator tools. A sub-agent cannot dispatch further sub-agents by runtime design, regardless of configuration.
+No explicit prevention needed. Sub-agents run via `SubAgentRunner` with `execCtx.SubAgent` set, which gives them a task-only prompt and no orchestrator tools — `SubAgentCatalog` and `SubAgentCollector` are never set on the sub-agent's `ExecutionContext`. A sub-agent cannot dispatch further sub-agents by runtime design, regardless of configuration. This invariant is enforced by dedicated tests (see PR1 test item 14).
 
 ## Core Concepts
 
 | Concept | Before | After |
 |---------|--------|-------|
-| Orchestrator trigger | `type: orchestrator` on agent | `len(resolvedSubAgents) > 0` at runtime |
+| Orchestrator trigger | `type: orchestrator` on agent | Non-empty filtered sub-agent catalog at runtime |
 | Prompt architecture | Separate `buildOrchestratorMessages` path | Injection layer onto existing prompt |
 | `AgentTypeOrchestrator` | Required for orchestration | Removed |
+| Built-in `Orchestrator` agent | Dedicated orchestrator identity | Removed — use any agent with sub-agents |
 | Chat orchestrator | Not supported | Supported via `ChatConfig.SubAgents` or chain inheritance |
 | Guardrails config | Only on `type: orchestrator` agents | Allowed on any agent |
 | Sub-agent registry | Excludes `type: orchestrator` | No type exclusion needed |
@@ -93,18 +95,18 @@ Existing orchestrator chains already have `sub_agents` configured, so orchestrat
 #### Config layer
 
 1. **`pkg/config/enums.go`** — Remove `AgentTypeOrchestrator` from the enum and `IsValid()`.
-2. **`pkg/config/builtin.go`** — Change built-in `Orchestrator` agent from `Type: AgentTypeOrchestrator` to `Type: AgentTypeDefault` (empty string).
+2. **`pkg/config/builtin.go`** — Remove the built-in `Orchestrator` agent (`AgentNameOrchestrator` constant and its `BuiltinAgentConfig` entry). A dedicated orchestrator agent contradicts the "capability, not identity" principle — any agent with sub-agents gains orchestration automatically.
 3. **`pkg/config/validator.go`** — Remove the rule tying `orchestrator:` block to `type: orchestrator`. Remove the `type == AgentTypeOrchestrator` check in `validateSubAgentRefs`.
 4. **`pkg/config/sub_agent_registry.go`** — Remove the `agent.Type == AgentTypeOrchestrator` exclusion from `BuildSubAgentRegistry`.
 
 #### Executor layer
 
-5. **`pkg/queue/executor.go`** — Replace `if resolvedConfig.Type == AgentTypeOrchestrator` with `subAgentRefs := resolveSubAgents(...); if len(subAgentRefs) > 0`. The orchestrator wiring block stays the same internally.
+5. **`pkg/queue/executor.go`** — Replace `if resolvedConfig.Type == AgentTypeOrchestrator` with: resolve sub-agent refs, filter against the registry, and gate on the filtered catalog being non-empty. The orchestrator wiring block stays the same internally.
 6. **`pkg/queue/executor_memory.go`** — Remove `AgentTypeOrchestrator` from `agentTypeSupportsMemory` switch (implicit orchestrators are `AgentTypeDefault`, already covered).
 
 #### Prompt layer
 
-7. **`pkg/agent/prompt/builder.go`** — Remove the `if execCtx.Config.Type == AgentTypeOrchestrator` dispatch in `BuildFunctionCallingMessages`. Instead, after building messages via the normal path (investigation/chat/action/sub-agent), inject orchestrator sections into the system message when `len(execCtx.SubAgentCatalog) > 0`.
+7. **`pkg/agent/prompt/builder.go`** — Remove the `if execCtx.Config.Type == AgentTypeOrchestrator` dispatch in `BuildFunctionCallingMessages`. Instead, after building messages via the normal path (investigation/chat/action/sub-agent), inject orchestrator sections into the system message when `SubAgentCatalog` is non-empty.
 8. **`pkg/agent/prompt/orchestrator.go`** — Refactor from a standalone message builder into an injection helper (e.g., `InjectOrchestratorSections(systemContent, catalog) string`). The orchestrator behavioral instructions, catalog formatting, and result delivery constants remain unchanged.
 
 #### Controller layer
@@ -113,14 +115,14 @@ Existing orchestrator chains already have `sub_agents` configured, so orchestrat
 
 #### Config files
 
-10. **`deploy/config/tarsy.yaml`** — Remove `type: orchestrator` from agent definitions.
-11. **`deploy/config/tarsy.yaml.example`** — Remove `type: orchestrator` from examples. Add `orchestrator:` guardrails block example to an agent definition (currently missing from the example file — see Q4).
-12. **`test/e2e/testdata/configs/orchestrator/tarsy.yaml`** — Remove `type: orchestrator`.
+10. **`deploy/config/tarsy.yaml`** — Remove `type: orchestrator` from agent definitions. Replace `name: "Orchestrator"` stage agent references with a suitable agent (e.g., `KubernetesAgent` or a custom agent defined in `agents:`).
+11. **`deploy/config/tarsy.yaml.example`** — Remove `type: orchestrator` from examples. Replace built-in `Orchestrator` references. Add `orchestrator:` guardrails block example to an agent definition (currently missing from the example file — see Q4).
+12. **`test/e2e/testdata/configs/`** — Remove `type: orchestrator` from all test configs. Update `builtin-orchestrator/tarsy.yaml` to use a custom agent instead of the removed built-in.
 13. **E2E golden files** — Update as needed.
 
 #### Tests
 
-14. Update unit tests across: `config/enums_test.go`, `config/validator_test.go`, `config/builtin_test.go`, `config/sub_agent_registry_test.go`, `config/loader_test.go`, `agent/config_resolver_test.go`, `agent/controller/factory_test.go`, `agent/prompt/builder_test.go`, `agent/prompt/orchestrator_test.go`, `queue/executor_memory_test.go`, `queue/executor_integration_test.go`.
+14. Update unit tests across: `config/enums_test.go`, `config/validator_test.go`, `config/builtin_test.go`, `config/sub_agent_registry_test.go`, `config/loader_test.go`, `agent/config_resolver_test.go`, `agent/controller/factory_test.go`, `agent/prompt/builder_test.go`, `agent/prompt/orchestrator_test.go`, `queue/executor_memory_test.go`, `queue/executor_integration_test.go`. Remove or replace all uses of `AgentNameOrchestrator` constant (`services/*_test.go`, `api/handler_trace_test.go`). Add recursion-safety tests verifying `SubAgentRunner` sets `execCtx.SubAgent` and never sets `SubAgentCatalog`/`SubAgentCollector` — sub-agents must not gain orchestrator tools or dispatch further sub-agents.
 15. Update E2E orchestrator tests in `test/e2e/orchestrator_test.go`.
 
 ### PR2: Chat orchestrator support (additive, opt-in)

--- a/docs/proposals/implicit-orchestrator-design.md
+++ b/docs/proposals/implicit-orchestrator-design.md
@@ -1,0 +1,135 @@
+# Implicit Orchestrator
+
+**Status:** Final — all decisions resolved in [implicit-orchestrator-questions.md](implicit-orchestrator-questions.md)
+
+## Overview
+
+Today, an agent must be declared `type: orchestrator` to gain sub-agent dispatch capabilities. This couples orchestration to agent identity rather than configuration, and makes it impossible for chat agents (or any other agent type) to dispatch sub-agents.
+
+This proposal makes orchestration an **additive capability**: any agent that resolves non-empty `sub_agents` at runtime automatically receives orchestrator tools (`dispatch_agent`, `cancel_agent`, `list_agents`) and orchestrator prompt sections injected into its existing system prompt. The `AgentTypeOrchestrator` enum value is removed entirely.
+
+**Primary goals:**
+
+1. Remove `AgentTypeOrchestrator` — clean code, no dead type.
+2. Gate orchestrator wiring on the presence of resolved sub-agents, not on type.
+3. Make orchestration an injection layer, not a separate prompt path — any agent keeps its identity.
+4. Enable chat agents to become orchestrators purely through configuration (PR2).
+
+## Design Principles
+
+- **Orchestration is a capability, not an identity.** An investigation agent with sub-agents is still an investigation agent. A chat agent with sub-agents is still a chat agent. They just gain orchestrator tools and instructions.
+- **Single trigger.** The orchestrator wiring is gated on exactly one condition: `len(resolvedSubAgents) > 0`. This applies uniformly across all execution paths.
+- **Additive injection.** Orchestrator prompt sections (behavioral strategy, agent catalog, result delivery rules) are appended to the agent's existing system prompt. No separate prompt path.
+- **Minimal config migration.** Existing configs with `sub_agents` continue to work after removing `type: orchestrator` from agent definitions (the only required config change). All other YAML syntax is unchanged.
+- **Convention over configuration.** Sub-agents present = orchestrator mode. One source of truth.
+
+## Architecture
+
+### Orchestration trigger (before vs. after)
+
+**Before:**
+```
+resolvedConfig.Type == AgentTypeOrchestrator?
+  YES → resolve sub-agents, build SubAgentRunner, wrap tools, build orchestrator prompts
+  NO  → plain agent
+```
+
+**After:**
+```
+resolveSubAgents(chain, stage, agentConfig)
+  len(refs) > 0 → build SubAgentRunner, wrap tools, inject orchestrator prompt sections
+  len(refs) == 0 → plain agent
+```
+
+### Prompt injection model
+
+The separate `buildOrchestratorMessages` dispatch path is eliminated. Instead, orchestrator sections are injected into whatever system prompt the agent already has:
+
+```
+[Normal system prompt — investigation / chat / action / custom instructions]
++ [Orchestrator Strategy]           ← injected when SubAgentCatalog non-empty
++ [Available Sub-Agents catalog]    ← injected when SubAgentCatalog non-empty
++ [Result Delivery rules]           ← injected when SubAgentCatalog non-empty
+```
+
+The user message is unaffected — it stays whatever the agent type produces (investigation context, chat question, action findings, etc.).
+
+### Chat sub-agent resolution (PR2)
+
+`ChatConfig` gains a `SubAgents SubAgentRefs` field. Resolution follows the same precedence pattern as `ChatConfig.MCPServers`:
+
+```
+chatCfg.SubAgents > chain.SubAgents > (empty — no orchestration)
+```
+
+### Guardrails
+
+The `orchestrator:` config block (max_concurrent_agents, agent_timeout, max_budget) is allowed on any agent definition. Resolution is unchanged: hardcoded defaults → `defaults.orchestrator` → `agentDef.Orchestrator`. The block is inert if the agent never resolves sub-agents.
+
+### Circularity prevention
+
+No explicit prevention needed. Sub-agents run via `SubAgentRunner` with `execCtx.SubAgent` set, which gives them a task-only prompt and no orchestrator tools. A sub-agent cannot dispatch further sub-agents by runtime design, regardless of configuration.
+
+## Core Concepts
+
+| Concept | Before | After |
+|---------|--------|-------|
+| Orchestrator trigger | `type: orchestrator` on agent | `len(resolvedSubAgents) > 0` at runtime |
+| Prompt architecture | Separate `buildOrchestratorMessages` path | Injection layer onto existing prompt |
+| `AgentTypeOrchestrator` | Required for orchestration | Removed |
+| Chat orchestrator | Not supported | Supported via `ChatConfig.SubAgents` or chain inheritance |
+| Guardrails config | Only on `type: orchestrator` agents | Allowed on any agent |
+| Sub-agent registry | Excludes `type: orchestrator` | No type exclusion needed |
+| Memory support | Type-based check includes orchestrator | `AgentTypeDefault` covers implicit orchestrators |
+
+## Implementation Plan
+
+**Hard constraint:** After every PR, TARSy must be fully functional. Config changes are acceptable, but no PR may leave any feature broken. Final code must be clean — no dead or legacy code.
+
+### PR1: Sub-agent-driven orchestration + type removal
+
+Existing orchestrator chains already have `sub_agents` configured, so orchestration keeps working via the new trigger. Configs need updating: `type: orchestrator` becomes invalid and must be removed from agent definitions.
+
+#### Config layer
+
+1. **`pkg/config/enums.go`** — Remove `AgentTypeOrchestrator` from the enum and `IsValid()`.
+2. **`pkg/config/builtin.go`** — Change built-in `Orchestrator` agent from `Type: AgentTypeOrchestrator` to `Type: AgentTypeDefault` (empty string).
+3. **`pkg/config/validator.go`** — Remove the rule tying `orchestrator:` block to `type: orchestrator`. Remove the `type == AgentTypeOrchestrator` check in `validateSubAgentRefs`.
+4. **`pkg/config/sub_agent_registry.go`** — Remove the `agent.Type == AgentTypeOrchestrator` exclusion from `BuildSubAgentRegistry`.
+
+#### Executor layer
+
+5. **`pkg/queue/executor.go`** — Replace `if resolvedConfig.Type == AgentTypeOrchestrator` with `subAgentRefs := resolveSubAgents(...); if len(subAgentRefs) > 0`. The orchestrator wiring block stays the same internally.
+6. **`pkg/queue/executor_memory.go`** — Remove `AgentTypeOrchestrator` from `agentTypeSupportsMemory` switch (implicit orchestrators are `AgentTypeDefault`, already covered).
+
+#### Prompt layer
+
+7. **`pkg/agent/prompt/builder.go`** — Remove the `if execCtx.Config.Type == AgentTypeOrchestrator` dispatch in `BuildFunctionCallingMessages`. Instead, after building messages via the normal path (investigation/chat/action/sub-agent), inject orchestrator sections into the system message when `len(execCtx.SubAgentCatalog) > 0`.
+8. **`pkg/agent/prompt/orchestrator.go`** — Refactor from a standalone message builder into an injection helper (e.g., `InjectOrchestratorSections(systemContent, catalog) string`). The orchestrator behavioral instructions, catalog formatting, and result delivery constants remain unchanged.
+
+#### Controller layer
+
+9. **`pkg/agent/controller/factory.go`** — Remove the `AgentTypeOrchestrator` case (was identical to `AgentTypeDefault` → `IteratingController`).
+
+#### Config files
+
+10. **`deploy/config/tarsy.yaml`** — Remove `type: orchestrator` from agent definitions.
+11. **`deploy/config/tarsy.yaml.example`** — Remove `type: orchestrator` from examples. Add `orchestrator:` guardrails block example to an agent definition (currently missing from the example file — see Q4).
+12. **`test/e2e/testdata/configs/orchestrator/tarsy.yaml`** — Remove `type: orchestrator`.
+13. **E2E golden files** — Update as needed.
+
+#### Tests
+
+14. Update unit tests across: `config/enums_test.go`, `config/validator_test.go`, `config/builtin_test.go`, `config/sub_agent_registry_test.go`, `config/loader_test.go`, `agent/config_resolver_test.go`, `agent/controller/factory_test.go`, `agent/prompt/builder_test.go`, `agent/prompt/orchestrator_test.go`, `queue/executor_memory_test.go`, `queue/executor_integration_test.go`.
+15. Update E2E orchestrator tests in `test/e2e/orchestrator_test.go`.
+
+### PR2: Chat orchestrator support (additive, opt-in)
+
+Only configs that add `chat.sub_agents` are affected.
+
+1. **`pkg/config/types.go`** — Add `SubAgents SubAgentRefs` to `ChatConfig`.
+2. **`pkg/config/validator.go`** — Validate `ChatConfig.SubAgents` refs.
+3. **`pkg/agent/config_resolver.go`** — In `ResolveChatAgentConfig`, resolve sub-agents: `chatCfg.SubAgents` > `chain.SubAgents` > nil.
+4. **`pkg/queue/chat_executor.go`** — Add `subAgentRegistry` field. Wire `SubAgentRunner` + `CompositeToolExecutor` + `SubAgentCollector` + `SubAgentCatalog` when resolved sub-agents are non-empty.
+5. **`pkg/agent/prompt/builder.go`** — The injection model from PR1 handles this automatically — chat system prompt gets orchestrator sections injected when `SubAgentCatalog` is non-empty.
+6. Tests and config examples.

--- a/docs/proposals/implicit-orchestrator-questions.md
+++ b/docs/proposals/implicit-orchestrator-questions.md
@@ -1,0 +1,159 @@
+# Implicit Orchestrator — Design Questions
+
+**Status:** All decisions resolved
+**Related:** [Design document](implicit-orchestrator-design.md)
+
+---
+
+## Q1: How do chat agents get their sub-agents?
+
+Chat agents currently have no sub-agent configuration path. We need to decide where chat sub-agents come from.
+
+### Option C: Both — `ChatConfig.SubAgents` overrides chain-level (chosen)
+
+Add a `SubAgents` field to `ChatConfig` but fall back to `chain.SubAgents` when the chat field is empty. Mirrors how `ChatConfig.MCPServers` already works (explicit override > chain-level > aggregated).
+
+```yaml
+# Chat inherits chain sub_agents automatically:
+agent_chains:
+  my-chain:
+    sub_agents: [LogAnalyzer, MetricChecker]
+    chat:
+      enabled: true
+
+# Or chat overrides with a subset:
+agent_chains:
+  my-chain:
+    sub_agents: [LogAnalyzer, MetricChecker, DangerousRemediator]
+    chat:
+      enabled: true
+      sub_agents: [LogAnalyzer, MetricChecker]  # no DangerousRemediator
+```
+
+- **Pro:** Works for both "just inherit" and "I need different agents for chat."
+- **Pro:** Follows established precedent (`ChatConfig.MCPServers` already uses this pattern).
+- **Con:** Slightly more complex resolution logic (but the pattern is already established).
+
+**Decision:** Option C — matches the existing `MCPServers` precedence pattern in `ResolveChatAgentConfig`. Zero-config defaults with explicit override support.
+
+_Considered and rejected: Option A (explicit-only `ChatConfig.SubAgents` — forces duplication for common case), Option B (chain inheritance only — no way to restrict chat sub-agents)_
+
+---
+
+## Q2: Should `AgentTypeOrchestrator` be removed or kept?
+
+Once orchestration is triggered by sub-agents, the `orchestrator` type value in `AgentType` becomes redundant for runtime behavior. The question is whether to keep it.
+
+### Option A: Remove entirely (chosen)
+
+Delete `AgentTypeOrchestrator` from `enums.go`, the controller factory, all switch cases, built-in agents, and tests. The `Orchestrator` built-in agent becomes `AgentTypeDefault` with `CustomInstructions`.
+
+- **Pro:** Clean — no dead code, no ambiguity about what the type means.
+- **Pro:** Users can't misconfigure (setting `type: orchestrator` without sub-agents).
+- **Con:** Breaking change for existing YAML configs that use `type: orchestrator`.
+- **Con:** Large diff touching many test files, golden files, and the E2E orchestrator config.
+
+**Decision:** Option A — clean code, no leftovers. The type is fully redundant once orchestration is triggered by sub-agents. Remove everywhere.
+
+_Considered and rejected: Option B (keep as cosmetic hint — dead code confuses contributors), Option C (deprecation path — unnecessary complexity at this stage)_
+
+---
+
+## Q3: How should orchestrator prompts be integrated?
+
+Orchestration is not a separate prompt path — it's an additive capability. Any agent with tools (investigation, chat, action, or future types) that resolves sub-agents should get orchestrator prompt sections injected into its existing prompt. The current design with a dedicated `buildOrchestratorMessages` that replaces the entire prompt is wrong for the implicit model.
+
+### Option A: Injection layer — append orchestrator sections to existing system prompt (chosen)
+
+Remove `buildOrchestratorMessages` as a separate dispatch path. Instead, after building the normal system prompt (investigation, chat, action — whatever the agent is), append the orchestrator sections (behavioral strategy, agent catalog, result delivery rules) when `SubAgentCatalog` is non-empty.
+
+The prompt builder flow becomes:
+1. Build system + user messages via the existing path (investigation/chat/action/sub-agent)
+2. If `len(execCtx.SubAgentCatalog) > 0`, append orchestrator behavioral instructions + catalog + result delivery to the system message
+
+```
+[Normal system prompt for agent type]
++ [Orchestrator Strategy section]        ← injected
++ [Available Sub-Agents catalog]         ← injected
++ [Result Delivery rules]                ← injected
+```
+
+- **Pro:** Any agent type with tools automatically becomes an orchestrator. No special dispatch needed.
+- **Pro:** Eliminates the separate `buildOrchestratorMessages` code path entirely.
+- **Pro:** Chat, investigation, action agents all get orchestrator capability the same way.
+- **Pro:** The agent keeps its own identity/instructions — orchestration is layered on top.
+- **Con:** Need to ensure the injected sections don't conflict with agent-specific instructions.
+
+**Decision:** Option A — orchestration is a capability, not an identity. The agent keeps its normal prompt and gains orchestrator tools + instructions as an additive layer. `buildOrchestratorMessages` is eliminated as a separate dispatch path; orchestrator sections are injected into whatever prompt the agent already has.
+
+_Considered and rejected: Option B (keep separate dispatch, extend to all agent types — loses agent identity, requires N variants)_
+
+---
+
+## Q4: Should the `Orchestrator` config block be allowed on any agent?
+
+Currently, `validator.go` rejects `orchestrator:` config on non-`type: orchestrator` agents. With implicit orchestration, a `default`-type agent may need guardrail overrides.
+
+### Option A: Allow `orchestrator:` on any agent (chosen)
+
+Remove the validator restriction (which was tied to `type: orchestrator`, now deleted per Q2). Any agent definition can include `orchestrator:` to customize max_concurrent_agents, agent_timeout, max_budget. If the agent never resolves sub-agents at runtime, the block is ignored.
+
+- **Pro:** Flexible — users can define guardrails for agents that might be used as orchestrators in some chains but not others.
+- **Pro:** Simple rule: "if present, it's validated; if agent gets sub-agents at runtime, it's applied."
+- **Con:** Slightly confusing: an agent config has `orchestrator:` but no `sub_agents` anywhere.
+
+Note: `deploy/config/tarsy.yaml.example` is missing the `orchestrator:` block — add it as part of this work.
+
+**Decision:** Option A — the validator restriction is deleted as part of Q2 cleanup. The `orchestrator:` block is allowed on any agent and applied when sub-agents are resolved.
+
+_Considered and rejected: Option B (cross-reference chains — complex, fragile), Option C (expand restriction — same complexity as B)_
+
+---
+
+## Q5: How do we prevent circular dispatch without the type marker?
+
+Currently, `BuildSubAgentRegistry` excludes `type: orchestrator` agents, and `validateSubAgentRefs` rejects orchestrator agents as sub-agents. Without the type as a reliable marker, we need an alternative.
+
+### Moot — runtime already prevents sub-agent recursion
+
+Sub-agents cannot become orchestrators by design:
+
+1. `SubAgentRunner` creates a fresh `ExecutionContext` with `SubAgent` set (task-only mode)
+2. The prompt builder sees `execCtx.SubAgent != nil` → builds task-only conversation, no orchestrator instructions
+3. The sub-agent's `ToolExecutor` is a plain MCP executor — no `CompositeToolExecutor`, no `dispatch_agent` tool
+
+Even if an orchestrator-capable agent is listed as a sub-agent, it runs in task-only mode without orchestrator tools. No circularity is possible at runtime.
+
+**Decision:** Remove the `type == AgentTypeOrchestrator` exclusion from `BuildSubAgentRegistry` and `validateSubAgentRefs` without adding a replacement. The runtime sub-agent execution path is the prevention. Budget/timeout guardrails remain as a safety net.
+
+---
+
+## Q6: Should memory support detection be type-based or capability-based?
+
+`agentTypeSupportsMemory` returns `true` for `AgentTypeDefault`, `AgentTypeAction`, and `AgentTypeOrchestrator`. With implicit orchestrators that may be `AgentTypeDefault`, the check is already correct (default supports memory). The question is whether to clean this up.
+
+### Moot — subsumed by Q2
+
+Q2 decided to remove `AgentTypeOrchestrator` entirely. Implicit orchestrators are `AgentTypeDefault`, which already returns `true` in `agentTypeSupportsMemory`. The dead `AgentTypeOrchestrator` case is simply deleted as part of Q2 cleanup. No design decision needed.
+
+---
+
+## Q7: Should chat orchestrator be in the same PR as the core change?
+
+The core change (sub-agent-driven trigger) and chat orchestrator support are logically related but different in scope.
+
+**Hard constraint:** After every PR, TARSy must be fully functional. Config changes are acceptable, but no PR may leave orchestration (or any feature) broken regardless of configuration. The final code must be clean — no dead or legacy code.
+
+### Decision: Two PRs
+
+**PR1: Core refactor** — Sub-agent-driven orchestration trigger + `AgentTypeOrchestrator` removal + prompt injection model.
+
+- Existing orchestrator chains already have `sub_agents` configured → orchestration keeps working, just triggered by sub-agents instead of type.
+- Configs need updating: remove `type: orchestrator` from agent definitions (it becomes an invalid value). All other YAML syntax unchanged.
+- Investigation orchestration: fully functional.
+- Chat orchestration: not yet available (same as before — no regression).
+
+**PR2: Chat orchestrator** — `ChatConfig.SubAgents`, chat executor wiring, prompt injection for chat path.
+
+- Purely additive. Only configs that opt into `chat.sub_agents` are affected.
+- No regressions — existing configs without `chat.sub_agents` behave identically.


### PR DESCRIPTION
- Design doc and questions doc for removing AgentTypeOrchestrator in favor of implicit orchestration based on sub_agents presence
- Any agent with tools and sub_agents becomes an orchestrator automatically via prompt injection and tool composition
- Two-PR implementation strategy ensuring backward compatibility
- Add cursor command for structured commit workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a standardized commit workflow document covering branch handling, change review, safe staging/commit practices, and post-commit verification.
  * Added architectural proposals and design notes for an implicit orchestrator approach, detailing orchestration trigger behavior, sub-agent precedence, circularity safeguards, and a phased implementation plan.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->