### PR TITLE
Switch google-default provider to Gemini 3.5 Flash

### DIFF
--- a/pkg/config/builtin.go
+++ b/pkg/config/builtin.go
@@ -208,7 +208,7 @@ func initBuiltinLLMProviders() map[string]LLMProviderConfig {
 		// --- Google Gemini ---
 		"google-default": {
 			Type:                LLMProviderTypeGoogle,
-			Model:               "gemini-3-flash-preview",
+			Model:               "gemini-3.5-flash",
 			APIKeyEnv:           "GOOGLE_API_KEY",
 			MaxToolResultTokens: 950000, // Conservative for 1M context
 			NativeTools:         geminiNativeTools(),


### PR DESCRIPTION
- Update built-in google-default model from gemini-3-flash-preview to gemini-3.5-flash (GA, released May 2026)
- 3.5 Flash outperforms 3.1 Pro on agentic benchmarks (MCP Atlas 83.6% vs 78.2%, GDPval-AA 1656 vs 1314 Elo) at 25% lower cost

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default Google AI model configuration to use a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->