### PR TITLE
Add Gemini 3.5 Flash to built-in LLM providers

### DIFF
--- a/pkg/config/builtin.go
+++ b/pkg/config/builtin.go
@@ -241,6 +241,13 @@ func initBuiltinLLMProviders() map[string]LLMProviderConfig {
 			MaxToolResultTokens: 950000, // Conservative for 1M context
 			NativeTools:         geminiNativeTools(),
 		},
+		"gemini-3.5-flash": {
+			Type:                LLMProviderTypeGoogle,
+			Model:               "gemini-3.5-flash",
+			APIKeyEnv:           "GOOGLE_API_KEY",
+			MaxToolResultTokens: 950000, // Conservative for 1M context
+			NativeTools:         geminiNativeTools(),
+		},
 		"gemini-2.5-flash": {
 			Type:                LLMProviderTypeGoogle,
 			Model:               "gemini-2.5-flash",

--- a/pkg/config/builtin_test.go
+++ b/pkg/config/builtin_test.go
@@ -216,7 +216,7 @@ func TestBuiltinImageProviderDisablesURLContext(t *testing.T) {
 	}
 
 	nonImageProviders := []string{
-		"google-default", "gemini-3-flash", "gemini-3.1-pro", "gemini-3.1-flash", "gemini-2.5-flash", "gemini-2.5-pro",
+		"google-default", "gemini-3.5-flash", "gemini-3-flash", "gemini-3.1-pro", "gemini-3.1-flash", "gemini-2.5-flash", "gemini-2.5-pro",
 	}
 	for _, name := range nonImageProviders {
 		t.Run(name+" has url_context", func(t *testing.T) {
@@ -302,6 +302,13 @@ func TestBuiltinLLMProviders(t *testing.T) {
 		{
 			name:          "gemini-3.1-flash",
 			providerID:    "gemini-3.1-flash",
+			wantType:      LLMProviderTypeGoogle,
+			wantMinTokens: 900000,
+			checkAPIKey:   true,
+		},
+		{
+			name:          "gemini-3.5-flash",
+			providerID:    "gemini-3.5-flash",
 			wantType:      LLMProviderTypeGoogle,
 			wantMinTokens: 900000,
 			checkAPIKey:   true,


### PR DESCRIPTION
- Add gemini-3.5-flash provider (stable GA model, released May 2026)
- Update tests for provider list and url_context validation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Gemini 3.5 Flash as a built-in LLM provider with Google backend integration.

* **Tests**
  * Extended test coverage to validate the new provider configuration, API key requirements, and native tool settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->