### PR TITLE
Make orchestration an implicit capability instead of an explicit agent type

### DIFF
--- a/deploy/config/tarsy.yaml.example
+++ b/deploy/config/tarsy.yaml.example
@@ -504,11 +504,11 @@ agent_chains:
               agent_timeout: 420s
               max_budget: 900s
             sub_agents:
-              - name: KubernetesAgent
-              - name: WebResearcher
-              - name: CodeExecutor
-              - name: GeneralWorker
-                mcp_servers: [kubernetes-server]
+              - name: KubernetesAgent              # built-in: K8s pod/deployment inspection
+              - name: WebResearcher                # built-in: web search + URL analysis
+              - name: CodeExecutor                 # built-in: Python code execution
+              - name: GeneralWorker                # built-in: pure reasoning / summarization
+                mcp_servers: [kubernetes-server]   # give GeneralWorker K8s access
                 max_iterations: 5
 
   # Any agent can become an orchestrator — just add sub_agents

--- a/deploy/config/tarsy.yaml.example
+++ b/deploy/config/tarsy.yaml.example
@@ -472,18 +472,19 @@ agent_chains:
       max_iterations: 20
 
   # ── Orchestrator chains ──────────────────────────────────────
-  # The built-in Orchestrator agent dispatches sub-agents dynamically.
-  # No need to define it in agents: — reference it by name.
+  # Any agent with sub_agents automatically gains orchestrator capabilities
+  # (dispatch_agent, cancel_agent, list_agents tools + orchestrator prompt).
+  # No special type required — orchestration is a capability, not an identity.
 
-  # Minimal orchestrator chain — uses defaults for everything
+  # Minimal orchestrator chain — KubernetesAgent gains orchestration from sub_agents
   orchestrator-minimal:
     alert_types: ["HighErrorRate"]
-    description: "Orchestrated investigation using built-in Orchestrator"
+    description: "Orchestrated investigation using KubernetesAgent"
     executive_summary_provider: "google-default"
     stages:
       - name: "orchestrate"
         agents:
-          - name: "Orchestrator"
+          - name: "KubernetesAgent"
             sub_agents: [KubernetesAgent, GeneralWorker]
 
   # Comprehensive orchestrator chain — overrides for orchestrator and sub-agents
@@ -494,20 +495,23 @@ agent_chains:
     stages:
       - name: "orchestrate"
         agents:
-          - name: "Orchestrator"
-            llm_provider: "gemini-3.1-pro"        # use a more capable model for orchestration
+          - name: "KubernetesAgent"
+            llm_provider: "gemini-3.1-pro"
             llm_backend: "google-native"
+            # orchestrator guardrails (optional — defaults applied if omitted)
+            orchestrator:
+              max_concurrent_agents: 5
+              agent_timeout: 420s
+              max_budget: 900s
             sub_agents:
-              - name: KubernetesAgent             # built-in: K8s pod/deployment inspection
-              - name: WebResearcher               # built-in: web search + URL analysis
-              - name: CodeExecutor                # built-in: Python code execution
-              - name: GeneralWorker               # built-in: pure reasoning / summarization
-                mcp_servers: [kubernetes-server]  # give GeneralWorker K8s access
+              - name: KubernetesAgent
+              - name: WebResearcher
+              - name: CodeExecutor
+              - name: GeneralWorker
+                mcp_servers: [kubernetes-server]
                 max_iterations: 5
 
-  # Custom agent as orchestrator — stage-level type override
-  # The agent's global definition stays unchanged (no type: orchestrator there).
-  # The type override applies only in this chain stage.
+  # Any agent can become an orchestrator — just add sub_agents
   # security-investigation:
   #   alert_types: ["SecurityInvestigation"]
   #   description: "Deep orchestrated security investigation"
@@ -515,7 +519,6 @@ agent_chains:
   #     - name: "investigate"
   #       agents:
   #         - name: "SecurityInvestigationAgent"
-  #           type: orchestrator                    # promote to orchestrator for this stage
   #           sub_agents:
   #             - name: KubernetesAgent
   #             - name: WebResearcher

