### PR TITLE
Fix clearing action taken and investigation feedback in reviews

### DIFF
--- a/pkg/services/session_service_review.go
+++ b/pkg/services/session_service_review.go
@@ -194,10 +194,18 @@ func (s *SessionService) updateSingleReview(sessionID string, req models.UpdateR
 			update = update.SetQualityRating(alertsession.QualityRating(*req.QualityRating))
 		}
 		if req.ActionTaken != nil {
-			update = update.SetActionTaken(*req.ActionTaken)
+			if *req.ActionTaken == "" {
+				update = update.ClearActionTaken()
+			} else {
+				update = update.SetActionTaken(*req.ActionTaken)
+			}
 		}
 		if req.InvestigationFeedback != nil {
-			update = update.SetInvestigationFeedback(*req.InvestigationFeedback)
+			if *req.InvestigationFeedback == "" {
+				update = update.ClearInvestigationFeedback()
+			} else {
+				update = update.SetInvestigationFeedback(*req.InvestigationFeedback)
+			}
 		}
 		affected, err := update.Save(writeCtx)
 		if err != nil {
@@ -216,10 +224,14 @@ func (s *SessionService) updateSingleReview(sessionID string, req models.UpdateR
 		snapshotActionTaken := req.ActionTaken
 		if snapshotActionTaken == nil {
 			snapshotActionTaken = current.ActionTaken
+		} else if *snapshotActionTaken == "" {
+			snapshotActionTaken = nil
 		}
 		snapshotFeedback := req.InvestigationFeedback
 		if snapshotFeedback == nil {
 			snapshotFeedback = current.InvestigationFeedback
+		} else if *snapshotFeedback == "" {
+			snapshotFeedback = nil
 		}
 
 		if err := s.insertActivity(writeCtx, tx, sessionID, req.Actor,

--- a/pkg/services/session_service_review_test.go
+++ b/pkg/services/session_service_review_test.go
@@ -414,6 +414,35 @@ func TestSessionService_UpdateReviewStatus(t *testing.T) {
 		assert.Equal(t, "Original feedback", *last.InvestigationFeedback)
 	})
 
+	t.Run("update_feedback clears action_taken and investigation_feedback with empty string", func(t *testing.T) {
+		id := seedReviewSession(t, service, "reviewed", "john@test.com")
+
+		ctx := context.Background()
+		require.NoError(t, service.client.AlertSession.UpdateOneID(id).
+			SetActionTaken("Original action").
+			SetInvestigationFeedback("Original feedback").
+			Exec(ctx))
+
+		emptyStr := ""
+		rating := "accurate"
+		sess := doReview(t, service, id, models.UpdateReviewRequest{
+			Action:                "update_feedback",
+			Actor:                 "john@test.com",
+			QualityRating:         &rating,
+			ActionTaken:           &emptyStr,
+			InvestigationFeedback: &emptyStr,
+		})
+		assert.Nil(t, sess.ActionTaken, "empty string should clear action_taken to nil")
+		assert.Nil(t, sess.InvestigationFeedback, "empty string should clear investigation_feedback to nil")
+
+		activities, err := service.GetReviewActivity(ctx, id)
+		require.NoError(t, err)
+		last := activities[len(activities)-1]
+		assert.Equal(t, sessionreviewactivity.ActionUpdateFeedback, last.Action)
+		assert.Nil(t, last.Note, "activity snapshot should be nil for cleared action_taken")
+		assert.Nil(t, last.InvestigationFeedback, "activity snapshot should be nil for cleared investigation_feedback")
+	})
+
 	t.Run("update_feedback with invalid quality_rating returns error", func(t *testing.T) {
 		id := seedReviewSession(t, service, "reviewed", "john@test.com")
 		badRating := "perfect"

--- a/web/dashboard/src/components/dashboard/DashboardView.tsx
+++ b/web/dashboard/src/components/dashboard/DashboardView.tsx
@@ -714,8 +714,8 @@ export function DashboardView() {
         session_ids: [sessionId],
         action: REVIEW_ACTION.UPDATE_FEEDBACK,
         quality_rating: qualityRating || undefined,
-        action_taken: actionTaken || undefined,
-        investigation_feedback: investigationFeedback || undefined,
+        action_taken: actionTaken,
+        investigation_feedback: investigationFeedback,
       });
       checkReviewResults(resp);
       fetchAllTriageGroups();
@@ -784,8 +784,8 @@ export function DashboardView() {
         session_ids: [targetSessionId],
         action: REVIEW_ACTION.UPDATE_FEEDBACK,
         quality_rating: qualityRating || undefined,
-        action_taken: actionTaken || undefined,
-        investigation_feedback: investigationFeedback || undefined,
+        action_taken: actionTaken,
+        investigation_feedback: investigationFeedback,
       });
       checkReviewResults(resp);
       setReviewTarget(null);

--- a/web/dashboard/src/pages/SessionDetailPage.tsx
+++ b/web/dashboard/src/pages/SessionDetailPage.tsx
@@ -1418,8 +1418,8 @@ export function SessionDetailPage() {
         session_ids: [id],
         action: REVIEW_ACTION.UPDATE_FEEDBACK,
         quality_rating: qualityRating || undefined,
-        action_taken: actionTaken || undefined,
-        investigation_feedback: investigationFeedback || undefined,
+        action_taken: actionTaken,
+        investigation_feedback: investigationFeedback,
       });
       if (resp.results[0]?.success) {
         setReviewModalMode(null);


### PR DESCRIPTION
- Dashboard converted empty strings to undefined via `|| undefined`, dropping the field from JSON so the backend never saw the clear intent
- Send empty strings through so the Go backend receives a non-nil pointer
- Backend now calls ClearActionTaken/ClearInvestigationFeedback when it receives an empty string, setting the DB column to NULL
- Activity log snapshots correctly record nil for cleared fields
- Add unit test covering the clear-via-empty-string path


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed feedback update behavior to properly clear "Action Taken" and "Investigation Feedback" fields when submitted as empty values, ensuring feedback changes are correctly recorded and previous data is appropriately cleared.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->