### PR TITLE
Update Gemini 3.1 Flash Lite to GA model name

### DIFF
--- a/pkg/config/builtin.go
+++ b/pkg/config/builtin.go
@@ -236,7 +236,7 @@ func initBuiltinLLMProviders() map[string]LLMProviderConfig {
 		},
 		"gemini-3.1-flash": {
 			Type:                LLMProviderTypeGoogle,
-			Model:               "gemini-3.1-flash-lite-preview",
+			Model:               "gemini-3.1-flash-lite",
 			APIKeyEnv:           "GOOGLE_API_KEY",
 			MaxToolResultTokens: 950000, // Conservative for 1M context
 			NativeTools:         geminiNativeTools(),


### PR DESCRIPTION
- Remove -preview suffix from gemini-3.1-flash-lite model identifier

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Gemini model provider to use the stable version instead of the preview variant for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->