--- a/docs/proposals/implicit-orchestrator-design.md
+++ b/docs/proposals/implicit-orchestrator-design.md
@@ -71,15 +71,11 @@ The `orchestrator:` config block (max_concurrent_agents, agent_timeout, max_budg
 
 No explicit prevention needed. Sub-agents run via `SubAgentRunner` with `execCtx.SubAgent` set, which gives them a task-only prompt and no orchestrator tools — `SubAgentCatalog` and `SubAgentCollector` are never set on the sub-agent's `ExecutionContext`. A sub-agent cannot dispatch further sub-agents by runtime design, regardless of configuration. This invariant is enforced by dedicated tests (see PR1 test item 14).
 
-### Known limitation: skills prevent full agent collapse
+### Skills and agent collapse (resolved in PR2)
 
-While the implicit orchestrator design allows the same agent definition to serve as both orchestrator and sub-agent, **skills** break this in practice. Orchestrator agents often need report-formatting skills injected into their system prompt, while sub-agent instances of the same agent should only gather evidence — giving them formatting skills wastes prompt tokens and risks confusing their role.
+After PR1, `required_skills` and `skills` are only configurable on `AgentConfig` (the base agent definition). Orchestrator agents often need report-formatting skills that their sub-agent counterparts should not have. Without stage-level skill overrides, this forces separate agent definitions for the orchestrator and sub-agent roles — the `type: orchestrator` line is gone, but the definitions remain distinct.
 
-Today, `required_skills` and `skills` are only configurable on the `AgentConfig` (base agent definition). There is no way to add skills at the stage-agent level in the chain config. This means orchestrators that need different skills than their sub-agent counterparts must remain as separate agent definitions.
-
-**Workaround (current):** Keep separate orchestrator and sub-agent definitions with different skills. The `type: orchestrator` line is removed, but the agent definitions remain distinct.
-
-**Resolution (PR3):** Add `required_skills` and `skills` to `StageAgentConfig`. Unlike `mcp_servers` and other stage-agent overrides which use replacement semantics, skills are **additive** — stage-level skills are appended to the agent definition's skills. This matches the nature of skills as cumulative knowledge injections rather than exclusive resource grants. See PR3 below.
+PR2 adds `RequiredSkills` and `Skills` fields to `StageAgentConfig`. Unlike `mcp_servers` and other stage-agent overrides which use replacement semantics, skills are **additive** — stage-level skills are appended to the agent definition's skills and deduplicated. This matches the nature of skills as cumulative knowledge injections rather than exclusive resource grants. See [PR2 — Stage-level skill overrides](#stage-level-skill-overrides-agent-collapse) for details.
 
 ## Core Concepts
 
@@ -151,7 +147,7 @@ Only configs that add `chat.sub_agents` are affected.
 
 #### Stage-level skill overrides (agent collapse)
 
-Addresses the [skills limitation](#known-limitation-skills-prevent-full-agent-collapse). Adds `required_skills` and `skills` fields to `StageAgentConfig`, enabling a single agent definition to serve as both orchestrator and sub-agent with different skill sets depending on the chain context.
+Addresses the [skills gap](#skills-and-agent-collapse-resolved-in-pr2) from PR1. Adds `RequiredSkills` and `Skills` fields to `StageAgentConfig`, enabling a single agent definition to serve as both orchestrator and sub-agent with different skill sets depending on the chain context.
 
 **Motivation:** Without stage-level skill overrides, orchestrator agents that need report-formatting skills must be defined separately from their sub-agent counterparts — defeating the "same agent, dual role" goal of the implicit orchestrator design.
 

--- a/docs/proposals/implicit-orchestrator-design.md
+++ b/docs/proposals/implicit-orchestrator-design.md
@@ -71,6 +71,16 @@ The `orchestrator:` config block (max_concurrent_agents, agent_timeout, max_budg
 
 No explicit prevention needed. Sub-agents run via `SubAgentRunner` with `execCtx.SubAgent` set, which gives them a task-only prompt and no orchestrator tools — `SubAgentCatalog` and `SubAgentCollector` are never set on the sub-agent's `ExecutionContext`. A sub-agent cannot dispatch further sub-agents by runtime design, regardless of configuration. This invariant is enforced by dedicated tests (see PR1 test item 14).
 
+### Known limitation: skills prevent full agent collapse
+
+While the implicit orchestrator design allows the same agent definition to serve as both orchestrator and sub-agent, **skills** break this in practice. Orchestrator agents often need report-formatting skills injected into their system prompt, while sub-agent instances of the same agent should only gather evidence — giving them formatting skills wastes prompt tokens and risks confusing their role.
+
+Today, `required_skills` and `skills` are only configurable on the `AgentConfig` (base agent definition). There is no way to add skills at the stage-agent level in the chain config. This means orchestrators that need different skills than their sub-agent counterparts must remain as separate agent definitions.
+
+**Workaround (current):** Keep separate orchestrator and sub-agent definitions with different skills. The `type: orchestrator` line is removed, but the agent definitions remain distinct.
+
+**Resolution (PR3):** Add `required_skills` and `skills` to `StageAgentConfig`. Unlike `mcp_servers` and other stage-agent overrides which use replacement semantics, skills are **additive** — stage-level skills are appended to the agent definition's skills. This matches the nature of skills as cumulative knowledge injections rather than exclusive resource grants. See PR3 below.
+
 ## Core Concepts
 
 | Concept | Before | After |
@@ -125,7 +135,11 @@ Existing orchestrator chains already have `sub_agents` configured, so orchestrat
 14. Update unit tests across: `config/enums_test.go`, `config/validator_test.go`, `config/builtin_test.go`, `config/sub_agent_registry_test.go`, `config/loader_test.go`, `agent/config_resolver_test.go`, `agent/controller/factory_test.go`, `agent/prompt/builder_test.go`, `agent/prompt/orchestrator_test.go`, `queue/executor_memory_test.go`, `queue/executor_integration_test.go`. Remove or replace all uses of `AgentNameOrchestrator` constant (`services/*_test.go`, `api/handler_trace_test.go`). Add recursion-safety tests verifying `SubAgentRunner` sets `execCtx.SubAgent` and never sets `SubAgentCatalog`/`SubAgentCollector` — sub-agents must not gain orchestrator tools or dispatch further sub-agents.
 15. Update E2E orchestrator tests in `test/e2e/orchestrator_test.go`.
 
-### PR2: Chat orchestrator support (additive, opt-in)
+### PR2: Chat orchestrator + stage-level skill overrides
+
+Completes the implicit orchestrator design: chat agents gain orchestration support, and stage-level skill overrides enable collapsing separate orchestrator/sub-agent definitions into a single agent.
+
+#### Chat orchestrator (additive, opt-in)
 
 Only configs that add `chat.sub_agents` are affected.
 
@@ -134,4 +148,50 @@ Only configs that add `chat.sub_agents` are affected.
 3. **`pkg/agent/config_resolver.go`** — In `ResolveChatAgentConfig`, resolve sub-agents: `chatCfg.SubAgents` > `chain.SubAgents` > nil.
 4. **`pkg/queue/chat_executor.go`** — Add `subAgentRegistry` field. Wire `SubAgentRunner` + `CompositeToolExecutor` + `SubAgentCollector` + `SubAgentCatalog` when resolved sub-agents are non-empty.
 5. **`pkg/agent/prompt/builder.go`** — The injection model from PR1 handles this automatically — chat system prompt gets orchestrator sections injected when `SubAgentCatalog` is non-empty.
-6. Tests and config examples.
+
+#### Stage-level skill overrides (agent collapse)
+
+Addresses the [skills limitation](#known-limitation-skills-prevent-full-agent-collapse). Adds `required_skills` and `skills` fields to `StageAgentConfig`, enabling a single agent definition to serve as both orchestrator and sub-agent with different skill sets depending on the chain context.
+
+**Motivation:** Without stage-level skill overrides, orchestrator agents that need report-formatting skills must be defined separately from their sub-agent counterparts — defeating the "same agent, dual role" goal of the implicit orchestrator design.
+
+6. **`pkg/config/types.go`** — Add `RequiredSkills []string` and `Skills []string` to `StageAgentConfig`.
+7. **`pkg/config/validator.go`** — Validate that stage-level skill references exist in the skill registry.
+8. **`pkg/agent/config_resolver.go`** — In `ResolveAgentConfig`, merge stage-level skills with agent-level skills. Semantics: stage-level skills are **additive** (appended to the agent definition's skills, deduplicated). This intentionally differs from `mcp_servers` and other stage-agent overrides which use replacement. Skills are cumulative knowledge injections — an agent that knows about triage runbooks doesn't lose that knowledge by also learning report formatting. Replacement would reintroduce the duplication problem this change exists to solve.
+
+#### Config migration
+
+9. **Production configs** — Collapse separate orchestrator/sub-agent pairs into single agent definitions. The stage-agent entry adds only the orchestrator-specific skills; base skills are inherited from the agent definition.
+
+    **Example (before):**
+    ```yaml
+    agents:
+      IncidentOrchestrator:
+        required_skills: [domain-knowledge, triage-runbook, incident-report-format]
+        # ...
+      IncidentInvestigator:
+        required_skills: [domain-knowledge, triage-runbook]
+        # ...
+    ```
+
+    **Example (after):**
+    ```yaml
+    agents:
+      IncidentInvestigator:
+        required_skills: [domain-knowledge, triage-runbook]
+        # ...
+
+    agent_chains:
+      incident-orchestrated:
+        stages:
+          - stage_agents:
+              - name: IncidentInvestigator
+                required_skills: [incident-report-format]  # additive: merged with agent-def skills
+            sub_agents:
+              - name: IncidentInvestigator
+              # inherits agent-def skills: [domain-knowledge, triage-runbook]
+    ```
+
+#### Tests
+
+10. Tests and config examples for chat orchestrator. Unit tests for skill merging and deduplication in `config_resolver_test.go`, validation in `validator_test.go`, and E2E coverage for stage-level skills.

--- a/pkg/agent/config_resolver_test.go
+++ b/pkg/agent/config_resolver_test.go
@@ -135,13 +135,13 @@ func TestResolveAgentConfig(t *testing.T) {
 		stageConfig := config.StageConfig{}
 		agentConfig := config.StageAgentConfig{
 			Name: config.AgentNameKubernetes,
-			Type: config.AgentTypeOrchestrator,
+			Type: config.AgentTypeAction,
 		}
 
 		resolved, err := ResolveAgentConfig(cfg, chain, stageConfig, agentConfig)
 		require.NoError(t, err)
 
-		assert.Equal(t, config.AgentTypeOrchestrator, resolved.Type)
+		assert.Equal(t, config.AgentTypeAction, resolved.Type)
 	})
 
 	t.Run("falls back to DefaultLLMBackend when no level sets backend", func(t *testing.T) {

--- a/pkg/agent/controller/factory.go
+++ b/pkg/agent/controller/factory.go
@@ -28,8 +28,6 @@ func (f *Factory) CreateController(agentType config.AgentType, execCtx *agent.Ex
 		return NewExecSummaryController(execCtx.PromptBuilder), nil
 	case config.AgentTypeScoring:
 		return NewScoringController(), nil
-	case config.AgentTypeOrchestrator:
-		return NewIteratingController(), nil
 	case config.AgentTypeAction:
 		return NewIteratingController(), nil
 	default:

--- a/pkg/agent/controller/factory_test.go
+++ b/pkg/agent/controller/factory_test.go
@@ -81,15 +81,6 @@ func TestFactory_CreateController(t *testing.T) {
 		assert.True(t, ok, "expected SingleShotController")
 	})
 
-	t.Run("orchestrator type returns IteratingController", func(t *testing.T) {
-		controller, err := factory.CreateController(config.AgentTypeOrchestrator, execCtx)
-		require.NoError(t, err)
-		require.NotNil(t, controller)
-
-		_, ok := controller.(*IteratingController)
-		assert.True(t, ok, "expected IteratingController")
-	})
-
 	t.Run("action type returns IteratingController", func(t *testing.T) {
 		controller, err := factory.CreateController(config.AgentTypeAction, execCtx)
 		require.NoError(t, err)

--- a/pkg/agent/orchestrator/runner_test.go
+++ b/pkg/agent/orchestrator/runner_test.go
@@ -670,6 +670,149 @@ func newMinimalRunner(maxConcurrent int) *SubAgentRunner {
 	)
 }
 
+// TestSubAgentRunner_Dispatch_NeverSetsOrchestratorFields verifies the
+// circularity prevention invariant: sub-agents dispatched by the orchestrator
+// must have SubAgent set but must never receive SubAgentCatalog or
+// SubAgentCollector, ensuring they cannot dispatch further sub-agents.
+func TestSubAgentRunner_Dispatch_NeverSetsOrchestratorFields(t *testing.T) {
+	ctx := context.Background()
+
+	var captured atomic.Pointer[agent.ExecutionContext]
+	runner, cleanup := setupIntegrationRunnerWithCapture(t,
+		func(_ context.Context) (*agent.ExecutionResult, error) {
+			return &agent.ExecutionResult{
+				Status:        agent.ExecutionStatusCompleted,
+				FinalAnalysis: "done",
+			}, nil
+		},
+		func(execCtx *agent.ExecutionContext) {
+			captured.Store(execCtx)
+		},
+	)
+	defer cleanup()
+
+	_, err := runner.Dispatch(ctx, "TestAgent", "verify no orchestrator wiring")
+	require.NoError(t, err)
+
+	_, err = runner.WaitForNext(ctx)
+	require.NoError(t, err)
+
+	execCtx := captured.Load()
+	require.NotNil(t, execCtx, "controller should have captured the execution context")
+
+	assert.NotNil(t, execCtx.SubAgent, "sub-agent context must be set")
+	assert.Nil(t, execCtx.SubAgentCatalog, "sub-agents must not receive SubAgentCatalog")
+	assert.Nil(t, execCtx.SubAgentCollector, "sub-agents must not receive SubAgentCollector")
+}
+
+// setupIntegrationRunnerWithCapture is like setupIntegrationRunner but uses a
+// capturingControllerFactory that calls captureFn with the ExecutionContext
+// before running the mock controller.
+func setupIntegrationRunnerWithCapture(
+	t *testing.T,
+	resultFn func(ctx context.Context) (*agent.ExecutionResult, error),
+	captureFn func(execCtx *agent.ExecutionContext),
+) (*SubAgentRunner, func()) {
+	t.Helper()
+
+	dbClient := testdb.NewTestClient(t)
+	ctx := context.Background()
+
+	stageService := services.NewStageService(dbClient.Client)
+	timelineService := services.NewTimelineService(dbClient.Client)
+	messageService := services.NewMessageService(dbClient.Client)
+	interactionService := services.NewInteractionService(dbClient.Client, messageService)
+	mcpRegistry := config.NewMCPServerRegistry(nil)
+	sessionService := services.NewSessionService(
+		dbClient.Client,
+		config.NewChainRegistry(map[string]*config.ChainConfig{
+			"test-chain": {
+				AlertTypes: []string{"test"},
+				Stages: []config.StageConfig{{
+					Name:   "stage1",
+					Agents: []config.StageAgentConfig{{Name: "TestAgent"}},
+				}},
+			},
+		}),
+		mcpRegistry,
+	)
+
+	session, err := sessionService.CreateSession(ctx, models.CreateSessionRequest{
+		SessionID: uuid.New().String(),
+		AlertData: "test alert",
+		AgentType: "test",
+		ChainID:   "test-chain",
+	})
+	require.NoError(t, err)
+
+	stages, err := stageService.GetStagesBySession(ctx, session.ID, true)
+	require.NoError(t, err)
+	require.NotEmpty(t, stages)
+	stageID := stages[0].ID
+
+	executions, err := stageService.GetAgentExecutions(ctx, stageID)
+	require.NoError(t, err)
+	require.NotEmpty(t, executions)
+	parentExecID := executions[0].ID
+
+	testProvider := &config.LLMProviderConfig{
+		Type:                config.LLMProviderTypeGoogle,
+		Model:               "test-model",
+		MaxToolResultTokens: 10000,
+	}
+
+	cfg := &config.Config{
+		Defaults: &config.Defaults{LLMProvider: "test-provider"},
+		AgentRegistry: config.NewAgentRegistry(map[string]*config.AgentConfig{
+			"TestAgent": {Description: "A test agent"},
+		}),
+		LLMProviderRegistry: config.NewLLMProviderRegistry(map[string]*config.LLMProviderConfig{
+			"test-provider": testProvider,
+		}),
+		MCPServerRegistry: config.NewMCPServerRegistry(nil),
+	}
+
+	chain := &config.ChainConfig{
+		AlertTypes: []string{"test"},
+		Stages: []config.StageConfig{{
+			Name:   "stage1",
+			Agents: []config.StageAgentConfig{{Name: "TestAgent"}},
+		}},
+	}
+
+	agentFactory := agent.NewAgentFactory(&capturingControllerFactory{resultFn: resultFn, captureFn: captureFn})
+	registry := config.BuildSubAgentRegistry(cfg.AgentRegistry.GetAll())
+
+	deps := &SubAgentDeps{
+		Config:             cfg,
+		Chain:              chain,
+		AgentFactory:       agentFactory,
+		StageService:       stageService,
+		TimelineService:    timelineService,
+		MessageService:     messageService,
+		InteractionService: interactionService,
+		AlertData:          "test alert",
+		AlertType:          "test",
+	}
+
+	runner := NewSubAgentRunner(
+		context.Background(),
+		deps,
+		parentExecID,
+		session.ID,
+		stageID,
+		registry,
+		&OrchestratorGuardrails{
+			MaxConcurrentAgents: 5,
+			AgentTimeout:        30 * time.Second,
+			MaxBudget:           60 * time.Second,
+		},
+		nil,
+	)
+
+	return runner, func() {}
+}
+
 // mockControllerFactory returns a factory that produces controllers
 // calling resultFn when Run is invoked. resultFn receives ctx so tests
 // can respect context cancellation/timeout.
@@ -687,6 +830,19 @@ type mockController struct {
 
 func (c *mockController) Run(ctx context.Context, _ *agent.ExecutionContext, _ string) (*agent.ExecutionResult, error) {
 	return c.resultFn(ctx)
+}
+
+// capturingControllerFactory captures the ExecutionContext before delegating to the mock.
+type capturingControllerFactory struct {
+	resultFn  func(ctx context.Context) (*agent.ExecutionResult, error)
+	captureFn func(execCtx *agent.ExecutionContext)
+}
+
+func (f *capturingControllerFactory) CreateController(_ config.AgentType, execCtx *agent.ExecutionContext) (agent.Controller, error) {
+	if f.captureFn != nil {
+		f.captureFn(execCtx)
+	}
+	return &mockController{resultFn: f.resultFn}, nil
 }
 
 // Compile-time check that noopEventPublisher satisfies agent.EventPublisher.

--- a/pkg/agent/orchestrator/runner_test.go
+++ b/pkg/agent/orchestrator/runner_test.go
@@ -678,7 +678,7 @@ func TestSubAgentRunner_Dispatch_NeverSetsOrchestratorFields(t *testing.T) {
 	ctx := context.Background()
 
 	var captured atomic.Pointer[agent.ExecutionContext]
-	runner, cleanup := setupIntegrationRunnerWithCapture(t,
+	runner, cleanup := setupIntegrationRunner(t,
 		func(_ context.Context) (*agent.ExecutionResult, error) {
 			return &agent.ExecutionResult{
 				Status:        agent.ExecutionStatusCompleted,
@@ -703,114 +703,6 @@ func TestSubAgentRunner_Dispatch_NeverSetsOrchestratorFields(t *testing.T) {
 	assert.NotNil(t, execCtx.SubAgent, "sub-agent context must be set")
 	assert.Nil(t, execCtx.SubAgentCatalog, "sub-agents must not receive SubAgentCatalog")
 	assert.Nil(t, execCtx.SubAgentCollector, "sub-agents must not receive SubAgentCollector")
-}
-
-// setupIntegrationRunnerWithCapture is like setupIntegrationRunner but uses a
-// capturingControllerFactory that calls captureFn with the ExecutionContext
-// before running the mock controller.
-func setupIntegrationRunnerWithCapture(
-	t *testing.T,
-	resultFn func(ctx context.Context) (*agent.ExecutionResult, error),
-	captureFn func(execCtx *agent.ExecutionContext),
-) (*SubAgentRunner, func()) {
-	t.Helper()
-
-	dbClient := testdb.NewTestClient(t)
-	ctx := context.Background()
-
-	stageService := services.NewStageService(dbClient.Client)
-	timelineService := services.NewTimelineService(dbClient.Client)
-	messageService := services.NewMessageService(dbClient.Client)
-	interactionService := services.NewInteractionService(dbClient.Client, messageService)
-	mcpRegistry := config.NewMCPServerRegistry(nil)
-	sessionService := services.NewSessionService(
-		dbClient.Client,
-		config.NewChainRegistry(map[string]*config.ChainConfig{
-			"test-chain": {
-				AlertTypes: []string{"test"},
-				Stages: []config.StageConfig{{
-					Name:   "stage1",
-					Agents: []config.StageAgentConfig{{Name: "TestAgent"}},
-				}},
-			},
-		}),
-		mcpRegistry,
-	)
-
-	session, err := sessionService.CreateSession(ctx, models.CreateSessionRequest{
-		SessionID: uuid.New().String(),
-		AlertData: "test alert",
-		AgentType: "test",
-		ChainID:   "test-chain",
-	})
-	require.NoError(t, err)
-
-	stages, err := stageService.GetStagesBySession(ctx, session.ID, true)
-	require.NoError(t, err)
-	require.NotEmpty(t, stages)
-	stageID := stages[0].ID
-
-	executions, err := stageService.GetAgentExecutions(ctx, stageID)
-	require.NoError(t, err)
-	require.NotEmpty(t, executions)
-	parentExecID := executions[0].ID
-
-	testProvider := &config.LLMProviderConfig{
-		Type:                config.LLMProviderTypeGoogle,
-		Model:               "test-model",
-		MaxToolResultTokens: 10000,
-	}
-
-	cfg := &config.Config{
-		Defaults: &config.Defaults{LLMProvider: "test-provider"},
-		AgentRegistry: config.NewAgentRegistry(map[string]*config.AgentConfig{
-			"TestAgent": {Description: "A test agent"},
-		}),
-		LLMProviderRegistry: config.NewLLMProviderRegistry(map[string]*config.LLMProviderConfig{
-			"test-provider": testProvider,
-		}),
-		MCPServerRegistry: config.NewMCPServerRegistry(nil),
-	}
-
-	chain := &config.ChainConfig{
-		AlertTypes: []string{"test"},
-		Stages: []config.StageConfig{{
-			Name:   "stage1",
-			Agents: []config.StageAgentConfig{{Name: "TestAgent"}},
-		}},
-	}
-
-	agentFactory := agent.NewAgentFactory(&capturingControllerFactory{resultFn: resultFn, captureFn: captureFn})
-	registry := config.BuildSubAgentRegistry(cfg.AgentRegistry.GetAll())
-
-	deps := &SubAgentDeps{
-		Config:             cfg,
-		Chain:              chain,
-		AgentFactory:       agentFactory,
-		StageService:       stageService,
-		TimelineService:    timelineService,
-		MessageService:     messageService,
-		InteractionService: interactionService,
-		AlertData:          "test alert",
-		AlertType:          "test",
-	}
-
-	runner := NewSubAgentRunner(
-		context.Background(),
-		deps,
-		parentExecID,
-		session.ID,
-		stageID,
-		registry,
-		&OrchestratorGuardrails{
-			MaxConcurrentAgents: 5,
-			AgentTimeout:        30 * time.Second,
-			MaxBudget:           60 * time.Second,
-		},
-		nil,
-	)
-
-	return runner, func() {}
 }
 
 // mockControllerFactory returns a factory that produces controllers
@@ -932,9 +824,12 @@ func (r *recordingEventPublisher) timelineCreated() []events.TimelineCreatedPayl
 
 // setupIntegrationRunner creates a fully wired SubAgentRunner backed by
 // testcontainers PostgreSQL. resultFn controls what the mock agent returns.
+// An optional captureFn, if provided, is called with the ExecutionContext
+// before each controller Run (useful for inspecting what was passed to sub-agents).
 func setupIntegrationRunner(
 	t *testing.T,
 	resultFn func(ctx context.Context) (*agent.ExecutionResult, error),
+	captureFn ...func(execCtx *agent.ExecutionContext),
 ) (*SubAgentRunner, func()) {
 	t.Helper()
 
@@ -1005,7 +900,13 @@ func setupIntegrationRunner(
 		}},
 	}
 
-	agentFactory := agent.NewAgentFactory(&mockControllerFactory{resultFn: resultFn})
+	var factory agent.ControllerFactory
+	if len(captureFn) > 0 && captureFn[0] != nil {
+		factory = &capturingControllerFactory{resultFn: resultFn, captureFn: captureFn[0]}
+	} else {
+		factory = &mockControllerFactory{resultFn: resultFn}
+	}
+	agentFactory := agent.NewAgentFactory(factory)
 
 	registry := config.BuildSubAgentRegistry(cfg.AgentRegistry.GetAll())
 

--- a/pkg/agent/prompt/builder.go
+++ b/pkg/agent/prompt/builder.go
@@ -41,15 +41,13 @@ const (
 // BuildFunctionCallingMessages builds the initial conversation for a function calling investigation.
 // Used by both google-native (Google SDK) and langchain (multi-provider) backends.
 //
-// Dispatches to specialized builders for orchestrator and sub-agent modes
-// before falling through to chat / investigation paths.
+// Dispatches to specialized builders for action and sub-agent modes,
+// then falls through to chat / investigation paths. Orchestrator sections
+// are injected additively when SubAgentCatalog is non-empty.
 func (b *PromptBuilder) BuildFunctionCallingMessages(
 	execCtx *agent.ExecutionContext,
 	prevStageContext string,
 ) []agent.ConversationMessage {
-	if execCtx.Config.Type == config.AgentTypeOrchestrator {
-		return b.buildOrchestratorMessages(execCtx, prevStageContext)
-	}
 	if execCtx.Config.Type == config.AgentTypeAction {
 		return b.buildActionMessages(execCtx, prevStageContext)
 	}
@@ -59,7 +57,6 @@ func (b *PromptBuilder) BuildFunctionCallingMessages(
 
 	isChat := execCtx.ChatContext != nil
 
-	// System message (tools are bound natively, not described in text)
 	var composed, focus string
 	if isChat {
 		composed = b.ComposeChatInstructions(execCtx)
@@ -68,13 +65,19 @@ func (b *PromptBuilder) BuildFunctionCallingMessages(
 		composed = b.ComposeInstructions(execCtx)
 		focus = taskFocus
 	}
+
+	// Inject orchestrator sections when this agent has sub-agents available.
+	if len(execCtx.SubAgentCatalog) > 0 {
+		composed = InjectOrchestratorSections(composed, execCtx.SubAgentCatalog)
+		focus = OrchestratorTaskFocus()
+	}
+
 	systemContent := composed + "\n\n" + focus
 
 	messages := []agent.ConversationMessage{
 		{Role: agent.RoleSystem, Content: systemContent},
 	}
 
-	// User message (no tool descriptions — tools are bound natively via function calling)
 	var userContent string
 	if isChat {
 		userContent = b.buildChatUserMessage(execCtx)

--- a/pkg/agent/prompt/builder_test.go
+++ b/pkg/agent/prompt/builder_test.go
@@ -157,10 +157,9 @@ func TestBuildFunctionCallingMessages_ChatMode(t *testing.T) {
 	assert.Contains(t, messages[1].Content, "Show me the pod status")
 }
 
-func TestBuildFunctionCallingMessages_OrchestratorMode(t *testing.T) {
+func TestBuildFunctionCallingMessages_OrchestratorInjection(t *testing.T) {
 	builder := newBuilderForTest()
 	execCtx := newFullExecCtx()
-	execCtx.Config.Type = config.AgentTypeOrchestrator
 	execCtx.SubAgentCatalog = []config.SubAgentEntry{
 		{Name: "LogAnalyzer", Description: "Analyzes logs", MCPServers: []string{"loki"}},
 	}
@@ -171,7 +170,19 @@ func TestBuildFunctionCallingMessages_OrchestratorMode(t *testing.T) {
 	assert.Contains(t, messages[0].Content, "Orchestrator Strategy")
 	assert.Contains(t, messages[0].Content, "Available Sub-Agents")
 	assert.Contains(t, messages[0].Content, "LogAnalyzer")
+	assert.Contains(t, messages[0].Content, "coordinating sub-agents")
 	assert.Contains(t, messages[1].Content, "Alert Details")
+}
+
+func TestBuildFunctionCallingMessages_NoOrchestratorWithoutCatalog(t *testing.T) {
+	builder := newBuilderForTest()
+	execCtx := newFullExecCtx()
+
+	messages := builder.BuildFunctionCallingMessages(execCtx, "")
+	require.Len(t, messages, 2)
+
+	assert.NotContains(t, messages[0].Content, "Orchestrator Strategy")
+	assert.NotContains(t, messages[0].Content, "Available Sub-Agents")
 }
 
 func TestBuildFunctionCallingMessages_ActionMode(t *testing.T) {
@@ -210,4 +221,41 @@ func TestBuildFunctionCallingMessages_SubAgentMode(t *testing.T) {
 	assert.Contains(t, messages[1].Content, "Find 5xx errors")
 	assert.NotContains(t, messages[1].Content, "Alert Details")
 	assert.NotContains(t, messages[1].Content, "Previous data")
+}
+
+func TestBuildFunctionCallingMessages_ChatModeWithOrchestration(t *testing.T) {
+	builder := newBuilderForTest()
+	execCtx := newFullExecCtx()
+	execCtx.ChatContext = &agent.ChatContext{
+		UserQuestion:         "Can you check the failing pods?",
+		InvestigationContext: "Previous investigation context.",
+	}
+	execCtx.SubAgentCatalog = []config.SubAgentEntry{
+		{Name: "LogAnalyzer", Description: "Analyzes logs", MCPServers: []string{"loki"}},
+	}
+
+	messages := builder.BuildFunctionCallingMessages(execCtx, "")
+	require.Len(t, messages, 2)
+
+	system := messages[0].Content
+	assert.Contains(t, system, "Chat Assistant Instructions")
+	assert.Contains(t, system, "Orchestrator Strategy")
+	assert.Contains(t, system, "Available Sub-Agents")
+	assert.Contains(t, system, "LogAnalyzer")
+	assert.Contains(t, system, "coordinating sub-agents")
+
+	assert.Contains(t, messages[1].Content, "Can you check the failing pods?")
+}
+
+func TestBuildFunctionCallingMessages_EmptyCatalogNoOrchestration(t *testing.T) {
+	builder := newBuilderForTest()
+	execCtx := newFullExecCtx()
+	execCtx.SubAgentCatalog = []config.SubAgentEntry{}
+
+	messages := builder.BuildFunctionCallingMessages(execCtx, "")
+	require.Len(t, messages, 2)
+
+	assert.NotContains(t, messages[0].Content, "Orchestrator Strategy")
+	assert.NotContains(t, messages[0].Content, "Available Sub-Agents")
+	assert.Contains(t, messages[0].Content, "Focus on investigation")
 }

--- a/pkg/agent/prompt/orchestrator.go
+++ b/pkg/agent/prompt/orchestrator.go
@@ -4,14 +4,13 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/codeready-toolchain/tarsy/pkg/agent"
 	"github.com/codeready-toolchain/tarsy/pkg/config"
 )
 
-// orchestratorBehavioralInstructions is auto-injected for every orchestrator agent
-// (built-in or custom). Provides the orchestration strategy and principles so that
-// custom agents with type=orchestrator get the same behavioral guidance without
-// duplicating it in their CustomInstructions.
+// orchestratorBehavioralInstructions is auto-injected for every agent that
+// resolves a non-empty sub-agent catalog at runtime. Provides the orchestration
+// strategy and principles so that any agent with sub-agents gets the same
+// behavioral guidance without duplicating it in their CustomInstructions.
 const orchestratorBehavioralInstructions = `## Orchestrator Strategy
 
 You are a dynamic investigation orchestrator. You analyze incoming alerts by dispatching
@@ -45,28 +44,19 @@ Tracking: keep a mental checklist of every agent you dispatch. When a result arr
 
 const orchestratorTaskFocus = "Focus on coordinating sub-agents to investigate the alert and consolidate their findings into actionable recommendations for human operators."
 
-// buildOrchestratorMessages builds the initial conversation for an orchestrator agent.
-// System prompt: Tier 1-3 instructions + behavioral strategy + agent catalog + mechanics.
-// User message: same as investigation.
-func (b *PromptBuilder) buildOrchestratorMessages(
-	execCtx *agent.ExecutionContext,
-	prevStageContext string,
-) []agent.ConversationMessage {
-	composed := b.ComposeInstructions(execCtx)
-	catalog := formatAgentCatalog(execCtx.SubAgentCatalog)
-	systemContent := composed + "\n\n" + orchestratorBehavioralInstructions + "\n\n" + catalog + "\n\n" + orchestratorResultDelivery + "\n\n" + orchestratorTaskFocus
+// InjectOrchestratorSections appends orchestrator behavioral instructions,
+// agent catalog, and result delivery rules to the given system prompt content.
+// Called when an agent's SubAgentCatalog is non-empty, regardless of agent type.
+func InjectOrchestratorSections(systemContent string, catalog []config.SubAgentEntry) string {
+	catalogSection := formatAgentCatalog(catalog)
+	return systemContent + "\n\n" + orchestratorBehavioralInstructions + "\n\n" + catalogSection + "\n\n" + orchestratorResultDelivery
+}
 
-	messages := []agent.ConversationMessage{
-		{Role: agent.RoleSystem, Content: systemContent},
-	}
-
-	userContent := b.buildInvestigationUserMessage(execCtx, prevStageContext)
-	messages = append(messages, agent.ConversationMessage{
-		Role:    agent.RoleUser,
-		Content: userContent,
-	})
-
-	return messages
+// OrchestratorTaskFocus returns the task focus string for orchestrator agents.
+// Used by the prompt builder to replace the default task focus when the agent
+// has a non-empty sub-agent catalog.
+func OrchestratorTaskFocus() string {
+	return orchestratorTaskFocus
 }
 
 // formatAgentCatalog renders the available sub-agents section for the

--- a/pkg/agent/prompt/orchestrator_test.go
+++ b/pkg/agent/prompt/orchestrator_test.go
@@ -75,52 +75,79 @@ func TestFormatAgentCatalog_EmptyEntries(t *testing.T) {
 	assert.NotContains(t, result, "**")
 }
 
-func TestBuildOrchestratorMessages_SystemIncludesCatalog(t *testing.T) {
+func TestInjectOrchestratorSections_Content(t *testing.T) {
+	catalog := []config.SubAgentEntry{
+		{Name: "LogAnalyzer", Description: "Analyzes logs", MCPServers: []string{"loki"}},
+		{Name: "GeneralWorker", Description: "General-purpose agent"},
+	}
+
+	result := InjectOrchestratorSections("Base system prompt.", catalog)
+
+	assert.Contains(t, result, "Base system prompt.")
+	assert.Contains(t, result, "Orchestrator Strategy")
+	assert.Contains(t, result, "Dispatch relevant sub-agents in parallel")
+	assert.Contains(t, result, "Available Sub-Agents")
+	assert.Contains(t, result, "LogAnalyzer")
+	assert.Contains(t, result, "GeneralWorker")
+	assert.Contains(t, result, "dispatch_agent")
+	assert.Contains(t, result, "Sub-agent results are delivered to you automatically")
+	assert.Contains(t, result, "NEVER predict, fabricate, or speculate")
+	assert.Contains(t, result, "keep a mental checklist of every agent you dispatch")
+}
+
+func TestInjectOrchestratorSections_BaseContentIsPrefix(t *testing.T) {
+	base := "Existing agent system prompt with custom instructions."
+	result := InjectOrchestratorSections(base, []config.SubAgentEntry{
+		{Name: "Worker", Description: "A worker"},
+	})
+
+	assert.True(t, strings.HasPrefix(result, base),
+		"injected prompt must start with the original base content")
+	behavioralPos := strings.Index(result, "Orchestrator Strategy")
+	assert.Greater(t, behavioralPos, len(base),
+		"orchestrator sections must come after the base content")
+}
+
+func TestOrchestratorTaskFocus(t *testing.T) {
+	focus := OrchestratorTaskFocus()
+	assert.NotEmpty(t, focus)
+	assert.Contains(t, focus, "coordinating sub-agents")
+}
+
+func TestInjectOrchestratorSections_ViaBuilder(t *testing.T) {
 	builder := newBuilderForTest()
 	execCtx := newFullExecCtx()
-	execCtx.Config.Type = config.AgentTypeOrchestrator
 	execCtx.SubAgentCatalog = []config.SubAgentEntry{
 		{Name: "LogAnalyzer", Description: "Analyzes logs", MCPServers: []string{"loki"}},
 		{Name: "GeneralWorker", Description: "General-purpose agent"},
 	}
 
-	messages := builder.buildOrchestratorMessages(execCtx, "")
+	messages := builder.BuildFunctionCallingMessages(execCtx, "")
 	require.Len(t, messages, 2)
 
 	system := messages[0]
 	assert.Equal(t, agent.RoleSystem, system.Role)
-	// Auto-injected orchestrator behavioral instructions
 	assert.Contains(t, system.Content, "Orchestrator Strategy")
-	assert.Contains(t, system.Content, "Dispatch relevant sub-agents in parallel")
 	assert.Contains(t, system.Content, "Available Sub-Agents")
 	assert.Contains(t, system.Content, "LogAnalyzer")
 	assert.Contains(t, system.Content, "GeneralWorker")
-	assert.Contains(t, system.Content, "dispatch_agent")
-	assert.Contains(t, system.Content, "Sub-agent results are delivered to you automatically")
-	assert.Contains(t, system.Content, "NEVER predict, fabricate, or speculate")
-	assert.Contains(t, system.Content, "keep a mental checklist of every agent you dispatch")
 	assert.Contains(t, system.Content, orchestratorTaskFocus)
-	// Tier 1 instructions
 	assert.Contains(t, system.Content, "General SRE Agent Instructions")
-	// Tier 2: MCP server instructions (from "kubernetes-server" in test registry)
 	assert.Contains(t, system.Content, "K8s server instructions.")
-	// Tier 3: custom instructions from agent config
 	assert.Contains(t, system.Content, "Be thorough.")
 }
 
-func TestBuildOrchestratorMessages_PromptLayerOrder(t *testing.T) {
+func TestInjectOrchestratorSections_PromptLayerOrder(t *testing.T) {
 	builder := newBuilderForTest()
 	execCtx := newFullExecCtx()
-	execCtx.Config.Type = config.AgentTypeOrchestrator
 	execCtx.Config.CustomInstructions = "Domain-specific security instructions."
 	execCtx.SubAgentCatalog = []config.SubAgentEntry{
 		{Name: "LogAnalyzer", Description: "Analyzes logs"},
 	}
 
-	messages := builder.buildOrchestratorMessages(execCtx, "")
+	messages := builder.BuildFunctionCallingMessages(execCtx, "")
 	system := messages[0].Content
 
-	// Verify ordering: Tier 1 → Tier 3 (custom) → behavioral → catalog → delivery → focus
 	tier1Pos := strings.Index(system, "General SRE Agent Instructions")
 	customPos := strings.Index(system, "Domain-specific security instructions.")
 	behavioralPos := strings.Index(system, "Orchestrator Strategy")
@@ -142,30 +169,30 @@ func TestBuildOrchestratorMessages_PromptLayerOrder(t *testing.T) {
 	assert.Less(t, deliveryPos, focusPos, "Delivery should come before focus")
 }
 
-func TestBuildOrchestratorMessages_NoCustomInstructions(t *testing.T) {
+func TestInjectOrchestratorSections_NoCustomInstructions(t *testing.T) {
 	builder := newBuilderForTest()
 	execCtx := newFullExecCtx()
-	execCtx.Config.Type = config.AgentTypeOrchestrator
-	execCtx.Config.CustomInstructions = "" // Built-in Orchestrator case
-	execCtx.SubAgentCatalog = []config.SubAgentEntry{}
+	execCtx.Config.CustomInstructions = ""
+	execCtx.SubAgentCatalog = []config.SubAgentEntry{
+		{Name: "LogAnalyzer", Description: "Analyzes logs"},
+	}
 
-	messages := builder.buildOrchestratorMessages(execCtx, "")
+	messages := builder.BuildFunctionCallingMessages(execCtx, "")
 	system := messages[0].Content
 
-	// Behavioral instructions still present even without custom instructions
 	assert.Contains(t, system, "Orchestrator Strategy")
 	assert.Contains(t, system, "Dispatch relevant sub-agents in parallel")
-	// No stale "Agent-Specific Instructions" header when custom instructions are empty
 	assert.NotContains(t, system, "Agent-Specific Instructions")
 }
 
-func TestBuildOrchestratorMessages_UserIncludesAlert(t *testing.T) {
+func TestInjectOrchestratorSections_UserIncludesAlert(t *testing.T) {
 	builder := newBuilderForTest()
 	execCtx := newFullExecCtx()
-	execCtx.Config.Type = config.AgentTypeOrchestrator
-	execCtx.SubAgentCatalog = []config.SubAgentEntry{}
+	execCtx.SubAgentCatalog = []config.SubAgentEntry{
+		{Name: "LogAnalyzer", Description: "Analyzes logs"},
+	}
 
-	messages := builder.buildOrchestratorMessages(execCtx, "Previous findings")
+	messages := builder.BuildFunctionCallingMessages(execCtx, "Previous findings")
 	require.Len(t, messages, 2)
 
 	user := messages[1]

--- a/pkg/api/handler_trace_test.go
+++ b/pkg/api/handler_trace_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/codeready-toolchain/tarsy/ent/message"
 	"github.com/codeready-toolchain/tarsy/ent/schema"
 	"github.com/codeready-toolchain/tarsy/ent/stage"
-	"github.com/codeready-toolchain/tarsy/pkg/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -195,7 +194,7 @@ func TestBuildTraceListResponse_SubAgentNesting(t *testing.T) {
 			StageType: stage.StageTypeInvestigation,
 			Edges: ent.StageEdges{
 				AgentExecutions: []*ent.AgentExecution{
-					{ID: "exec-orch", AgentName: config.AgentNameOrchestrator, AgentIndex: 1},
+					{ID: "exec-orch", AgentName: "TestOrchestrator", AgentIndex: 1},
 					{ID: "exec-sub-1", AgentName: "LogAnalyzer", AgentIndex: 1, ParentExecutionID: &parentExecID},
 					{ID: "exec-sub-2", AgentName: "GeneralWorker", AgentIndex: 2, ParentExecutionID: &parentExecID},
 				},
@@ -222,7 +221,7 @@ func TestBuildTraceListResponse_SubAgentNesting(t *testing.T) {
 	require.Len(t, resp.Stages[0].Executions, 1)
 	orch := resp.Stages[0].Executions[0]
 	assert.Equal(t, "exec-orch", orch.ExecutionID)
-	assert.Equal(t, config.AgentNameOrchestrator, orch.AgentName)
+	assert.Equal(t, "TestOrchestrator", orch.AgentName)
 	require.Len(t, orch.LLMInteractions, 1)
 	assert.Equal(t, "llm-orch", orch.LLMInteractions[0].ID)
 

--- a/pkg/config/agent.go
+++ b/pkg/config/agent.go
@@ -33,7 +33,8 @@ type AgentConfig struct {
 	// missing keys fall through to the provider default.
 	NativeTools map[GoogleNativeTool]bool `yaml:"native_tools,omitempty"`
 
-	// Orchestrator-specific configuration (only valid when Type == orchestrator)
+	// Orchestrator guardrails (valid on any agent type; inert unless the agent
+	// has sub-agents at runtime).
 	Orchestrator *OrchestratorConfig `yaml:"orchestrator,omitempty"`
 
 	// Skills controls the on-demand skill catalog (available via load_skill).

--- a/pkg/config/builtin.go
+++ b/pkg/config/builtin.go
@@ -34,12 +34,11 @@ type BuiltinAgentConfig struct {
 // Built-in agent names. Use these constants instead of string literals
 // when referencing built-in agents in resolvers, executors, and tests.
 const (
-	AgentNameKubernetes   = "KubernetesAgent"
-	AgentNameChat         = "ChatAgent"
-	AgentNameExecSummary  = "ExecSummaryAgent"
-	AgentNameSynthesis    = "SynthesisAgent"
-	AgentNameScoring      = "ScoringAgent"
-	AgentNameOrchestrator = "Orchestrator"
+	AgentNameKubernetes  = "KubernetesAgent"
+	AgentNameChat        = "ChatAgent"
+	AgentNameExecSummary = "ExecSummaryAgent"
+	AgentNameSynthesis   = "SynthesisAgent"
+	AgentNameScoring     = "ScoringAgent"
 )
 
 var (
@@ -137,10 +136,6 @@ Show your work. Report results clearly.`,
 			Description: "General-purpose agent for analysis, summarization, reasoning, and other tasks",
 			CustomInstructions: `You are GeneralWorker, a general-purpose agent.
 Complete the assigned task thoroughly and concisely.`,
-		},
-		AgentNameOrchestrator: {
-			Description: "Dynamic investigation orchestrator that dispatches specialized sub-agents",
-			Type:        AgentTypeOrchestrator,
 		},
 	}
 }

--- a/pkg/config/builtin_test.go
+++ b/pkg/config/builtin_test.go
@@ -104,12 +104,6 @@ func TestBuiltinAgents(t *testing.T) {
 			wantType: AgentTypeExecSummary,
 		},
 		{
-			name:     AgentNameOrchestrator,
-			agentID:  AgentNameOrchestrator,
-			wantDesc: "Dynamic investigation orchestrator that dispatches specialized sub-agents",
-			wantType: AgentTypeOrchestrator,
-		},
-		{
 			name:     AgentNameScoring,
 			agentID:  AgentNameScoring,
 			wantDesc: "Evaluates session quality via a multi-turn LLM conversation",
@@ -199,28 +193,10 @@ func TestBuiltinSynthesisAgentHasNoMCPServers(t *testing.T) {
 	assert.Empty(t, agent.MCPServers, "SynthesisAgent should not have MCP servers (it never calls tools)")
 }
 
-func TestBuiltinOrchestratorAgentProperties(t *testing.T) {
+func TestBuiltinOrchestratorAgentRemoved(t *testing.T) {
 	cfg := GetBuiltinConfig()
-	agent, exists := cfg.Agents[AgentNameOrchestrator]
-	require.True(t, exists)
-
-	assert.Equal(t, AgentTypeOrchestrator, agent.Type)
-	assert.Empty(t, agent.MCPServers, "Orchestrator should not have MCP servers (sub-agents have them)")
-	assert.Nil(t, agent.NativeTools, "Orchestrator should not set native tools")
-	assert.Empty(t, agent.LLMBackend, "Orchestrator should inherit LLM backend from defaults")
-}
-
-func TestBuiltinOrchestratorExcludedFromSubAgentRegistry(t *testing.T) {
-	cfg := GetBuiltinConfig()
-	agents := mergeAgents(cfg.Agents, nil)
-	registry := BuildSubAgentRegistry(agents)
-
-	_, found := registry.Get(AgentNameOrchestrator)
-	assert.False(t, found, "Orchestrator should not appear in SubAgentRegistry")
-
-	// Other described agents should still be present.
-	_, found = registry.Get("GeneralWorker")
-	assert.True(t, found, "GeneralWorker should appear in SubAgentRegistry")
+	_, exists := cfg.Agents["Orchestrator"]
+	assert.False(t, exists, "built-in Orchestrator agent should no longer exist")
 }
 
 func TestBuiltinImageProviderDisablesURLContext(t *testing.T) {

--- a/pkg/config/enums.go
+++ b/pkg/config/enums.go
@@ -12,8 +12,6 @@ const (
 	AgentTypeExecSummary AgentType = "exec_summary"
 	// AgentTypeScoring evaluates session quality (single-shot)
 	AgentTypeScoring AgentType = "scoring"
-	// AgentTypeOrchestrator dispatches and coordinates sub-agents (iterating controller)
-	AgentTypeOrchestrator AgentType = "orchestrator"
 	// AgentTypeAction evaluates findings and executes remediation actions (iterating controller)
 	AgentTypeAction AgentType = "action"
 )
@@ -21,7 +19,7 @@ const (
 // IsValid checks if the agent type is valid (empty string is valid — means default).
 func (t AgentType) IsValid() bool {
 	switch t {
-	case AgentTypeDefault, AgentTypeSynthesis, AgentTypeExecSummary, AgentTypeScoring, AgentTypeOrchestrator, AgentTypeAction:
+	case AgentTypeDefault, AgentTypeSynthesis, AgentTypeExecSummary, AgentTypeScoring, AgentTypeAction:
 		return true
 	default:
 		return false

--- a/pkg/config/enums_test.go
+++ b/pkg/config/enums_test.go
@@ -15,8 +15,9 @@ func TestAgentTypeIsValid(t *testing.T) {
 		{"default (empty)", AgentTypeDefault, true},
 		{"synthesis", AgentTypeSynthesis, true},
 		{"scoring", AgentTypeScoring, true},
-		{"orchestrator", AgentTypeOrchestrator, true},
+		{"action", AgentTypeAction, true},
 		{"invalid", AgentType("invalid"), false},
+		{"orchestrator is now invalid", AgentType("orchestrator"), false},
 	}
 
 	for _, tt := range tests {

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -176,7 +176,6 @@ agents:
     mcp_servers:
       - "test-server"
   orch-agent:
-    type: orchestrator
     description: "Orchestrator"
     orchestrator:
       max_concurrent_agents: 3
@@ -201,7 +200,7 @@ agent_chains:
       - name: "stage2"
         agents:
           - name: "worker-agent"
-            type: orchestrator
+            type: action
             sub_agents: ["worker-agent"]
 `
 	err := os.WriteFile(filepath.Join(configDir, "tarsy.yaml"), []byte(config), 0644)
@@ -217,9 +216,9 @@ agent_chains:
 	assert.Equal(t, 5*time.Minute, *cfg.Defaults.Orchestrator.AgentTimeout)
 	assert.Equal(t, 30*time.Minute, *cfg.Defaults.Orchestrator.MaxBudget)
 
-	// Agent orchestrator config
+	// Agent orchestrator config (orchestrator block is valid on any agent type)
 	orch := cfg.Agents["orch-agent"]
-	assert.Equal(t, AgentTypeOrchestrator, orch.Type)
+	assert.Equal(t, AgentTypeDefault, orch.Type)
 	require.NotNil(t, orch.Orchestrator)
 	assert.Equal(t, 3, *orch.Orchestrator.MaxConcurrentAgents)
 	assert.Equal(t, 2*time.Minute, *orch.Orchestrator.AgentTimeout)
@@ -238,7 +237,7 @@ agent_chains:
 	// Stage-agent type override parsed from YAML
 	stage2Agent := chain.Stages[1].Agents[0]
 	assert.Equal(t, "worker-agent", stage2Agent.Name)
-	assert.Equal(t, AgentTypeOrchestrator, stage2Agent.Type)
+	assert.Equal(t, AgentTypeAction, stage2Agent.Type)
 
 	// Stage 1 agent has no type override
 	assert.Equal(t, AgentType(""), chain.Stages[0].Agents[0].Type)

--- a/pkg/config/sub_agent_registry.go
+++ b/pkg/config/sub_agent_registry.go
@@ -16,11 +16,11 @@ type SubAgentRegistry struct {
 }
 
 // BuildSubAgentRegistry creates a registry from the merged agent map.
-// Includes agents with non-empty Description, excludes orchestrator agents.
+// Includes agents with non-empty Description.
 func BuildSubAgentRegistry(agents map[string]*AgentConfig) *SubAgentRegistry {
 	var entries []SubAgentEntry
 	for name, agent := range agents {
-		if agent == nil || agent.Description == "" || agent.Type == AgentTypeOrchestrator {
+		if agent == nil || agent.Description == "" {
 			continue
 		}
 		entry := SubAgentEntry{

--- a/pkg/config/sub_agent_registry_test.go
+++ b/pkg/config/sub_agent_registry_test.go
@@ -27,16 +27,12 @@ func TestBuildSubAgentRegistry(t *testing.T) {
 		"NoDescAgent": {
 			MCPServers: []string{"some-server"},
 		},
-		"MyOrchestrator": {
-			Type:        AgentTypeOrchestrator,
-			Description: "An orchestrator",
-		},
 	}
 
 	registry := BuildSubAgentRegistry(agents)
 	entries := registry.Entries()
 
-	// Should include agents with Description, excluding orchestrators and no-description
+	// Should include agents with Description, excluding no-description
 	require.Len(t, entries, 3)
 
 	// Sorted by name
@@ -67,6 +63,27 @@ func TestBuildSubAgentRegistry_DisabledNativeToolsExcluded(t *testing.T) {
 
 	require.Len(t, entries, 1)
 	assert.Equal(t, []string{"code_execution"}, entries[0].NativeTools)
+}
+
+func TestBuildSubAgentRegistry_IncludesAllTypesWithDescription(t *testing.T) {
+	agents := map[string]*AgentConfig{
+		"DefaultAgent":   {Description: "Default agent", Type: AgentTypeDefault},
+		"ActionAgent":    {Description: "Action agent", Type: AgentTypeAction},
+		"SynthesisAgent": {Description: "Synthesis agent", Type: AgentTypeSynthesis},
+		"NoDescAgent":    {Type: AgentTypeDefault},
+	}
+
+	registry := BuildSubAgentRegistry(agents)
+	entries := registry.Entries()
+
+	require.Len(t, entries, 3, "all described agents regardless of type")
+	names := make([]string, len(entries))
+	for i, e := range entries {
+		names[i] = e.Name
+	}
+	assert.Contains(t, names, "DefaultAgent")
+	assert.Contains(t, names, "ActionAgent")
+	assert.Contains(t, names, "SynthesisAgent")
 }
 
 func TestBuildSubAgentRegistry_Empty(t *testing.T) {
@@ -151,11 +168,6 @@ func TestBuildSubAgentRegistry_WithBuiltinAgents(t *testing.T) {
 		}
 	}
 
-	// Orchestrator agents (if any are built-in) must be excluded
-	for _, e := range entries {
-		agent := merged[e.Name]
-		assert.NotEqual(t, AgentTypeOrchestrator, agent.Type, "orchestrator %s should not be in registry", e.Name)
-	}
 }
 
 func TestSubAgentRegistry_Get(t *testing.T) {

--- a/pkg/config/validator.go
+++ b/pkg/config/validator.go
@@ -253,11 +253,6 @@ func (v *Validator) validateAgents() error {
 			}
 		}
 
-		// Orchestrator config only valid on orchestrator agents
-		if agent.Orchestrator != nil && agent.Type != AgentTypeOrchestrator {
-			return NewValidationError("agent", name, "orchestrator", fmt.Errorf("orchestrator config only valid on orchestrator agents"))
-		}
-
 		if agent.Orchestrator != nil {
 			if err := v.validateOrchestratorConfig(agent.Orchestrator, "agent", name); err != nil {
 				return err
@@ -738,10 +733,6 @@ func (v *Validator) validateSubAgentRefs(subAgents SubAgentRefs, section, name, 
 	for _, ref := range subAgents {
 		if !v.cfg.AgentRegistry.Has(ref.Name) {
 			return NewValidationError(section, name, field, fmt.Errorf("agent '%s' not found", ref.Name))
-		}
-		agentDef, _ := v.cfg.AgentRegistry.Get(ref.Name)
-		if agentDef.Type == AgentTypeOrchestrator {
-			return NewValidationError(section, name, field, fmt.Errorf("agent '%s' is an orchestrator and cannot be a sub-agent", ref.Name))
 		}
 		if ref.LLMBackend != "" && !ref.LLMBackend.IsValid() {
 			return NewValidationError(section, name, field, fmt.Errorf("sub-agent '%s' has invalid llm_backend: %s", ref.Name, ref.LLMBackend))

--- a/pkg/config/validator.go
+++ b/pkg/config/validator.go
@@ -734,6 +734,11 @@ func (v *Validator) validateSubAgentRefs(subAgents SubAgentRefs, section, name, 
 		if !v.cfg.AgentRegistry.Has(ref.Name) {
 			return NewValidationError(section, name, field, fmt.Errorf("agent '%s' not found", ref.Name))
 		}
+		agentDef, _ := v.cfg.AgentRegistry.Get(ref.Name)
+		if agentDef != nil && agentDef.Description == "" {
+			return NewValidationError(section, name, field,
+				fmt.Errorf("agent '%s' has no description (required for sub-agent catalog)", ref.Name))
+		}
 		if ref.LLMBackend != "" && !ref.LLMBackend.IsValid() {
 			return NewValidationError(section, name, field, fmt.Errorf("sub-agent '%s' has invalid llm_backend: %s", ref.Name, ref.LLMBackend))
 		}

--- a/pkg/config/validator_test.go
+++ b/pkg/config/validator_test.go
@@ -133,10 +133,9 @@ func TestValidateAgents(t *testing.T) {
 			errMsg:  "invalid native tool",
 		},
 		{
-			name: "orchestrator agent with orchestrator config is valid",
+			name: "any agent with orchestrator config is valid",
 			agents: map[string]*AgentConfig{
-				"my-orch": {
-					Type:         AgentTypeOrchestrator,
+				"my-agent": {
 					Orchestrator: &OrchestratorConfig{MaxConcurrentAgents: intPtr(3)},
 				},
 			},
@@ -144,21 +143,9 @@ func TestValidateAgents(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "non-orchestrator agent with orchestrator config is invalid",
-			agents: map[string]*AgentConfig{
-				"regular": {
-					Orchestrator: &OrchestratorConfig{MaxConcurrentAgents: intPtr(3)},
-				},
-			},
-			servers: map[string]*MCPServerConfig{},
-			wantErr: true,
-			errMsg:  "orchestrator config only valid on orchestrator agents",
-		},
-		{
 			name: "orchestrator config with zero max_concurrent_agents",
 			agents: map[string]*AgentConfig{
 				"orch": {
-					Type:         AgentTypeOrchestrator,
 					Orchestrator: &OrchestratorConfig{MaxConcurrentAgents: intPtr(0)},
 				},
 			},
@@ -170,7 +157,6 @@ func TestValidateAgents(t *testing.T) {
 			name: "orchestrator config with negative agent_timeout",
 			agents: map[string]*AgentConfig{
 				"orch": {
-					Type:         AgentTypeOrchestrator,
 					Orchestrator: &OrchestratorConfig{AgentTimeout: durPtr(-1 * time.Second)},
 				},
 			},
@@ -182,7 +168,6 @@ func TestValidateAgents(t *testing.T) {
 			name: "orchestrator config with zero max_budget",
 			agents: map[string]*AgentConfig{
 				"orch": {
-					Type:         AgentTypeOrchestrator,
 					Orchestrator: &OrchestratorConfig{MaxBudget: durPtr(0)},
 				},
 			},
@@ -199,15 +184,7 @@ func TestValidateAgents(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "orchestrator agent without orchestrator config is valid",
-			agents: map[string]*AgentConfig{
-				"orch": {Type: AgentTypeOrchestrator},
-			},
-			servers: map[string]*MCPServerConfig{},
-			wantErr: false,
-		},
-		{
-			name: "synthesis agent with orchestrator config is invalid",
+			name: "synthesis agent with orchestrator config is valid (inert if no sub-agents)",
 			agents: map[string]*AgentConfig{
 				"synth": {
 					Type:         AgentTypeSynthesis,
@@ -215,8 +192,7 @@ func TestValidateAgents(t *testing.T) {
 				},
 			},
 			servers: map[string]*MCPServerConfig{},
-			wantErr: true,
-			errMsg:  "orchestrator config only valid on orchestrator agents",
+			wantErr: false,
 		},
 	}
 
@@ -1152,7 +1128,7 @@ func TestValidateStageComprehensive(t *testing.T) {
 				Agents: []StageAgentConfig{
 					{
 						Name: "test-agent",
-						Type: AgentTypeOrchestrator,
+						Type: AgentTypeAction,
 					},
 				},
 			},
@@ -2523,7 +2499,7 @@ func TestValidateSubAgents(t *testing.T) {
 	baseAgents := map[string]*AgentConfig{
 		"LogAnalyzer":    {Description: "Analyzes logs"},
 		"MetricChecker":  {Description: "Checks metrics"},
-		"MyOrchestrator": {Type: AgentTypeOrchestrator, Description: "Orchestrator"},
+		"MyOrchestrator": {Description: "Orchestrator agent"},
 	}
 
 	t.Run("valid chain-level sub_agents", func(t *testing.T) {
@@ -2565,27 +2541,6 @@ func TestValidateSubAgents(t *testing.T) {
 		err := validator.validateChains()
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "agent 'NonExistent' not found")
-	})
-
-	t.Run("sub_agents cannot reference orchestrator", func(t *testing.T) {
-		cfg := &Config{
-			AgentRegistry:       NewAgentRegistry(baseAgents),
-			MCPServerRegistry:   NewMCPServerRegistry(map[string]*MCPServerConfig{}),
-			LLMProviderRegistry: NewLLMProviderRegistry(map[string]*LLMProviderConfig{}),
-			ChainRegistry: NewChainRegistry(map[string]*ChainConfig{
-				"chain1": {
-					AlertTypes: []string{"test"},
-					SubAgents:  SubAgentRefs{{Name: "MyOrchestrator"}},
-					Stages: []StageConfig{
-						{Name: "s1", Agents: []StageAgentConfig{{Name: "LogAnalyzer"}}},
-					},
-				},
-			}),
-		}
-		validator := NewValidator(cfg)
-		err := validator.validateChains()
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "is an orchestrator and cannot be a sub-agent")
 	})
 
 	t.Run("valid stage-level sub_agents", func(t *testing.T) {
@@ -2635,7 +2590,7 @@ func TestValidateSubAgents(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("stage-level sub_agents cannot reference orchestrator", func(t *testing.T) {
+	t.Run("any agent can be a sub-agent", func(t *testing.T) {
 		cfg := &Config{
 			AgentRegistry:       NewAgentRegistry(baseAgents),
 			MCPServerRegistry:   NewMCPServerRegistry(map[string]*MCPServerConfig{}),
@@ -2655,8 +2610,7 @@ func TestValidateSubAgents(t *testing.T) {
 		}
 		validator := NewValidator(cfg)
 		err := validator.validateChains()
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "is an orchestrator and cannot be a sub-agent")
+		assert.NoError(t, err)
 	})
 
 	t.Run("stage-agent-level sub_agents references unknown agent", func(t *testing.T) {

--- a/pkg/config/validator_test.go
+++ b/pkg/config/validator_test.go
@@ -2638,6 +2638,32 @@ func TestValidateSubAgents(t *testing.T) {
 		assert.Contains(t, err.Error(), "agent 'Ghost' not found")
 	})
 
+	t.Run("sub_agent ref to agent with empty description", func(t *testing.T) {
+		agents := map[string]*AgentConfig{
+			"LogAnalyzer": {Description: "Analyzes logs"},
+			"NoDescAgent": {MCPServers: []string{"some-server"}},
+		}
+		cfg := &Config{
+			AgentRegistry:       NewAgentRegistry(agents),
+			MCPServerRegistry:   NewMCPServerRegistry(map[string]*MCPServerConfig{}),
+			LLMProviderRegistry: NewLLMProviderRegistry(map[string]*LLMProviderConfig{}),
+			ChainRegistry: NewChainRegistry(map[string]*ChainConfig{
+				"chain1": {
+					AlertTypes: []string{"test"},
+					SubAgents:  SubAgentRefs{{Name: "NoDescAgent"}},
+					Stages: []StageConfig{
+						{Name: "s1", Agents: []StageAgentConfig{{Name: "LogAnalyzer"}}},
+					},
+				},
+			}),
+		}
+		validator := NewValidator(cfg)
+		err := validator.validateChains()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "NoDescAgent")
+		assert.Contains(t, err.Error(), "no description")
+	})
+
 	t.Run("sub_agent ref with valid overrides", func(t *testing.T) {
 		cfg := &Config{
 			AgentRegistry:       NewAgentRegistry(baseAgents),

--- a/pkg/queue/executor.go
+++ b/pkg/queue/executor.go
@@ -715,7 +715,7 @@ func (e *RealSessionExecutor) executeAgent(
 			runner := orchestrator.NewSubAgentRunner(ctx, deps, exec.ID, input.session.ID, stg.ID, registry, guardrails, subAgentRefs)
 			toolExecutor = orchestrator.NewCompositeToolExecutor(toolExecutor, runner, registry)
 			execCtx.SubAgentCollector = orchestrator.NewResultCollector(runner)
-			execCtx.SubAgentCatalog = registry.Entries()
+			execCtx.SubAgentCatalog = applyCatalogOverrides(registry.Entries(), subAgentRefs)
 		}
 	}
 

--- a/pkg/queue/executor.go
+++ b/pkg/queue/executor.go
@@ -669,52 +669,54 @@ func (e *RealSessionExecutor) executeAgent(
 		},
 	}
 
-	if resolvedConfig.Type == config.AgentTypeOrchestrator {
-		agentDef, getErr := e.cfg.GetAgent(agentConfig.Name)
-		if getErr != nil {
-			failErr := fmt.Errorf("failed to get orchestrator agent config: %w", getErr)
-			logger.Error("Failed to get agent definition for orchestrator", "error", getErr)
-			if updateErr := input.stageService.UpdateAgentExecutionStatus(
-				context.Background(), exec.ID, agentexecution.StatusFailed, failErr.Error(),
-			); updateErr != nil {
-				logger.Error("Failed to update agent execution status", "error", updateErr)
-			}
-			publishExecutionStatus(context.Background(), e.eventPublisher, input.session.ID, stg.ID, exec.ID, agentIndex+1, string(agentexecution.StatusFailed), failErr.Error())
-			return agentResult{
-				executionID:     exec.ID,
-				status:          agent.ExecutionStatusFailed,
-				err:             failErr,
-				llmBackend:      resolvedBackend,
-				llmProviderName: resolvedConfig.LLMProviderName,
-			}
-		}
-
-		guardrails := resolveOrchestratorGuardrails(e.cfg, agentDef)
-		subAgentRefs := resolveSubAgents(input.chain, input.stageConfig, agentConfig)
+	subAgentRefs := resolveSubAgents(input.chain, input.stageConfig, agentConfig)
+	if len(subAgentRefs) > 0 {
 		registry := e.subAgentRegistry.Filter(subAgentRefs.Names())
+		if len(registry.Entries()) > 0 {
+			agentDef, getErr := e.cfg.GetAgent(agentConfig.Name)
+			if getErr != nil {
+				failErr := fmt.Errorf("failed to get agent config for orchestration: %w", getErr)
+				logger.Error("Failed to get agent definition for orchestration", "error", getErr)
+				if updateErr := input.stageService.UpdateAgentExecutionStatus(
+					context.Background(), exec.ID, agentexecution.StatusFailed, failErr.Error(),
+				); updateErr != nil {
+					logger.Error("Failed to update agent execution status", "error", updateErr)
+				}
+				publishExecutionStatus(context.Background(), e.eventPublisher, input.session.ID, stg.ID, exec.ID, agentIndex+1, string(agentexecution.StatusFailed), failErr.Error())
+				return agentResult{
+					executionID:     exec.ID,
+					status:          agent.ExecutionStatusFailed,
+					err:             failErr,
+					llmBackend:      resolvedBackend,
+					llmProviderName: resolvedConfig.LLMProviderName,
+				}
+			}
 
-		deps := &orchestrator.SubAgentDeps{
-			Config:             e.cfg,
-			Chain:              input.chain,
-			AgentFactory:       e.agentFactory,
-			MCPFactory:         e.mcpFactory,
-			LLMClient:          e.llmClient,
-			EventPublisher:     e.eventPublisher,
-			PromptBuilder:      e.promptBuilder,
-			StageService:       input.stageService,
-			TimelineService:    input.timelineService,
-			MessageService:     input.messageService,
-			InteractionService: input.interactionService,
-			AlertData:          input.session.AlertData,
-			AlertType:          input.session.AlertType,
-			RunbookContent:     input.runbookContent,
-			WrapToolExecutor:   e.memoryToolWrapper(input.session),
+			guardrails := resolveOrchestratorGuardrails(e.cfg, agentDef)
+
+			deps := &orchestrator.SubAgentDeps{
+				Config:             e.cfg,
+				Chain:              input.chain,
+				AgentFactory:       e.agentFactory,
+				MCPFactory:         e.mcpFactory,
+				LLMClient:          e.llmClient,
+				EventPublisher:     e.eventPublisher,
+				PromptBuilder:      e.promptBuilder,
+				StageService:       input.stageService,
+				TimelineService:    input.timelineService,
+				MessageService:     input.messageService,
+				InteractionService: input.interactionService,
+				AlertData:          input.session.AlertData,
+				AlertType:          input.session.AlertType,
+				RunbookContent:     input.runbookContent,
+				WrapToolExecutor:   e.memoryToolWrapper(input.session),
+			}
+
+			runner := orchestrator.NewSubAgentRunner(ctx, deps, exec.ID, input.session.ID, stg.ID, registry, guardrails, subAgentRefs)
+			toolExecutor = orchestrator.NewCompositeToolExecutor(toolExecutor, runner, registry)
+			execCtx.SubAgentCollector = orchestrator.NewResultCollector(runner)
+			execCtx.SubAgentCatalog = registry.Entries()
 		}
-
-		runner := orchestrator.NewSubAgentRunner(ctx, deps, exec.ID, input.session.ID, stg.ID, registry, guardrails, subAgentRefs)
-		toolExecutor = orchestrator.NewCompositeToolExecutor(toolExecutor, runner, registry)
-		execCtx.SubAgentCollector = orchestrator.NewResultCollector(runner)
-		execCtx.SubAgentCatalog = registry.Entries()
 	}
 
 	// Wrap with skill tool executor (after orchestrator)

--- a/pkg/queue/executor_helpers.go
+++ b/pkg/queue/executor_helpers.go
@@ -489,6 +489,29 @@ func applyOrchestratorConfig(g *orchestrator.OrchestratorGuardrails, oc *config.
 	}
 }
 
+// applyCatalogOverrides merges per-ref MCPServers overrides into catalog entries.
+// SubAgentRef.MCPServers, when non-empty, replaces the base agent's MCPServers
+// in the catalog shown to the orchestrator LLM, so the prompt accurately
+// reflects what tools each sub-agent will have when dispatched.
+// Entries are already deep copies from registry.Entries(), safe to mutate.
+func applyCatalogOverrides(entries []config.SubAgentEntry, refs config.SubAgentRefs) []config.SubAgentEntry {
+	overrides := make(map[string]config.SubAgentRef, len(refs))
+	for _, ref := range refs {
+		overrides[ref.Name] = ref
+	}
+	for i, entry := range entries {
+		ref, ok := overrides[entry.Name]
+		if !ok {
+			continue
+		}
+		if len(ref.MCPServers) > 0 {
+			entries[i].MCPServers = make([]string, len(ref.MCPServers))
+			copy(entries[i].MCPServers, ref.MCPServers)
+		}
+	}
+	return entries
+}
+
 // resolveSubAgents returns the sub_agents override from the most specific level
 // in the hierarchy: stage-agent > stage > chain. Returns nil if no override
 // (meaning the full global registry is used).

--- a/pkg/queue/executor_integration_test.go
+++ b/pkg/queue/executor_integration_test.go
@@ -2303,7 +2303,10 @@ func TestExecutor_OrchestratorDispatchesSubAgent(t *testing.T) {
 			{
 				Name: "orchestrate",
 				Agents: []config.StageAgentConfig{
-					{Name: "OrchestratorAgent"},
+					{
+						Name:      "OrchestratorAgent",
+						SubAgents: config.SubAgentRefs{{Name: "GeneralWorker"}},
+					},
 				},
 			},
 		},
@@ -2317,7 +2320,6 @@ func TestExecutor_OrchestratorDispatchesSubAgent(t *testing.T) {
 		},
 		AgentRegistry: config.NewAgentRegistry(map[string]*config.AgentConfig{
 			"OrchestratorAgent": {
-				Type:          config.AgentTypeOrchestrator,
 				Description:   "Test orchestrator",
 				LLMBackend:    config.LLMBackendLangChain,
 				MaxIterations: &maxIter,

--- a/pkg/queue/executor_memory.go
+++ b/pkg/queue/executor_memory.go
@@ -18,7 +18,7 @@ import (
 // spuriously record injected IDs.
 func agentTypeSupportsMemory(agentType config.AgentType) bool {
 	switch agentType {
-	case config.AgentTypeDefault, config.AgentTypeAction, config.AgentTypeOrchestrator:
+	case config.AgentTypeDefault, config.AgentTypeAction:
 		return true
 	default:
 		return false

--- a/pkg/queue/executor_memory_test.go
+++ b/pkg/queue/executor_memory_test.go
@@ -12,7 +12,6 @@ func TestAgentTypeSupportsMemory(t *testing.T) {
 	supported := []config.AgentType{
 		config.AgentTypeDefault,
 		config.AgentTypeAction,
-		config.AgentTypeOrchestrator,
 	}
 	for _, at := range supported {
 		name := string(at)

--- a/pkg/queue/executor_test.go
+++ b/pkg/queue/executor_test.go
@@ -752,3 +752,50 @@ func TestResolveSubAgents(t *testing.T) {
 		})
 	}
 }
+
+func TestApplyCatalogOverrides(t *testing.T) {
+	t.Run("mcp_servers override replaces base", func(t *testing.T) {
+		entries := []config.SubAgentEntry{
+			{Name: "GeneralWorker", Description: "Worker", MCPServers: nil},
+			{Name: "LogAnalyzer", Description: "Logs", MCPServers: []string{"loki"}},
+		}
+		refs := config.SubAgentRefs{
+			{Name: "GeneralWorker", MCPServers: []string{"kubernetes-server"}},
+		}
+		result := applyCatalogOverrides(entries, refs)
+
+		assert.Equal(t, []string{"kubernetes-server"}, result[0].MCPServers)
+		assert.Equal(t, []string{"loki"}, result[1].MCPServers, "unmatched entry unchanged")
+	})
+
+	t.Run("empty ref mcp_servers preserves base", func(t *testing.T) {
+		entries := []config.SubAgentEntry{
+			{Name: "LogAnalyzer", Description: "Logs", MCPServers: []string{"loki"}},
+		}
+		refs := config.SubAgentRefs{
+			{Name: "LogAnalyzer"},
+		}
+		result := applyCatalogOverrides(entries, refs)
+		assert.Equal(t, []string{"loki"}, result[0].MCPServers)
+	})
+
+	t.Run("no matching refs returns entries unchanged", func(t *testing.T) {
+		entries := []config.SubAgentEntry{
+			{Name: "A", Description: "Agent A"},
+		}
+		result := applyCatalogOverrides(entries, config.SubAgentRefs{{Name: "B"}})
+		assert.Equal(t, entries, result)
+	})
+
+	t.Run("override is a defensive copy", func(t *testing.T) {
+		entries := []config.SubAgentEntry{
+			{Name: "Worker", Description: "Worker"},
+		}
+		refs := config.SubAgentRefs{
+			{Name: "Worker", MCPServers: []string{"server-a"}},
+		}
+		result := applyCatalogOverrides(entries, refs)
+		result[0].MCPServers[0] = "mutated"
+		assert.Equal(t, "server-a", refs[0].MCPServers[0], "original ref must not be mutated")
+	})
+}

--- a/pkg/services/session_service_test.go
+++ b/pkg/services/session_service_test.go
@@ -978,7 +978,7 @@ func TestSessionService_GetSessionDetail(t *testing.T) {
 			SetID(uuid.New().String()).
 			SetSessionID(sess.ID).
 			SetStageID(stg.ID).
-			SetAgentName(config.AgentNameOrchestrator).
+			SetAgentName("TestOrchestrator").
 			SetAgentIndex(1).
 			SetLlmBackend(string(config.LLMBackendLangChain)).
 			SetStatus("completed").
@@ -1048,7 +1048,7 @@ func TestSessionService_GetSessionDetail(t *testing.T) {
 
 		orch := detail.Stages[0].Executions[0]
 		assert.Equal(t, orchestrator.ID, orch.ExecutionID)
-		assert.Equal(t, config.AgentNameOrchestrator, orch.AgentName)
+		assert.Equal(t, "TestOrchestrator", orch.AgentName)
 		assert.Nil(t, orch.ParentExecutionID)
 		assert.Nil(t, orch.Task)
 		assert.Equal(t, int64(100), orch.InputTokens)

--- a/pkg/services/stage_service_test.go
+++ b/pkg/services/stage_service_test.go
@@ -1085,7 +1085,7 @@ func TestStageService_CreateAgentExecution_SubAgent(t *testing.T) {
 	orchestrator, err := stageService.CreateAgentExecution(ctx, models.CreateAgentExecutionRequest{
 		StageID:    stg.ID,
 		SessionID:  session.ID,
-		AgentName:  config.AgentNameOrchestrator,
+		AgentName:  "TestOrchestrator",
 		AgentIndex: 1,
 		LLMBackend: config.LLMBackendLangChain,
 	})
@@ -1261,7 +1261,7 @@ func TestStageService_UpdateStageStatus_ExcludesSubAgents(t *testing.T) {
 	orchestrator, err := stageService.CreateAgentExecution(ctx, models.CreateAgentExecutionRequest{
 		StageID:    stg.ID,
 		SessionID:  session.ID,
-		AgentName:  config.AgentNameOrchestrator,
+		AgentName:  "TestOrchestrator",
 		AgentIndex: 1,
 		LLMBackend: config.LLMBackendLangChain,
 	})
@@ -1323,7 +1323,7 @@ func TestStageService_GetSubAgentExecutions(t *testing.T) {
 	orchestrator, err := stageService.CreateAgentExecution(ctx, models.CreateAgentExecutionRequest{
 		StageID:    stg.ID,
 		SessionID:  session.ID,
-		AgentName:  config.AgentNameOrchestrator,
+		AgentName:  "TestOrchestrator",
 		AgentIndex: 1,
 		LLMBackend: config.LLMBackendLangChain,
 	})
@@ -1392,7 +1392,7 @@ func TestStageService_GetExecutionTree(t *testing.T) {
 	orchestrator, err := stageService.CreateAgentExecution(ctx, models.CreateAgentExecutionRequest{
 		StageID:    stg.ID,
 		SessionID:  session.ID,
-		AgentName:  config.AgentNameOrchestrator,
+		AgentName:  "TestOrchestrator",
 		AgentIndex: 1,
 		LLMBackend: config.LLMBackendLangChain,
 	})
@@ -1578,7 +1578,7 @@ func TestStageService_SubAgentCascadeDelete(t *testing.T) {
 	orchestrator, err := stageService.CreateAgentExecution(ctx, models.CreateAgentExecutionRequest{
 		StageID:    stg.ID,
 		SessionID:  session.ID,
-		AgentName:  config.AgentNameOrchestrator,
+		AgentName:  "TestOrchestrator",
 		AgentIndex: 1,
 		LLMBackend: config.LLMBackendLangChain,
 	})

--- a/pkg/services/timeline_service_test.go
+++ b/pkg/services/timeline_service_test.go
@@ -162,7 +162,7 @@ func TestTimelineService_CreateTimelineEvent(t *testing.T) {
 		parentExec, err := stageService.CreateAgentExecution(ctx, models.CreateAgentExecutionRequest{
 			StageID:    stg.ID,
 			SessionID:  session.ID,
-			AgentName:  config.AgentNameOrchestrator,
+			AgentName:  "TestOrchestrator",
 			AgentIndex: 2,
 			LLMBackend: config.LLMBackendLangChain,
 		})

--- a/test/e2e/orchestrator_test.go
+++ b/test/e2e/orchestrator_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/codeready-toolchain/tarsy/pkg/agent"
-	"github.com/codeready-toolchain/tarsy/pkg/config"
 	"github.com/codeready-toolchain/tarsy/test/e2e/testdata"
 	"github.com/codeready-toolchain/tarsy/test/e2e/testdata/configs"
 )
@@ -606,18 +605,21 @@ func TestE2E_OrchestratorMultiAgent(t *testing.T) {
 }
 
 // ────────────────────────────────────────────────────────────
-// Built-in Orchestrator agent — verifies that a user-defined chain can
-// reference the built-in "Orchestrator" agent by name (not defined in
-// the test config's agents: section) and get full orchestrator functionality.
+// Implicit orchestrator — verifies that any agent with sub_agents
+// automatically gains orchestration capabilities (dispatch, cancel,
+// list tools + orchestrator prompt sections). Uses a custom
+// InvestigationOrchestrator defined in the test config.
 //
 // Same pattern as TestE2E_OrchestratorMultiAgent but uses:
-//   - Built-in "Orchestrator" agent (type=orchestrator) instead of custom "SREOrchestrator"
-//   - Config: builtin-orchestrator (Orchestrator not in agents: section)
+//   - Custom "InvestigationOrchestrator" (no type: orchestrator — implicit)
+//   - Config: builtin-orchestrator
 //
-// Verifies: built-in agent resolved, 3 executions, parent-child links, trace API, session completion.
+// Verifies: implicit orchestration resolved, 3 executions, parent-child links, trace API, session completion.
 // ────────────────────────────────────────────────────────────
 
 func TestE2E_OrchestratorBuiltinAgent(t *testing.T) {
+	const orchAgent = "InvestigationOrchestrator"
+
 	llm := NewScriptedLLMClient()
 
 	subAgentGate := make(chan struct{})
@@ -625,7 +627,7 @@ func TestE2E_OrchestratorBuiltinAgent(t *testing.T) {
 	orchIter2Ready := make(chan struct{}, 1)
 
 	// Orchestrator iteration 1: dispatch both sub-agents.
-	llm.AddRouted(config.AgentNameOrchestrator, LLMScriptEntry{
+	llm.AddRouted(orchAgent, LLMScriptEntry{
 		Chunks: []agent.Chunk{
 			&agent.ToolCallChunk{CallID: "orch-d1", Name: "dispatch_agent",
 				Arguments: `{"name":"LogAnalyzer","task":"Analyze recent error logs for the payment service"}`},
@@ -635,7 +637,7 @@ func TestE2E_OrchestratorBuiltinAgent(t *testing.T) {
 		},
 	})
 	// Iteration 2: text → WaitForResult. OnBlock signals readiness.
-	llm.AddRouted(config.AgentNameOrchestrator, LLMScriptEntry{
+	llm.AddRouted(orchAgent, LLMScriptEntry{
 		WaitCh:  orchIter2Gate,
 		OnBlock: orchIter2Ready,
 		Chunks: []agent.Chunk{
@@ -645,7 +647,7 @@ func TestE2E_OrchestratorBuiltinAgent(t *testing.T) {
 	})
 	// Iterations 3-4: buffer for timing variance.
 	for i := range 2 {
-		llm.AddRouted(config.AgentNameOrchestrator, LLMScriptEntry{
+		llm.AddRouted(orchAgent, LLMScriptEntry{
 			Chunks: []agent.Chunk{
 				&agent.TextChunk{Content: fmt.Sprintf("Waiting for sub-agent results (cycle %d).", i+2)},
 				&agent.UsageChunk{InputTokens: 250, OutputTokens: 15, TotalTokens: 265},
@@ -653,7 +655,7 @@ func TestE2E_OrchestratorBuiltinAgent(t *testing.T) {
 		})
 	}
 	// Final answer after receiving all results.
-	llm.AddRouted(config.AgentNameOrchestrator, LLMScriptEntry{
+	llm.AddRouted(orchAgent, LLMScriptEntry{
 		Chunks: []agent.Chunk{
 			&agent.TextChunk{Content: "Both sub-agents completed. LogAnalyzer found errors, " +
 				"GeneralWorker assessed severity. Root cause: memory pressure after deploy-5678."},
@@ -734,7 +736,7 @@ func TestE2E_OrchestratorBuiltinAgent(t *testing.T) {
 	assert.NotEmpty(t, session["final_analysis"])
 	assert.NotEmpty(t, session["executive_summary"])
 
-	// ── DB: 4 executions (Orchestrator + 2 sub-agents + exec_summary), all completed ──
+	// ── DB: 4 executions (orchestrator + 2 sub-agents + exec_summary), all completed ──
 	execs := app.QueryExecutions(t, sessionID)
 	require.Len(t, execs, 4, "expected orchestrator + 2 sub-agents + exec_summary")
 
@@ -745,7 +747,7 @@ func TestE2E_OrchestratorBuiltinAgent(t *testing.T) {
 		assert.Equal(t, "completed", string(e.Status), "%s should be completed", e.AgentName)
 
 		switch e.AgentName {
-		case config.AgentNameOrchestrator:
+		case orchAgent:
 			orchExecID = e.ID
 			assert.Nil(t, e.ParentExecutionID)
 		case "LogAnalyzer":
@@ -758,7 +760,7 @@ func TestE2E_OrchestratorBuiltinAgent(t *testing.T) {
 			assert.Contains(t, *e.Task, "alert context")
 		}
 	}
-	assert.True(t, agentNames[config.AgentNameOrchestrator], "should have built-in Orchestrator")
+	assert.True(t, agentNames[orchAgent], "should have InvestigationOrchestrator")
 	assert.True(t, agentNames["LogAnalyzer"], "should have LogAnalyzer")
 	assert.True(t, agentNames["GeneralWorker"], "should have GeneralWorker")
 	assert.NotEmpty(t, orchExecID)
@@ -780,7 +782,7 @@ func TestE2E_OrchestratorBuiltinAgent(t *testing.T) {
 	require.Len(t, traceExecs, 1, "only orchestrator at top level")
 
 	orchTrace := traceExecs[0].(map[string]interface{})
-	assert.Equal(t, config.AgentNameOrchestrator, orchTrace["agent_name"])
+	assert.Equal(t, orchAgent, orchTrace["agent_name"])
 
 	subAgents := orchTrace["sub_agents"].([]interface{})
 	require.Len(t, subAgents, 2, "orchestrator should have 2 nested sub-agents")

--- a/test/e2e/testdata/configs/builtin-orchestrator/tarsy.yaml
+++ b/test/e2e/testdata/configs/builtin-orchestrator/tarsy.yaml
@@ -14,12 +14,14 @@ mcp_servers:
       command: mock
 
 agents:
+  InvestigationOrchestrator:
+    description: "Investigation orchestrator that dispatches specialized sub-agents"
+    custom_instructions: "You are InvestigationOrchestrator, you investigate alerts by dispatching sub-agents."
   LogAnalyzer:
     description: "Analyzes logs for error patterns and anomalies"
     mcp_servers: [test-mcp]
     max_iterations: 2
     custom_instructions: "You are LogAnalyzer, you analyze logs to find error patterns."
-  # Orchestrator: built-in agent — no override needed
   # GeneralWorker: built-in agent — no override needed
 
 agent_chains:
@@ -29,7 +31,7 @@ agent_chains:
     stages:
       - name: orchestrate
         agents:
-          - name: Orchestrator
+          - name: InvestigationOrchestrator
             sub_agents:
               - name: LogAnalyzer
                 max_iterations: 3

--- a/test/e2e/testdata/configs/orchestrator-cancel/tarsy.yaml
+++ b/test/e2e/testdata/configs/orchestrator-cancel/tarsy.yaml
@@ -15,7 +15,6 @@ mcp_servers:
 
 agents:
   SREOrchestrator:
-    type: orchestrator
     description: "SRE investigation orchestrator"
     max_iterations: 10
     custom_instructions: "You are SREOrchestrator, you investigate alerts by dispatching specialized sub-agents."

--- a/test/e2e/testdata/configs/orchestrator/tarsy.yaml
+++ b/test/e2e/testdata/configs/orchestrator/tarsy.yaml
@@ -15,7 +15,6 @@ mcp_servers:
 
 agents:
   SREOrchestrator:
-    type: orchestrator
     description: "SRE investigation orchestrator"
     custom_instructions: "You are SREOrchestrator, you investigate alerts by dispatching specialized sub-agents."
     orchestrator:

--- a/test/e2e/testdata/configs/skills-orchestrator/tarsy.yaml
+++ b/test/e2e/testdata/configs/skills-orchestrator/tarsy.yaml
@@ -15,7 +15,6 @@ mcp_servers:
 
 agents:
   SREOrchestrator:
-    type: orchestrator
     description: "SRE investigation orchestrator"
     custom_instructions: "You are SREOrchestrator, you investigate alerts by dispatching specialized sub-agents."
     orchestrator:


### PR DESCRIPTION
- Remove AgentTypeOrchestrator enum and built-in Orchestrator agent
- Trigger orchestration by non-empty filtered sub-agent catalog at runtime
- Refactor orchestrator prompt from separate dispatch to injection layer (InjectOrchestratorSections appends to existing system prompt)
- Relax validator: allow orchestrator config on any agent type, permit any agent as a sub-agent
- Update all configs, E2E test data, and 16 test files
- Add circularity prevention test (sub-agents never get catalog/collector)
- Add tests for chat+orchestration, empty catalog, type-agnostic registry


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Built-in "Orchestrator" agent removed — orchestrators are now defined via config (implicit when sub-agents present).

* **Configuration Changes**
  * Orchestration is implicit: agents with sub_agents trigger orchestration; remove type: orchestrator.
  * Per-orchestrator guardrails: max_concurrent_agents, agent_timeout, max_budget.
  * Sub-agent refs may override MCP servers; referenced sub-agents must include a non-empty description.

* **New Features**
  * Stage-level skill overrides are additive to agent skills.

* **Documentation**
  * Added migration and design guidance for implicit orchestrators and stage-level skill overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->