### PR TITLE
Improve scoring resilience during rolling updates

### DIFF
--- a/cmd/tarsy/main.go
+++ b/cmd/tarsy/main.go
@@ -422,14 +422,17 @@ func main() {
 	}
 
 	// Then drain scoring executor (scoring goroutines spawned by completed sessions).
-	scoringShutdownCtx, scoringCancel := context.WithTimeout(ctx, 30*time.Second)
-	defer scoringCancel()
-
+	// Stop() waits up to ScoringShutdownTimeout for natural completion before
+	// force-cancelling remaining contexts.
 	scoringDone := make(chan struct{})
 	go func() {
-		scoringExecutor.Stop()
+		scoringExecutor.Stop(cfg.Queue.ScoringShutdownTimeout)
 		close(scoringDone)
 	}()
+
+	// Outer budget: grace period + 15s cleanup buffer for post-cancel drain.
+	scoringShutdownCtx, scoringCancel := context.WithTimeout(ctx, cfg.Queue.ScoringShutdownTimeout+15*time.Second)
+	defer scoringCancel()
 
 	select {
 	case <-scoringDone:

--- a/deploy/config/tarsy.yaml.example
+++ b/deploy/config/tarsy.yaml.example
@@ -38,6 +38,10 @@ queue:
   # Kubernetes terminationGracePeriodSeconds must be >= this value
   graceful_shutdown_timeout: 40m
 
+  # How long to wait for in-flight scoring evaluations to complete naturally
+  # during shutdown before cancelling them.
+  scoring_shutdown_timeout: 3m
+
   # Orphan detection: scans for stuck in_progress sessions with stale heartbeats
   orphan_detection_interval: 5m
   orphan_threshold: 5m

--- a/deploy/kustomize/base/tarsy-deployment.yaml
+++ b/deploy/kustomize/base/tarsy-deployment.yaml
@@ -18,8 +18,8 @@ spec:
       labels:
         component: tarsy
     spec:
-      # session_timeout (2400s) + 60s buffer (15s preStop + 45s cleanup)
-      terminationGracePeriodSeconds: 2460
+      # session_timeout (2400s) + scoring_shutdown_timeout (180s) + http_shutdown (5s) + buffer (15s)
+      terminationGracePeriodSeconds: 2600
       serviceAccountName: tarsy
       containers:
 
@@ -112,6 +112,10 @@ spec:
         - name: llm-service
           image: tarsy-llm:latest
           imagePullPolicy: Always
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sleep", "200"]
           ports:
             - containerPort: 50051
           env:

--- a/pkg/config/queue.go
+++ b/pkg/config/queue.go
@@ -27,6 +27,10 @@ type QueueConfig struct {
 	// to complete during shutdown. Should match SessionTimeout.
 	GracefulShutdownTimeout time.Duration `yaml:"graceful_shutdown_timeout"`
 
+	// ScoringShutdownTimeout is how long to wait for in-flight scoring
+	// evaluations to complete naturally during shutdown before cancelling them.
+	ScoringShutdownTimeout time.Duration `yaml:"scoring_shutdown_timeout"`
+
 	// OrphanDetectionInterval is how often to scan for orphaned sessions.
 	OrphanDetectionInterval time.Duration `yaml:"orphan_detection_interval"`
 
@@ -48,6 +52,7 @@ func DefaultQueueConfig() *QueueConfig {
 		PollIntervalJitter:      500 * time.Millisecond,
 		SessionTimeout:          40 * time.Minute,
 		GracefulShutdownTimeout: 40 * time.Minute,
+		ScoringShutdownTimeout:  3 * time.Minute,
 		OrphanDetectionInterval: 5 * time.Minute,
 		OrphanThreshold:         5 * time.Minute,
 		HeartbeatInterval:       30 * time.Second,

--- a/pkg/config/queue_test.go
+++ b/pkg/config/queue_test.go
@@ -17,6 +17,7 @@ func TestDefaultQueueConfig(t *testing.T) {
 	assert.Equal(t, 500*time.Millisecond, cfg.PollIntervalJitter)
 	assert.Equal(t, 40*time.Minute, cfg.SessionTimeout)
 	assert.Equal(t, 40*time.Minute, cfg.GracefulShutdownTimeout)
+	assert.Equal(t, 3*time.Minute, cfg.ScoringShutdownTimeout)
 	assert.Equal(t, 5*time.Minute, cfg.OrphanDetectionInterval)
 	assert.Equal(t, 5*time.Minute, cfg.OrphanThreshold)
 	assert.Equal(t, 30*time.Second, cfg.HeartbeatInterval)
@@ -109,6 +110,25 @@ func TestValidateQueue(t *testing.T) {
 			}(),
 			wantErr: true,
 			errMsg:  "graceful_shutdown_timeout must be positive",
+		},
+		{
+			name: "scoring shutdown timeout negative",
+			queue: func() *QueueConfig {
+				q := DefaultQueueConfig()
+				q.ScoringShutdownTimeout = -1 * time.Second
+				return q
+			}(),
+			wantErr: true,
+			errMsg:  "scoring_shutdown_timeout must be non-negative",
+		},
+		{
+			name: "scoring shutdown timeout zero is valid",
+			queue: func() *QueueConfig {
+				q := DefaultQueueConfig()
+				q.ScoringShutdownTimeout = 0
+				return q
+			}(),
+			wantErr: false,
 		},
 		{
 			name: "orphan detection interval zero",

--- a/pkg/config/validator.go
+++ b/pkg/config/validator.go
@@ -88,6 +88,9 @@ func (v *Validator) validateQueue() error {
 	if q.GracefulShutdownTimeout <= 0 {
 		return fmt.Errorf("graceful_shutdown_timeout must be positive, got %v", q.GracefulShutdownTimeout)
 	}
+	if q.ScoringShutdownTimeout < 0 {
+		return fmt.Errorf("scoring_shutdown_timeout must be non-negative, got %v", q.ScoringShutdownTimeout)
+	}
 	if q.OrphanDetectionInterval <= 0 {
 		return fmt.Errorf("orphan_detection_interval must be positive, got %v", q.OrphanDetectionInterval)
 	}

--- a/pkg/queue/scoring_executor.go
+++ b/pkg/queue/scoring_executor.go
@@ -561,22 +561,41 @@ func (e *ScoringExecutor) removeCancel(scoreID string) {
 	e.mu.Unlock()
 }
 
-// Stop marks the executor as stopped, cancels in-flight scoring contexts
-// and pending cleanup timers, then waits for active goroutines to drain.
-func (e *ScoringExecutor) Stop() {
+// Stop marks the executor as stopped, waits up to gracePeriod for in-flight
+// scoring to complete naturally, then cancels any remaining contexts and
+// waits for goroutines to drain.
+func (e *ScoringExecutor) Stop(gracePeriod time.Duration) {
 	e.mu.Lock()
 	e.stopped = true
-	for _, cancel := range e.activeCancels {
-		cancel()
-	}
-	e.activeCancels = nil
 	for _, t := range e.cleanupTimers {
 		t.Stop()
 	}
 	e.cleanupTimers = nil
 	e.mu.Unlock()
 
-	e.wg.Wait()
+	// Wait for in-flight scoring to finish naturally within the grace period.
+	done := make(chan struct{})
+	go func() {
+		e.wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		return
+	case <-time.After(gracePeriod):
+		slog.Warn("Scoring grace period expired, cancelling in-flight scoring")
+	}
+
+	// Grace period exceeded — force-cancel remaining contexts.
+	e.mu.Lock()
+	for _, cancel := range e.activeCancels {
+		cancel()
+	}
+	e.activeCancels = nil
+	e.mu.Unlock()
+
+	<-done
 }
 
 // ────────────────────────────────────────────────────────────

--- a/pkg/queue/scoring_executor_integration_test.go
+++ b/pkg/queue/scoring_executor_integration_test.go
@@ -245,7 +245,7 @@ func TestScoringExecutor_SubmitScoring_ReturnsScoreID(t *testing.T) {
 		return getErr == nil && s.Status != sessionscore.StatusInProgress && s.Status != sessionscore.StatusPending
 	}, 5*time.Second, 50*time.Millisecond, "score should reach terminal state")
 
-	executor.Stop()
+	executor.Stop(0)
 
 	assert.True(t, pub.hasStageStatus("Reflection", "started"), "expected scoring stage started event")
 }
@@ -264,7 +264,7 @@ func TestScoringExecutor_ScoreSessionAsync_SilentWhenScoringDisabled(t *testing.
 	session := createScoringTestSession(t, entClient, chainID, alertsession.StatusCompleted)
 
 	executor.ScoreSessionAsync(session.ID, "auto", true)
-	executor.Stop()
+	executor.Stop(0)
 
 	// Verify no LLM calls were made
 	llm.mu.Lock()
@@ -305,7 +305,7 @@ func TestScoringExecutor_GracefulShutdown(t *testing.T) {
 	// Stop() also cancels in-flight contexts, so the blocked LLM returns.
 	stopped := make(chan struct{})
 	go func() {
-		executor.Stop()
+		executor.Stop(0)
 		close(stopped)
 	}()
 

--- a/pkg/queue/scoring_executor_test.go
+++ b/pkg/queue/scoring_executor_test.go
@@ -3,6 +3,7 @@ package queue
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/codeready-toolchain/tarsy/ent/alertsession"
 	"github.com/codeready-toolchain/tarsy/pkg/agent"
@@ -37,14 +38,68 @@ func TestIsTerminalStatus(t *testing.T) {
 func TestScoringExecutor_StopIdempotent(t *testing.T) {
 	exec := &ScoringExecutor{}
 
-	assert.NotPanics(t, func() { exec.Stop() })
-	assert.NotPanics(t, func() { exec.Stop() })
+	assert.NotPanics(t, func() { exec.Stop(0) })
+	assert.NotPanics(t, func() { exec.Stop(0) })
 	assert.True(t, exec.stopped)
+}
+
+func TestScoringExecutor_StopWaitsBeforeCancelling(t *testing.T) {
+	exec := &ScoringExecutor{
+		activeCancels: make(map[string]context.CancelFunc),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Simulate an in-flight goroutine that completes quickly.
+	exec.wg.Add(1)
+	exec.trackCancel("score-1", cancel)
+	go func() {
+		defer exec.wg.Done()
+		time.Sleep(50 * time.Millisecond)
+	}()
+
+	start := time.Now()
+	exec.Stop(5 * time.Second)
+	elapsed := time.Since(start)
+
+	// Should have completed well within the grace period (goroutine takes ~50ms).
+	assert.Less(t, elapsed, 1*time.Second)
+	// Context should NOT have been cancelled (goroutine finished naturally).
+	assert.NoError(t, ctx.Err())
+}
+
+func TestScoringExecutor_StopCancelsAfterGracePeriod(t *testing.T) {
+	exec := &ScoringExecutor{
+		activeCancels: make(map[string]context.CancelFunc),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Simulate an in-flight goroutine that blocks until cancelled.
+	exec.wg.Add(1)
+	exec.trackCancel("score-1", cancel)
+	go func() {
+		defer exec.wg.Done()
+		<-ctx.Done()
+	}()
+
+	gracePeriod := 100 * time.Millisecond
+	start := time.Now()
+	exec.Stop(gracePeriod)
+	elapsed := time.Since(start)
+
+	// Should have waited approximately the grace period before cancelling.
+	assert.GreaterOrEqual(t, elapsed, gracePeriod)
+	assert.Less(t, elapsed, 2*time.Second)
+	// Context should have been cancelled by Stop().
+	assert.ErrorIs(t, ctx.Err(), context.Canceled)
 }
 
 func TestScoringExecutor_ScoreSessionAsyncRejectedWhenStopped(t *testing.T) {
 	exec := &ScoringExecutor{}
-	exec.Stop()
+	exec.Stop(0)
 
 	assert.NotPanics(t, func() {
 		exec.ScoreSessionAsync("session-123", "auto", true)
@@ -53,7 +108,7 @@ func TestScoringExecutor_ScoreSessionAsyncRejectedWhenStopped(t *testing.T) {
 
 func TestScoringExecutor_SubmitScoringRejectedWhenStopped(t *testing.T) {
 	exec := &ScoringExecutor{}
-	exec.Stop()
+	exec.Stop(0)
 
 	_, err := exec.SubmitScoring(t.Context(), "session-123", "user", false)
 	assert.ErrorIs(t, err, ErrShuttingDown)
@@ -141,7 +196,7 @@ func (m *mockScoreEventPublisher) PublishSessionScoreUpdated(_ context.Context, 
 
 func TestScoringExecutor_RunFeedbackReflectorAsyncRejectedWhenStopped(t *testing.T) {
 	exec := &ScoringExecutor{}
-	exec.Stop()
+	exec.Stop(0)
 
 	assert.NotPanics(t, func() {
 		exec.RunFeedbackReflectorAsync("session-123", "Great investigation", "accurate")
@@ -158,7 +213,7 @@ func TestScoringExecutor_RunFeedbackReflectorAsyncNilMemoryService(t *testing.T)
 	})
 
 	assert.NotPanics(t, func() {
-		exec.Stop()
+		exec.Stop(0)
 	})
 }
 

--- a/test/e2e/harness.go
+++ b/test/e2e/harness.go
@@ -309,7 +309,7 @@ func NewTestApp(t *testing.T, opts ...TestAppOption) *TestApp {
 		chatExecutor.Stop()
 		workerPool.Stop()
 		if scoringExecutor != nil {
-			scoringExecutor.Stop()
+			scoringExecutor.Stop(0)
 		}
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()

--- a/test/e2e/scoring_test.go
+++ b/test/e2e/scoring_test.go
@@ -446,7 +446,7 @@ func TestE2E_Scoring_Disabled_NoAutoTrigger(t *testing.T) {
 	// ScoreSessionAsync before completing the session; Stop() waits for the
 	// goroutine to finish (it returns immediately on ErrScoringDisabled).
 	// Stop() is idempotent, so the cleanup teardown calling it again is fine.
-	app.ScoringExecutor.Stop()
+	app.ScoringExecutor.Stop(0)
 
 	scoringStages, err := app.EntClient.Stage.Query().
 		Where(stage.SessionIDEQ(sessionID), stage.StageTypeEQ(stage.StageTypeScoring)).

--- a/web/dashboard/src/components/common/ScoreBadge.tsx
+++ b/web/dashboard/src/components/common/ScoreBadge.tsx
@@ -15,7 +15,7 @@
  */
 
 import { Box, Chip, CircularProgress, Tooltip, Typography, alpha } from '@mui/material';
-import { Error as ErrorIcon } from '@mui/icons-material';
+import { Error as ErrorIcon, Refresh as RefreshIcon } from '@mui/icons-material';
 import {
   EXECUTION_STATUS,
   SESSION_STATUS,
@@ -174,24 +174,31 @@ export function ScoreBadge({ score, scoringStatus, size = 'small', variant = 'ch
 
   // --- Scoring failed / timed out ---
   if (scoringStatus != null && FAILED_EXECUTION_STATUSES.has(scoringStatus)) {
+    const actionable = !!onClick;
+    const icon = actionable
+      ? <RefreshIcon sx={{ fontSize: variant === 'pill' ? 14 : 16 }} />
+      : <ErrorIcon sx={{ fontSize: variant === 'pill' ? 14 : 16 }} />;
+    const label = actionable ? 'Re-score' : (variant === 'pill' ? 'score failed' : 'Score Failed');
+    const tooltip = actionable ? 'Click to re-score' : 'Scoring failed';
+
     if (variant === 'pill') {
       return (
         <PillBadge
           color="error"
-          icon={<ErrorIcon sx={{ fontSize: 14 }} />}
+          icon={icon}
           value=""
-          label="score failed"
-          tooltip="Scoring failed"
+          label={label}
+          tooltip={tooltip}
           onClick={onClick}
         />
       );
     }
 
     return (
-      <Tooltip title="Scoring failed">
+      <Tooltip title={tooltip}>
         <Chip
-          icon={<ErrorIcon sx={{ fontSize: 16 }} />}
-          label="Score Failed"
+          icon={icon}
+          label={label}
           size={size}
           color="error"
           variant="outlined"

--- a/web/dashboard/src/constants/sessionStatus.ts
+++ b/web/dashboard/src/constants/sessionStatus.ts
@@ -53,13 +53,16 @@ export const TERMINAL_EXECUTION_STATUSES = new Set<string>([
   EXECUTION_STATUS.TIMED_OUT,
 ]);
 
-/** Failed-family statuses (for error display logic). */
+/** Failed-family statuses (for error display logic). Includes cancelled
+ *  so that scoring evaluations cancelled by shutdown also show the error badge. */
 export const FAILED_EXECUTION_STATUSES = new Set<string>([
   EXECUTION_STATUS.FAILED,
   EXECUTION_STATUS.TIMED_OUT,
+  EXECUTION_STATUS.CANCELLED,
 ]);
 
-/** Cancelled statuses (terminal but not an error — user-initiated). */
+/** Cancelled statuses (terminal but not an error — user-initiated).
+ *  Used by timeline components for distinct cancelled-state rendering. */
 export const CANCELLED_EXECUTION_STATUSES = new Set<string>([
   EXECUTION_STATUS.CANCELLED,
 ]);

--- a/web/dashboard/src/pages/ScoringPage.tsx
+++ b/web/dashboard/src/pages/ScoringPage.tsx
@@ -286,7 +286,7 @@ export function ScoringPage() {
                       </Typography>
                       {score ? (
                         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mt: 0.5, flexWrap: 'wrap' }}>
-                          <ScoreBadge score={score.total_score} scoringStatus={score.status} onClick={handleRescoreClick} />
+                          <ScoreBadge score={score.total_score} scoringStatus={score.status} onClick={rescoring ? undefined : handleRescoreClick} />
                           <Typography variant="body2" color="text.secondary">
                             Triggered by: {score.score_triggered_by}
                           </Typography>

--- a/web/dashboard/src/pages/ScoringPage.tsx
+++ b/web/dashboard/src/pages/ScoringPage.tsx
@@ -27,7 +27,6 @@ import {
 import { alpha } from '@mui/material/styles';
 import {
   ArrowBack,
-  Refresh,
   GradingOutlined,
   BuildOutlined,
 } from '@mui/icons-material';
@@ -287,7 +286,7 @@ export function ScoringPage() {
                       </Typography>
                       {score ? (
                         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mt: 0.5, flexWrap: 'wrap' }}>
-                          <ScoreBadge score={score.total_score} scoringStatus={score.status} />
+                          <ScoreBadge score={score.total_score} scoringStatus={score.status} onClick={handleRescoreClick} />
                           <Typography variant="body2" color="text.secondary">
                             Triggered by: {score.score_triggered_by}
                           </Typography>
@@ -315,16 +314,6 @@ export function ScoringPage() {
                     </Box>
                   </Box>
 
-                  {/* Re-score button */}
-                  <Button
-                    variant="outlined"
-                    startIcon={rescoring ? <CircularProgress size={16} color="inherit" /> : <Refresh />}
-                    onClick={handleRescoreClick}
-                    disabled={rescoring}
-                    sx={{ textTransform: 'none', fontWeight: 500 }}
-                  >
-                    {rescoring ? 'Scoring...' : 'Re-score'}
-                  </Button>
                 </Box>
 
                 {rescoreError && (


### PR DESCRIPTION
- Change ScoringExecutor.Stop() to wait for in-flight scoring to complete naturally before force-cancelling (grace period pattern)
- Add configurable ScoringShutdownTimeout (default 3m) to QueueConfig
- Update K8s terminationGracePeriodSeconds to account for scoring drain
- Add preStop sleep to LLM service container so it outlives the Go backend's scoring calls during shutdown
- Make ScoreBadge show actionable "Re-score" button when scoring fails and onClick is provided (replaces separate Re-score button)
- Add cancelled to FAILED_EXECUTION_STATUSES so shutdown-cancelled scores render the error/re-score badge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Score badges are now clickable to trigger re-score (replaces the separate re-score button) and show an action-specific icon/tooltip.

* **Improvements**
  * Scoring shutdown is configurable (default 3 minutes) with added drain buffer to allow in-flight evaluations to finish.
  * Deployment termination window extended to allow longer, smoother shutdowns for services.

* **Bug Fixes**
  * Cancelled scoring evaluations now render as failed in the dashboard.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->