### PR TITLE
Add native tool fallback safety guard

### DIFF
--- a/.cursor/commands/verify-design.md
+++ b/.cursor/commands/verify-design.md
@@ -1,6 +1,8 @@
 # Verify Design Document
 
-Carefully and systematically review the provided design document to verify it is **consistent**, **aligned with the current codebase**, and **free of meaningful gaps**.
+Carefully and systematically review the provided design document to verify it is
+**consistent**, **aligned with the current codebase**, and **free of meaningful
+gaps**. **Fix everything you can, then ask about the rest.**
 
 ---
 
@@ -8,9 +10,12 @@ Carefully and systematically review the provided design document to verify it is
 
 Build a thorough understanding of the relevant parts of the system:
 
-- Read the design document fully — understand its goals, architecture, concepts, and implementation plan
-- If a companion questions doc exists (e.g. `{name}-questions.md`), read it too — check that resolved decisions are reflected accurately in the design
-- Explore the codebase: look at the packages, types, interfaces, and patterns that the design touches or depends on
+- Read the design document fully — understand its goals, architecture, concepts,
+  and implementation plan
+- If a companion questions doc exists (e.g. `{name}-questions.md`), read it too
+  — check that resolved decisions are reflected accurately in the design
+- Explore the codebase: look at the packages, types, interfaces, and patterns
+  that the design touches or depends on
 - Read existing documentation in `docs/` that relates to the same area
 
 ---
@@ -18,18 +23,21 @@ Build a thorough understanding of the relevant parts of the system:
 ## What to verify
 
 ### 1. Internal consistency
+
 - Do all sections of the document agree with each other?
 - Are terms, names, and concepts used consistently throughout?
 - Do examples and diagrams match the described architecture?
 - If there are phases or steps, do they form a coherent sequence?
 
 ### 2. Alignment with the codebase
+
 - Do referenced types, interfaces, packages, and files actually exist?
 - Does the design correctly describe current behavior where it references it?
 - Are proposed changes compatible with existing patterns and conventions?
 - Are there recent code changes that the design doesn't account for?
 
 ### 3. Gaps and omissions
+
 - Are there edge cases or failure modes not addressed?
 - Are migration or backward-compatibility concerns covered where needed?
 - Does the implementation plan have enough detail to act on?
@@ -37,18 +45,14 @@ Build a thorough understanding of the relevant parts of the system:
 - Are there dependencies between components that aren't acknowledged?
 
 ### 4. Open questions
+
 - Are all open questions clearly marked?
 - Are there unmarked decisions that should be questions?
 - Have any "resolved" questions been left inconsistent with the design text?
 
 ---
 
-## Output
+## Act on findings
 
-Present your findings as a structured review:
-
-1. **Summary** — one paragraph overall assessment
-2. **Issues** — numbered list, each with severity (high / medium / low), location in the document, and a clear description of the problem
-3. **Suggestions** — optional improvements that aren't strictly issues
-
-Do **not** modify the design document. Report findings only.
+If the fix is obvious, apply it directly. If you need user input to resolve
+something, ask. Report what you fixed and what you need input on.

--- a/docs/adr/0017-native-tool-fallback-safety.md
+++ b/docs/adr/0017-native-tool-fallback-safety.md
@@ -1,0 +1,89 @@
+# ADR-0017: Native Tool Fallback Safety
+
+**Status:** Implemented  
+**Date:** 2026-05-27  
+**Supersedes:** Extends ADR-0003 (LLM Provider Fallback)
+
+## Overview
+
+When an LLM provider fails during agent execution, TARSy's fallback mechanism (ADR-0003) switches to alternative providers. However, certain agents — notably `WebResearcher` and `CodeExecutor` — require the `google-native` backend because they depend on native Gemini tools (`google_search`, `url_context`, `code_execution`) that only work through the Google SDK.
+
+Previously, the fallback mechanism would switch these agents to incompatible providers (e.g. LangChain/Claude), logging a warning but proceeding anyway. This silently stripped the agent's core capabilities, causing it to "run" without its essential tools — a worse outcome than failing fast.
+
+## Design Principles
+
+1. **Fail safely over silently degrading.** An agent that loses its core tools should not continue pretending to work. Skipping an incompatible fallback entry is better than switching to it.
+2. **Minimal change, maximum safety.** The fix is a small guard in the existing fallback path, not a rearchitecture.
+3. **Configuration remains simple.** No new config surface. The system infers compatibility from existing metadata (backend + native tools).
+4. **Startup validation catches obvious misconfigs.** If an operator configures only incompatible fallback entries for a chain that runs native-tool agents, warn at startup.
+
+## Architecture
+
+### Fallback Candidate Selection
+
+```
+tryFallback() called
+  → shouldFallback() returns true (error threshold met)
+  → Loop over ResolvedFallbackProviders from current index:
+      → Skip if same provider name as current
+      → Skip if entry would drop required native tools (log at Info)
+  → If no compatible entries remain → return false (no fallback available)
+  → Switch to first compatible entry
+```
+
+Both skip conditions (same-provider and incompatible-backend) are checked in the same loop. Skipped-incompatible entries are NOT added to `FallbackState.AttemptedProviders` since they were never actually attempted.
+
+The skip is unconditional (hard guard). An agent without its native tools is broken, not degraded. No config option to override.
+
+### Determining "Required Native Tools"
+
+The guard distinguishes between:
+- **Agent requires native tools** — agent definition declares `NativeTools` with at least one enabled tool (e.g. WebResearcher, CodeExecutor). Losing them breaks the agent.
+- **Provider happens to support native tools** — agent uses a Gemini provider but doesn't declare `NativeTools` in its definition (e.g. VMRemediationAgent, orchestrators running on `gemini-3.5-flash`). Falling back to langchain is fine.
+
+Checking the provider's NativeTools alone is insufficient — all Gemini providers declare `google_search: true, url_context: true` by default, so any agent on a Gemini provider would trigger the guard incorrectly.
+
+**Solution:** A `RequiresNativeTools` boolean on the resolved agent config, set to `true` when the agent definition has at least one enabled native tool. The runtime guard checks this field, not the provider's native tools map.
+
+### Compatibility Rule
+
+An entry is "incompatible" when:
+
+1. `RequiresNativeTools` is `true`
+2. The fallback entry's backend is NOT `google-native`
+
+Backend-level check only — no per-tool validation within `google-native` entries. If an edge case occurs (e.g., image model as fallback), the runtime error naturally triggers the next fallback attempt.
+
+### Observability
+
+When an entry is skipped due to incompatibility:
+- Log at **Info** level (correct behavior, not an anomaly)
+- Include `skipped_incompatible` entries in timeline metadata when fallback ultimately succeeds
+
+No dedicated metric — skipping is a feature, not a problem to alert on.
+
+### Startup Validation
+
+A validation pass checks chains that include agents with native tools and warns if no compatible fallback entry exists in the resolved fallback list for that chain. Warning only — non-breaking, defense-in-depth.
+
+## Core Concepts
+
+### Compatible Fallback Entry
+
+A fallback entry is "compatible" with the current execution when switching to it would not break the agent's required capabilities:
+- If `RequiresNativeTools` is true → only `google-native` backend entries are compatible
+- If `RequiresNativeTools` is false → any entry is compatible
+
+### Native Tool Agents
+
+Agents whose **definition** includes `NativeTools` with at least one enabled tool. Currently: `WebResearcher` and `CodeExecutor`. Agents that merely *use* a Gemini provider (which supports native tools at the provider level) do NOT qualify — they can fall back to any backend.
+
+## Decisions
+
+| # | Question | Decision | Rationale |
+|---|----------|----------|-----------|
+| Q1 | Skip observability | Info log + timeline metadata. No metric. | Skipping is correct behavior, not an anomaly. Timeline provides audit trail for operators who need it. |
+| Q2 | Hard skip vs. configurable | Hard skip, always. No config option. | An agent without its core tools is broken, not degraded. A configurable option adds complexity for a useless mode. |
+| Q3 | Per-tool check within google-native | Backend-level only. | Most Gemini providers support all tools. Agent native-tool overrides are merged onto fallback configs. Edge cases (image models) are handled naturally by error→fallback flow. |
+| Q4 | Startup validation severity | Warning only. | Runtime guard is the real safety net. Non-breaking for existing deployments. Can be promoted to error later. |
+| Q5 | Resolution-time vs. runtime filtering | Runtime-only in `tryFallback()`. | Single location for the logic. Faithful config representation. Easier to debug (all entries visible, skips logged). |

--- a/pkg/agent/config_resolver.go
+++ b/pkg/agent/config_resolver.go
@@ -130,6 +130,7 @@ func ResolveAgentConfig(
 		ResolvedFallbackProviders: resolvedFallback,
 		InitialResponseTimeout:    DefaultInitialResponseTimeout,
 		StallTimeout:              DefaultStallTimeout,
+		RequiresNativeTools:       requiresNativeTools(agentDef.NativeTools),
 		RequiredSkillContent:      requiredSkills,
 		OnDemandSkills:            onDemandSkills,
 	}, nil
@@ -261,6 +262,7 @@ func ResolveChatAgentConfig(
 		ResolvedFallbackProviders: resolvedFallback,
 		InitialResponseTimeout:    DefaultInitialResponseTimeout,
 		StallTimeout:              DefaultStallTimeout,
+		RequiresNativeTools:       requiresNativeTools(agentDef.NativeTools),
 		RequiredSkillContent:      requiredSkills,
 		OnDemandSkills:            onDemandSkills,
 	}, nil
@@ -378,6 +380,7 @@ func ResolveScoringConfig(
 		ResolvedFallbackProviders: resolvedFallback,
 		InitialResponseTimeout:    DefaultInitialResponseTimeout,
 		StallTimeout:              DefaultStallTimeout,
+		RequiresNativeTools:       requiresNativeTools(agentDef.NativeTools),
 	}, nil
 }
 
@@ -450,7 +453,19 @@ func ResolveExecSummaryConfig(
 		ResolvedFallbackProviders: resolvedFallback,
 		InitialResponseTimeout:    DefaultInitialResponseTimeout,
 		StallTimeout:              DefaultStallTimeout,
+		RequiresNativeTools:       requiresNativeTools(agentDef.NativeTools),
 	}, nil
+}
+
+// requiresNativeTools returns true when the agent definition declares at least
+// one enabled native tool. Used to set RequiresNativeTools on ResolvedAgentConfig.
+func requiresNativeTools(agentTools map[config.GoogleNativeTool]bool) bool {
+	for _, enabled := range agentTools {
+		if enabled {
+			return true
+		}
+	}
+	return false
 }
 
 // applyAgentNativeTools clones the provider and merges agent-level native tool

--- a/pkg/agent/config_resolver_test.go
+++ b/pkg/agent/config_resolver_test.go
@@ -406,6 +406,64 @@ func TestResolveAgentConfig(t *testing.T) {
 			// Original provider must be unchanged
 			assert.False(t, providerWithNative.NativeTools[config.GoogleNativeToolCodeExecution])
 		})
+
+		t.Run("RequiresNativeTools true when agent has enabled native tools", func(t *testing.T) {
+			ntCfg := &config.Config{
+				Defaults: &config.Defaults{LLMProvider: "google-native"},
+				AgentRegistry: config.NewAgentRegistry(map[string]*config.AgentConfig{
+					"TestAgent": {
+						NativeTools: map[config.GoogleNativeTool]bool{
+							config.GoogleNativeToolGoogleSearch: true,
+							config.GoogleNativeToolURLContext:   true,
+						},
+					},
+				}),
+				LLMProviderRegistry: config.NewLLMProviderRegistry(map[string]*config.LLMProviderConfig{
+					"google-native": providerWithNative,
+				}),
+			}
+
+			resolved, err := ResolveAgentConfig(ntCfg, &config.ChainConfig{}, config.StageConfig{}, config.StageAgentConfig{Name: "TestAgent"})
+			require.NoError(t, err)
+			assert.True(t, resolved.RequiresNativeTools)
+		})
+
+		t.Run("RequiresNativeTools false when agent has no native tools", func(t *testing.T) {
+			ntCfg := &config.Config{
+				Defaults: &config.Defaults{LLMProvider: "google-native"},
+				AgentRegistry: config.NewAgentRegistry(map[string]*config.AgentConfig{
+					"TestAgent": {},
+				}),
+				LLMProviderRegistry: config.NewLLMProviderRegistry(map[string]*config.LLMProviderConfig{
+					"google-native": providerWithNative,
+				}),
+			}
+
+			resolved, err := ResolveAgentConfig(ntCfg, &config.ChainConfig{}, config.StageConfig{}, config.StageAgentConfig{Name: "TestAgent"})
+			require.NoError(t, err)
+			assert.False(t, resolved.RequiresNativeTools)
+		})
+
+		t.Run("RequiresNativeTools false when all agent native tools disabled", func(t *testing.T) {
+			ntCfg := &config.Config{
+				Defaults: &config.Defaults{LLMProvider: "google-native"},
+				AgentRegistry: config.NewAgentRegistry(map[string]*config.AgentConfig{
+					"TestAgent": {
+						NativeTools: map[config.GoogleNativeTool]bool{
+							config.GoogleNativeToolGoogleSearch:  false,
+							config.GoogleNativeToolCodeExecution: false,
+						},
+					},
+				}),
+				LLMProviderRegistry: config.NewLLMProviderRegistry(map[string]*config.LLMProviderConfig{
+					"google-native": providerWithNative,
+				}),
+			}
+
+			resolved, err := ResolveAgentConfig(ntCfg, &config.ChainConfig{}, config.StageConfig{}, config.StageAgentConfig{Name: "TestAgent"})
+			require.NoError(t, err)
+			assert.False(t, resolved.RequiresNativeTools)
+		})
 	})
 }
 

--- a/pkg/agent/config_resolver_test.go
+++ b/pkg/agent/config_resolver_test.go
@@ -681,6 +681,43 @@ func TestResolveChatAgentConfig(t *testing.T) {
 		assert.NotSame(t, providerWithNative, resolved.LLMProvider)
 	})
 
+	t.Run("RequiresNativeTools true when chat agent has enabled native tools", func(t *testing.T) {
+		ntCfg := &config.Config{
+			Defaults: &config.Defaults{LLMProvider: "google-default"},
+			AgentRegistry: config.NewAgentRegistry(map[string]*config.AgentConfig{
+				config.AgentNameChat: {
+					NativeTools: map[config.GoogleNativeTool]bool{
+						config.GoogleNativeToolGoogleSearch: true,
+						config.GoogleNativeToolURLContext:   true,
+					},
+				},
+			}),
+			LLMProviderRegistry: config.NewLLMProviderRegistry(map[string]*config.LLMProviderConfig{
+				"google-default": googleProvider,
+			}),
+		}
+
+		resolved, err := ResolveChatAgentConfig(ntCfg, &config.ChainConfig{}, nil)
+		require.NoError(t, err)
+		assert.True(t, resolved.RequiresNativeTools)
+	})
+
+	t.Run("RequiresNativeTools false when chat agent has no native tools", func(t *testing.T) {
+		ntCfg := &config.Config{
+			Defaults: &config.Defaults{LLMProvider: "google-default"},
+			AgentRegistry: config.NewAgentRegistry(map[string]*config.AgentConfig{
+				config.AgentNameChat: {},
+			}),
+			LLMProviderRegistry: config.NewLLMProviderRegistry(map[string]*config.LLMProviderConfig{
+				"google-default": googleProvider,
+			}),
+		}
+
+		resolved, err := ResolveChatAgentConfig(ntCfg, &config.ChainConfig{}, nil)
+		require.NoError(t, err)
+		assert.False(t, resolved.RequiresNativeTools)
+	})
+
 	t.Run("errors on unknown agent", func(t *testing.T) {
 		chain := &config.ChainConfig{}
 		chatCfg := &config.ChatConfig{
@@ -941,6 +978,53 @@ func TestResolveScoringConfig(t *testing.T) {
 		assert.True(t, resolved.LLMProvider.NativeTools[config.GoogleNativeToolGoogleSearch])
 		assert.False(t, resolved.LLMProvider.NativeTools[config.GoogleNativeToolURLContext])
 		assert.NotSame(t, providerWithNative, resolved.LLMProvider)
+	})
+
+	t.Run("RequiresNativeTools true when scoring agent has enabled native tools", func(t *testing.T) {
+		providerWithNative := &config.LLMProviderConfig{
+			Type:      config.LLMProviderTypeGoogle,
+			Model:     "gemini-2.5-pro",
+			APIKeyEnv: "GOOGLE_API_KEY",
+		}
+		ntCfg := &config.Config{
+			Defaults: &config.Defaults{LLMProvider: "google-nt"},
+			AgentRegistry: config.NewAgentRegistry(map[string]*config.AgentConfig{
+				config.AgentNameScoring: {
+					Type: config.AgentTypeScoring,
+					NativeTools: map[config.GoogleNativeTool]bool{
+						config.GoogleNativeToolGoogleSearch: true,
+					},
+				},
+			}),
+			LLMProviderRegistry: config.NewLLMProviderRegistry(map[string]*config.LLMProviderConfig{
+				"google-nt": providerWithNative,
+			}),
+		}
+
+		resolved, err := ResolveScoringConfig(ntCfg, &config.ChainConfig{}, nil)
+		require.NoError(t, err)
+		assert.True(t, resolved.RequiresNativeTools)
+	})
+
+	t.Run("RequiresNativeTools false when scoring agent has no native tools", func(t *testing.T) {
+		providerWithNative := &config.LLMProviderConfig{
+			Type:      config.LLMProviderTypeGoogle,
+			Model:     "gemini-2.5-pro",
+			APIKeyEnv: "GOOGLE_API_KEY",
+		}
+		ntCfg := &config.Config{
+			Defaults: &config.Defaults{LLMProvider: "google-nt"},
+			AgentRegistry: config.NewAgentRegistry(map[string]*config.AgentConfig{
+				config.AgentNameScoring: {Type: config.AgentTypeScoring},
+			}),
+			LLMProviderRegistry: config.NewLLMProviderRegistry(map[string]*config.LLMProviderConfig{
+				"google-nt": providerWithNative,
+			}),
+		}
+
+		resolved, err := ResolveScoringConfig(ntCfg, &config.ChainConfig{}, nil)
+		require.NoError(t, err)
+		assert.False(t, resolved.RequiresNativeTools)
 	})
 
 	t.Run("LLM provider full hierarchy: scoringCfg overrides chain overrides defaults.Scoring overrides defaults", func(t *testing.T) {
@@ -1607,6 +1691,33 @@ func TestResolveExecSummaryConfig(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, resolved.FallbackProviders, 1)
 		assert.Equal(t, "openai-default", resolved.FallbackProviders[0].Provider)
+	})
+
+	t.Run("RequiresNativeTools true when exec-summary agent has enabled native tools", func(t *testing.T) {
+		ntCfg := &config.Config{
+			Defaults: &config.Defaults{LLMProvider: "google-default"},
+			AgentRegistry: config.NewAgentRegistry(map[string]*config.AgentConfig{
+				config.AgentNameExecSummary: {
+					Type: config.AgentTypeExecSummary,
+					NativeTools: map[config.GoogleNativeTool]bool{
+						config.GoogleNativeToolGoogleSearch: true,
+					},
+				},
+			}),
+			LLMProviderRegistry: config.NewLLMProviderRegistry(map[string]*config.LLMProviderConfig{
+				"google-default": googleProvider,
+			}),
+		}
+
+		resolved, err := ResolveExecSummaryConfig(ntCfg, &config.ChainConfig{})
+		require.NoError(t, err)
+		assert.True(t, resolved.RequiresNativeTools)
+	})
+
+	t.Run("RequiresNativeTools false when exec-summary agent has no native tools", func(t *testing.T) {
+		resolved, err := ResolveExecSummaryConfig(cfg, &config.ChainConfig{})
+		require.NoError(t, err)
+		assert.False(t, resolved.RequiresNativeTools)
 	})
 
 	t.Run("nil chain returns error", func(t *testing.T) {

--- a/pkg/agent/context.go
+++ b/pkg/agent/context.go
@@ -113,6 +113,11 @@ type ResolvedAgentConfig struct {
 	// Adaptive timeout: max gap between consecutive chunks (default: 60s)
 	StallTimeout time.Duration
 
+	// RequiresNativeTools is true when the agent definition declares NativeTools
+	// with at least one enabled tool. Such agents MUST run on a google-native
+	// backend — incompatible fallback entries are skipped at runtime.
+	RequiresNativeTools bool
+
 	// NativeToolsOverride is the per-alert native tools override (nil = use provider defaults).
 	// Set by the session executor when the alert provides an MCP selection with native_tools.
 	NativeToolsOverride *models.NativeToolsConfig

--- a/pkg/agent/controller/fallback.go
+++ b/pkg/agent/controller/fallback.go
@@ -146,20 +146,34 @@ func tryFallback(
 
 	// Find the next fallback entry whose provider name differs from the
 	// currently active one. An entry with the same provider name would just
-	// repeat the same failure, so skip it.
+	// repeat the same failure, so skip it. Also skip entries that are
+	// incompatible with the agent's required native tools.
 	nextIdx := state.CurrentProviderIndex + 1
+	var skippedIncompatible []string
 	for nextIdx < len(execCtx.Config.ResolvedFallbackProviders) {
 		candidate := execCtx.Config.ResolvedFallbackProviders[nextIdx]
-		if candidate.ProviderName != execCtx.Config.LLMProviderName {
-			break
+		if candidate.ProviderName == execCtx.Config.LLMProviderName {
+			slog.Info("Skipping fallback entry identical to current provider",
+				"session_id", execCtx.SessionID,
+				"execution_id", execCtx.ExecutionID,
+				"skipped_provider", candidate.ProviderName,
+				"skipped_backend", candidate.Backend,
+			)
+			nextIdx++
+			continue
 		}
-		slog.Info("Skipping fallback entry identical to current provider",
-			"session_id", execCtx.SessionID,
-			"execution_id", execCtx.ExecutionID,
-			"skipped_provider", candidate.ProviderName,
-			"skipped_backend", candidate.Backend,
-		)
-		nextIdx++
+		if execCtx.Config.RequiresNativeTools && candidate.Backend != config.LLMBackendNativeGemini {
+			slog.Info("Skipping fallback entry incompatible with required native tools",
+				"session_id", execCtx.SessionID,
+				"execution_id", execCtx.ExecutionID,
+				"skipped_provider", candidate.ProviderName,
+				"skipped_backend", candidate.Backend,
+			)
+			skippedIncompatible = append(skippedIncompatible, candidate.ProviderName)
+			nextIdx++
+			continue
+		}
+		break
 	}
 	if nextIdx >= len(execCtx.Config.ResolvedFallbackProviders) {
 		return false
@@ -220,6 +234,9 @@ func tryFallback(
 	}
 	if len(droppedTools) > 0 {
 		meta["native_tools_dropped"] = droppedTools
+	}
+	if len(skippedIncompatible) > 0 {
+		meta["skipped_incompatible"] = skippedIncompatible
 	}
 	createTimelineEvent(ctx, execCtx, timelineevent.EventTypeProviderFallback,
 		fmt.Sprintf("Provider fallback: %s → %s", prevProvider, entry.ProviderName),

--- a/pkg/agent/controller/fallback_test.go
+++ b/pkg/agent/controller/fallback_test.go
@@ -604,6 +604,74 @@ func TestNativeToolsDroppedOnFallback(t *testing.T) {
 }
 
 func TestTryFallback_NativeToolsDroppedMetadata(t *testing.T) {
+	t.Run("blocked when agent requires native tools", func(t *testing.T) {
+		llm := &mockLLMClient{
+			responses: []mockLLMResponse{
+				{chunks: []agent.Chunk{&agent.TextChunk{Content: "hello"}}},
+			},
+		}
+		execCtx := newTestExecCtx(t, llm, &mockToolExecutor{})
+		execCtx.Config.LLMProviderName = "primary"
+		execCtx.Config.LLMProvider.NativeTools = map[config.GoogleNativeTool]bool{
+			config.GoogleNativeToolGoogleSearch: true,
+			config.GoogleNativeToolURLContext:   true,
+		}
+		execCtx.Config.RequiresNativeTools = true
+		execCtx.Config.ResolvedFallbackProviders = []agent.ResolvedFallbackEntry{
+			{
+				ProviderName: "langchain-fb",
+				Backend:      config.LLMBackendLangChain,
+				Config:       &config.LLMProviderConfig{Model: "gpt-fallback"},
+			},
+		}
+
+		state := NewFallbackState(execCtx)
+		eventSeq := 0
+
+		result := tryFallback(context.Background(), execCtx, state,
+			makePartialError(LLMErrorMaxRetries), &eventSeq)
+		require.False(t, result)
+
+		// Provider was NOT swapped — still on primary
+		assert.Equal(t, "primary", execCtx.Config.LLMProviderName)
+		assert.Equal(t, 0, eventSeq)
+	})
+
+	t.Run("proceeds when agent does not require native tools", func(t *testing.T) {
+		llm := &mockLLMClient{
+			responses: []mockLLMResponse{
+				{chunks: []agent.Chunk{&agent.TextChunk{Content: "hello"}}},
+			},
+		}
+		execCtx := newTestExecCtx(t, llm, &mockToolExecutor{})
+		execCtx.Config.LLMProviderName = "primary"
+		execCtx.Config.LLMProvider.NativeTools = map[config.GoogleNativeTool]bool{
+			config.GoogleNativeToolGoogleSearch: true,
+			config.GoogleNativeToolURLContext:   true,
+		}
+		execCtx.Config.RequiresNativeTools = false
+		execCtx.Config.ResolvedFallbackProviders = []agent.ResolvedFallbackEntry{
+			{
+				ProviderName: "langchain-fb",
+				Backend:      config.LLMBackendLangChain,
+				Config:       &config.LLMProviderConfig{Model: "gpt-fallback"},
+			},
+		}
+
+		state := NewFallbackState(execCtx)
+		eventSeq := 0
+
+		result := tryFallback(context.Background(), execCtx, state,
+			makePartialError(LLMErrorMaxRetries), &eventSeq)
+		require.True(t, result)
+
+		assert.Equal(t, 1, eventSeq)
+		assert.Equal(t, "langchain-fb", execCtx.Config.LLMProviderName)
+		assert.Equal(t, config.LLMBackendLangChain, execCtx.Config.LLMBackend)
+	})
+}
+
+func TestTryFallback_NativeToolsSkipAndAdvance(t *testing.T) {
 	llm := &mockLLMClient{
 		responses: []mockLLMResponse{
 			{chunks: []agent.Chunk{&agent.TextChunk{Content: "hello"}}},
@@ -611,16 +679,18 @@ func TestTryFallback_NativeToolsDroppedMetadata(t *testing.T) {
 	}
 	execCtx := newTestExecCtx(t, llm, &mockToolExecutor{})
 	execCtx.Config.LLMProviderName = "primary"
-	execCtx.Config.LLMProvider.NativeTools = map[config.GoogleNativeTool]bool{
-		config.GoogleNativeToolGoogleSearch: true,
-		config.GoogleNativeToolURLContext:   true,
-	}
-	// Fallback directly to langchain backend
+	execCtx.Config.LLMBackend = config.LLMBackendNativeGemini
+	execCtx.Config.RequiresNativeTools = true
 	execCtx.Config.ResolvedFallbackProviders = []agent.ResolvedFallbackEntry{
 		{
 			ProviderName: "langchain-fb",
 			Backend:      config.LLMBackendLangChain,
 			Config:       &config.LLMProviderConfig{Model: "gpt-fallback"},
+		},
+		{
+			ProviderName: "gemini-fb",
+			Backend:      config.LLMBackendNativeGemini,
+			Config:       &config.LLMProviderConfig{Model: "gemini-fallback"},
 		},
 	}
 
@@ -631,10 +701,86 @@ func TestTryFallback_NativeToolsDroppedMetadata(t *testing.T) {
 		makePartialError(LLMErrorMaxRetries), &eventSeq)
 	require.True(t, result)
 
-	// Verify the timeline event was created (contains native_tools_dropped metadata)
-	assert.Equal(t, 1, eventSeq)
+	// Langchain entry was skipped, google-native entry selected
+	assert.Equal(t, "gemini-fb", execCtx.Config.LLMProviderName)
+	assert.Equal(t, config.LLMBackendNativeGemini, execCtx.Config.LLMBackend)
+	// Skipped entry was NOT added to AttemptedProviders
+	assert.Equal(t, []string{"primary", "gemini-fb"}, state.AttemptedProviders)
+}
 
-	// Verify the provider was swapped to langchain
-	assert.Equal(t, "langchain-fb", execCtx.Config.LLMProviderName)
-	assert.Equal(t, config.LLMBackendLangChain, execCtx.Config.LLMBackend)
+func TestTryFallback_AllIncompatible(t *testing.T) {
+	llm := &mockLLMClient{
+		responses: []mockLLMResponse{
+			{chunks: []agent.Chunk{&agent.TextChunk{Content: "hello"}}},
+		},
+	}
+	execCtx := newTestExecCtx(t, llm, &mockToolExecutor{})
+	execCtx.Config.LLMProviderName = "primary"
+	execCtx.Config.LLMBackend = config.LLMBackendNativeGemini
+	execCtx.Config.RequiresNativeTools = true
+	execCtx.Config.ResolvedFallbackProviders = []agent.ResolvedFallbackEntry{
+		{
+			ProviderName: "langchain-fb-1",
+			Backend:      config.LLMBackendLangChain,
+			Config:       &config.LLMProviderConfig{Model: "gpt-1"},
+		},
+		{
+			ProviderName: "langchain-fb-2",
+			Backend:      config.LLMBackendLangChain,
+			Config:       &config.LLMProviderConfig{Model: "gpt-2"},
+		},
+	}
+
+	state := NewFallbackState(execCtx)
+	eventSeq := 0
+
+	result := tryFallback(context.Background(), execCtx, state,
+		makePartialError(LLMErrorMaxRetries), &eventSeq)
+	require.False(t, result)
+
+	// Provider unchanged
+	assert.Equal(t, "primary", execCtx.Config.LLMProviderName)
+	assert.Equal(t, config.LLMBackendNativeGemini, execCtx.Config.LLMBackend)
+	assert.Equal(t, 0, eventSeq)
+}
+
+func TestTryFallback_MixedSkipReasons(t *testing.T) {
+	llm := &mockLLMClient{
+		responses: []mockLLMResponse{
+			{chunks: []agent.Chunk{&agent.TextChunk{Content: "hello"}}},
+		},
+	}
+	execCtx := newTestExecCtx(t, llm, &mockToolExecutor{})
+	execCtx.Config.LLMProviderName = "primary"
+	execCtx.Config.LLMBackend = config.LLMBackendNativeGemini
+	execCtx.Config.RequiresNativeTools = true
+	execCtx.Config.ResolvedFallbackProviders = []agent.ResolvedFallbackEntry{
+		{
+			ProviderName: "primary", // same-provider skip
+			Backend:      config.LLMBackendNativeGemini,
+			Config:       &config.LLMProviderConfig{Model: "same-model"},
+		},
+		{
+			ProviderName: "langchain-fb", // incompatible-backend skip
+			Backend:      config.LLMBackendLangChain,
+			Config:       &config.LLMProviderConfig{Model: "gpt-fallback"},
+		},
+		{
+			ProviderName: "gemini-fb", // compatible — selected
+			Backend:      config.LLMBackendNativeGemini,
+			Config:       &config.LLMProviderConfig{Model: "gemini-fallback"},
+		},
+	}
+
+	state := NewFallbackState(execCtx)
+	eventSeq := 0
+
+	result := tryFallback(context.Background(), execCtx, state,
+		makePartialError(LLMErrorMaxRetries), &eventSeq)
+	require.True(t, result)
+
+	// Both skip types were traversed, landing on the compatible entry
+	assert.Equal(t, "gemini-fb", execCtx.Config.LLMProviderName)
+	assert.Equal(t, config.LLMBackendNativeGemini, execCtx.Config.LLMBackend)
+	assert.Equal(t, []string{"primary", "gemini-fb"}, state.AttemptedProviders)
 }

--- a/pkg/config/validator.go
+++ b/pkg/config/validator.go
@@ -46,6 +46,8 @@ func (v *Validator) ValidateAll() error {
 		return fmt.Errorf("chain validation failed: %w", err)
 	}
 
+	v.warnNativeToolAgentsWithoutCompatibleFallback()
+
 	if err := v.validateDefaults(); err != nil {
 		return fmt.Errorf("defaults validation failed: %w", err)
 	}
@@ -921,4 +923,85 @@ func (v *Validator) validateSkills() error {
 	}
 
 	return nil
+}
+
+// warnNativeToolAgentsWithoutCompatibleFallback checks chains for agents that
+// require native tools but have no google-native fallback entry in their
+// effective fallback list. Logs a warning for each such case. Non-blocking.
+func (v *Validator) warnNativeToolAgentsWithoutCompatibleFallback() {
+	var defaultsFallback []FallbackProviderEntry
+	if v.cfg.Defaults != nil {
+		defaultsFallback = v.cfg.Defaults.FallbackProviders
+	}
+
+	for chainID, chain := range v.cfg.ChainRegistry.GetAll() {
+		// Check stage agents
+		for _, stage := range chain.Stages {
+			for _, agentCfg := range stage.Agents {
+				v.warnIfNativeAgentLacksFallback(chainID, agentCfg.Name,
+					defaultsFallback, chain.FallbackProviders,
+					stage.FallbackProviders, agentCfg.FallbackProviders)
+			}
+		}
+
+		// Check chain-level sub-agents (orchestrator dispatch targets)
+		for _, ref := range chain.SubAgents {
+			v.warnIfNativeAgentLacksFallback(chainID, ref.Name,
+				defaultsFallback, chain.FallbackProviders, nil, nil)
+		}
+	}
+}
+
+func (v *Validator) warnIfNativeAgentLacksFallback(
+	chainID, agentName string,
+	defaultsFallback, chainFallback, stageFallback, agentFallback []FallbackProviderEntry,
+) {
+	agentDef, err := v.cfg.AgentRegistry.Get(agentName)
+	if err != nil {
+		return
+	}
+
+	if !agentHasEnabledNativeTools(agentDef.NativeTools) {
+		return
+	}
+
+	// Resolve effective fallback list using the same precedence as runtime:
+	// last non-nil wins (defaults → chain → stage → agent)
+	effective := resolveEffectiveFallback(defaultsFallback, chainFallback, stageFallback, agentFallback)
+	if len(effective) == 0 {
+		return
+	}
+
+	for _, entry := range effective {
+		if entry.Backend == LLMBackendNativeGemini {
+			return
+		}
+	}
+
+	slog.Warn("Chain has native-tool agent with no compatible fallback entry",
+		"chain", chainID,
+		"agent", agentName,
+		"hint", "all fallback entries use non-google-native backends; runtime will skip them",
+	)
+}
+
+func agentHasEnabledNativeTools(nativeTools map[GoogleNativeTool]bool) bool {
+	for _, enabled := range nativeTools {
+		if enabled {
+			return true
+		}
+	}
+	return false
+}
+
+// resolveEffectiveFallback returns the last non-nil fallback list, mirroring
+// the runtime resolution logic in pkg/agent/config_resolver.go.
+func resolveEffectiveFallback(layers ...[]FallbackProviderEntry) []FallbackProviderEntry {
+	var result []FallbackProviderEntry
+	for _, layer := range layers {
+		if layer != nil {
+			result = layer
+		}
+	}
+	return result
 }

--- a/pkg/config/validator_test.go
+++ b/pkg/config/validator_test.go
@@ -3712,3 +3712,204 @@ func TestWarnMemoryWithoutScoring(t *testing.T) {
 		assert.Contains(t, buf.String(), "Memory is enabled but no chain has scoring enabled")
 	})
 }
+
+func TestWarnNativeToolAgentsWithoutCompatibleFallback(t *testing.T) {
+	captureLogs := func(t *testing.T) (*bytes.Buffer, func()) {
+		t.Helper()
+		var buf bytes.Buffer
+		old := slog.Default()
+		slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+		return &buf, func() { slog.SetDefault(old) }
+	}
+
+	t.Run("warns when native-tool agent has only langchain fallback", func(t *testing.T) {
+		buf, restore := captureLogs(t)
+		t.Cleanup(restore)
+
+		cfg := &Config{
+			Defaults: &Defaults{
+				FallbackProviders: []FallbackProviderEntry{
+					{Provider: "openai-fb", Backend: LLMBackendLangChain},
+				},
+			},
+			AgentRegistry: NewAgentRegistry(map[string]*AgentConfig{
+				"WebResearcher": {
+					NativeTools: map[GoogleNativeTool]bool{
+						GoogleNativeToolGoogleSearch: true,
+						GoogleNativeToolURLContext:   true,
+					},
+				},
+			}),
+			ChainRegistry: NewChainRegistry(map[string]*ChainConfig{
+				"test-chain": {
+					Stages: []StageConfig{
+						{Name: "s1", Agents: []StageAgentConfig{{Name: "WebResearcher"}}},
+					},
+				},
+			}),
+		}
+		v := NewValidator(cfg)
+		v.warnNativeToolAgentsWithoutCompatibleFallback()
+
+		assert.Contains(t, buf.String(), "native-tool agent with no compatible fallback")
+		assert.Contains(t, buf.String(), "WebResearcher")
+	})
+
+	t.Run("no warning when fallback includes google-native entry", func(t *testing.T) {
+		buf, restore := captureLogs(t)
+		t.Cleanup(restore)
+
+		cfg := &Config{
+			Defaults: &Defaults{
+				FallbackProviders: []FallbackProviderEntry{
+					{Provider: "openai-fb", Backend: LLMBackendLangChain},
+					{Provider: "gemini-fb", Backend: LLMBackendNativeGemini},
+				},
+			},
+			AgentRegistry: NewAgentRegistry(map[string]*AgentConfig{
+				"WebResearcher": {
+					NativeTools: map[GoogleNativeTool]bool{
+						GoogleNativeToolGoogleSearch: true,
+					},
+				},
+			}),
+			ChainRegistry: NewChainRegistry(map[string]*ChainConfig{
+				"test-chain": {
+					Stages: []StageConfig{
+						{Name: "s1", Agents: []StageAgentConfig{{Name: "WebResearcher"}}},
+					},
+				},
+			}),
+		}
+		v := NewValidator(cfg)
+		v.warnNativeToolAgentsWithoutCompatibleFallback()
+
+		assert.Empty(t, buf.String())
+	})
+
+	t.Run("no warning when agent has no native tools", func(t *testing.T) {
+		buf, restore := captureLogs(t)
+		t.Cleanup(restore)
+
+		cfg := &Config{
+			Defaults: &Defaults{
+				FallbackProviders: []FallbackProviderEntry{
+					{Provider: "openai-fb", Backend: LLMBackendLangChain},
+				},
+			},
+			AgentRegistry: NewAgentRegistry(map[string]*AgentConfig{
+				"KubernetesAgent": {},
+			}),
+			ChainRegistry: NewChainRegistry(map[string]*ChainConfig{
+				"test-chain": {
+					Stages: []StageConfig{
+						{Name: "s1", Agents: []StageAgentConfig{{Name: "KubernetesAgent"}}},
+					},
+				},
+			}),
+		}
+		v := NewValidator(cfg)
+		v.warnNativeToolAgentsWithoutCompatibleFallback()
+
+		assert.Empty(t, buf.String())
+	})
+
+	t.Run("no warning when no fallback providers configured", func(t *testing.T) {
+		buf, restore := captureLogs(t)
+		t.Cleanup(restore)
+
+		cfg := &Config{
+			AgentRegistry: NewAgentRegistry(map[string]*AgentConfig{
+				"WebResearcher": {
+					NativeTools: map[GoogleNativeTool]bool{
+						GoogleNativeToolGoogleSearch: true,
+					},
+				},
+			}),
+			ChainRegistry: NewChainRegistry(map[string]*ChainConfig{
+				"test-chain": {
+					Stages: []StageConfig{
+						{Name: "s1", Agents: []StageAgentConfig{{Name: "WebResearcher"}}},
+					},
+				},
+			}),
+		}
+		v := NewValidator(cfg)
+		v.warnNativeToolAgentsWithoutCompatibleFallback()
+
+		assert.Empty(t, buf.String())
+	})
+
+	t.Run("agent-level fallback overrides chain-level", func(t *testing.T) {
+		buf, restore := captureLogs(t)
+		t.Cleanup(restore)
+
+		cfg := &Config{
+			Defaults: &Defaults{
+				FallbackProviders: []FallbackProviderEntry{
+					{Provider: "gemini-fb", Backend: LLMBackendNativeGemini},
+				},
+			},
+			AgentRegistry: NewAgentRegistry(map[string]*AgentConfig{
+				"WebResearcher": {
+					NativeTools: map[GoogleNativeTool]bool{
+						GoogleNativeToolGoogleSearch: true,
+					},
+				},
+			}),
+			ChainRegistry: NewChainRegistry(map[string]*ChainConfig{
+				"test-chain": {
+					Stages: []StageConfig{
+						{
+							Name: "s1",
+							Agents: []StageAgentConfig{{
+								Name: "WebResearcher",
+								FallbackProviders: []FallbackProviderEntry{
+									{Provider: "openai-only", Backend: LLMBackendLangChain},
+								},
+							}},
+						},
+					},
+				},
+			}),
+		}
+		v := NewValidator(cfg)
+		v.warnNativeToolAgentsWithoutCompatibleFallback()
+
+		assert.Contains(t, buf.String(), "native-tool agent with no compatible fallback")
+	})
+
+	t.Run("warns for native-tool sub-agent refs", func(t *testing.T) {
+		buf, restore := captureLogs(t)
+		t.Cleanup(restore)
+
+		cfg := &Config{
+			Defaults: &Defaults{
+				FallbackProviders: []FallbackProviderEntry{
+					{Provider: "openai-fb", Backend: LLMBackendLangChain},
+				},
+			},
+			AgentRegistry: NewAgentRegistry(map[string]*AgentConfig{
+				"Orchestrator": {},
+				"CodeExecutor": {
+					NativeTools: map[GoogleNativeTool]bool{
+						GoogleNativeToolCodeExecution: true,
+					},
+				},
+			}),
+			ChainRegistry: NewChainRegistry(map[string]*ChainConfig{
+				"test-chain": {
+					SubAgents: SubAgentRefs{{Name: "CodeExecutor"}},
+					Stages: []StageConfig{
+						{Name: "s1", Agents: []StageAgentConfig{{Name: "Orchestrator"}}},
+					},
+				},
+			}),
+		}
+		v := NewValidator(cfg)
+		v.warnNativeToolAgentsWithoutCompatibleFallback()
+
+		assert.Contains(t, buf.String(), "native-tool agent with no compatible fallback")
+		assert.Contains(t, buf.String(), "CodeExecutor")
+	})
+}

--- a/test/e2e/fallback_test.go
+++ b/test/e2e/fallback_test.go
@@ -473,6 +473,195 @@ func TestE2E_FallbackExecutiveSummary(t *testing.T) {
 }
 
 // ────────────────────────────────────────────────────────────
+// TestE2E_NativeToolFallbackSkipsIncompatible — Agent that requires native
+// tools (google_search, url_context) hits a provider error. The first fallback
+// entry uses langchain backend (incompatible) and must be skipped. The second
+// entry uses google-native (compatible) and is selected.
+//
+// Verifies:
+//   - Session completes after skipping incompatible fallback
+//   - Execution uses the compatible fallback provider (not langchain)
+//   - provider_fallback timeline event includes skipped_incompatible metadata
+//   - LLM call after fallback uses the compatible model
+// ────────────────────────────────────────────────────────────
+
+func TestE2E_NativeToolFallbackSkipsIncompatible(t *testing.T) {
+	llm := NewScriptedLLMClient()
+
+	// Iteration 1: primary fails → triggers fallback
+	llm.AddRouted("NativeResearcher", LLMScriptEntry{
+		Chunks: []agent.Chunk{
+			&agent.ErrorChunk{Message: "rate limit exceeded", Code: "max_retries", Retryable: true},
+		},
+	})
+	// Iteration 1 (retried on compatible fallback): success
+	llm.AddRouted("NativeResearcher", LLMScriptEntry{
+		Chunks: []agent.Chunk{
+			&agent.TextChunk{Content: "Research complete using native tools on compatible fallback."},
+			&agent.UsageChunk{InputTokens: 80, OutputTokens: 30, TotalTokens: 110},
+		},
+	})
+	// Executive summary
+	llm.AddSequential(LLMScriptEntry{Text: "Summary: research completed after fallback."})
+
+	app := NewTestApp(t,
+		WithConfig(configs.Load(t, "native-tool-fallback")),
+		WithLLMClient(llm),
+	)
+
+	_, sessionID := submitAndSubscribe(t, app, "test-native-skip", "Research needed for CVE-2026-1234")
+
+	app.WaitForSessionStatus(t, sessionID, "completed")
+
+	// ── Session completed ──
+	session := app.GetSession(t, sessionID)
+	assert.Equal(t, "completed", session["status"])
+
+	// ── Execution: fell back to compatible provider, skipping langchain ──
+	execs := app.QueryExecutions(t, sessionID)
+	researcher := findExecution(execs, "NativeResearcher")
+	require.NotNil(t, researcher)
+	assert.Equal(t, "completed", string(researcher.Status))
+	require.NotNil(t, researcher.OriginalLlmProvider)
+	assert.Equal(t, "gemini-primary", *researcher.OriginalLlmProvider)
+	require.NotNil(t, researcher.LlmProvider)
+	assert.Equal(t, "gemini-compatible", *researcher.LlmProvider)
+
+	// ── Timeline: one provider_fallback event with skipped_incompatible ──
+	timeline := app.QueryTimeline(t, sessionID)
+	fallbackEvents := filterTimelineByType(timeline, timelineevent.EventTypeProviderFallback)
+	require.Len(t, fallbackEvents, 1)
+	assert.Equal(t, "gemini-primary", fallbackEvents[0].Metadata["original_provider"])
+	assert.Equal(t, "gemini-compatible", fallbackEvents[0].Metadata["fallback_provider"])
+
+	skipped, ok := fallbackEvents[0].Metadata["skipped_incompatible"]
+	require.True(t, ok, "timeline event should include skipped_incompatible metadata")
+	skippedList, ok := skipped.([]interface{})
+	require.True(t, ok)
+	assert.Contains(t, skippedList, "langchain-incompatible")
+
+	// ── LLM call after fallback uses compatible model ──
+	inputs := llm.CapturedInputs()
+	require.GreaterOrEqual(t, len(inputs), 2)
+	assert.Equal(t, "gemini-compatible-model", inputs[1].Config.Model)
+	assert.True(t, inputs[1].ClearCache)
+}
+
+// ────────────────────────────────────────────────────────────
+// TestE2E_NativeToolFallbackAllIncompatible — Agent that requires native tools
+// fails on primary, but ALL fallback entries are langchain (incompatible).
+// No fallback occurs; the agent retries on primary until max_iterations
+// exhaustion → session fails.
+//
+// Verifies:
+//   - Session fails (not silently degraded)
+//   - No provider_fallback timeline events (fallback was blocked)
+//   - Execution stays on the primary provider
+// ────────────────────────────────────────────────────────────
+
+func TestE2E_NativeToolFallbackAllIncompatible(t *testing.T) {
+	llm := NewScriptedLLMClient()
+
+	// All iterations fail on primary — no compatible fallback available.
+	for range 3 {
+		llm.AddRouted("NativeResearcher", LLMScriptEntry{
+			Chunks: []agent.Chunk{
+				&agent.ErrorChunk{Message: "service unavailable", Code: "max_retries", Retryable: true},
+			},
+		})
+	}
+	// Force conclusion attempt also fails
+	llm.AddRouted("NativeResearcher", LLMScriptEntry{
+		Chunks: []agent.Chunk{
+			&agent.ErrorChunk{Message: "service unavailable", Code: "max_retries", Retryable: true},
+		},
+	})
+
+	app := NewTestApp(t,
+		WithConfig(configs.Load(t, "native-tool-fallback")),
+		WithLLMClient(llm),
+	)
+
+	_, sessionID := submitAndSubscribe(t, app, "test-native-exhausted", "Research needed but all providers down")
+
+	app.WaitForSessionStatus(t, sessionID, "failed")
+
+	// ── Session failed ──
+	session := app.GetSession(t, sessionID)
+	assert.Equal(t, "failed", session["status"])
+
+	// ── No fallback occurred — agent stayed on primary ──
+	timeline := app.QueryTimeline(t, sessionID)
+	fallbackEvents := filterTimelineByType(timeline, timelineevent.EventTypeProviderFallback)
+	assert.Empty(t, fallbackEvents, "no fallback should occur when all entries are incompatible")
+
+	// ── Execution failed without provider swap ──
+	execs := app.QueryExecutions(t, sessionID)
+	researcher := findExecution(execs, "NativeResearcher")
+	require.NotNil(t, researcher)
+	assert.Equal(t, "failed", string(researcher.Status))
+	assert.Nil(t, researcher.OriginalLlmProvider, "no fallback means no original_llm_provider")
+}
+
+// ────────────────────────────────────────────────────────────
+// TestE2E_NativeToolFallbackNonNativeAgent — Agent WITHOUT native tools
+// falls back to langchain normally (existing behavior preserved).
+//
+// Verifies:
+//   - Non-native-tool agent can fall back to langchain without being blocked
+//   - Session completes with the langchain fallback
+// ────────────────────────────────────────────────────────────
+
+func TestE2E_NativeToolFallbackNonNativeAgent(t *testing.T) {
+	llm := NewScriptedLLMClient()
+
+	// Iteration 1: primary fails → fallback to langchain (allowed for non-native agents)
+	llm.AddRouted("PlainAgent", LLMScriptEntry{
+		Chunks: []agent.Chunk{
+			&agent.ErrorChunk{Message: "rate limit exceeded", Code: "max_retries", Retryable: true},
+		},
+	})
+	// Iteration 1 (retried on langchain fallback): success
+	llm.AddRouted("PlainAgent", LLMScriptEntry{
+		Chunks: []agent.Chunk{
+			&agent.TextChunk{Content: "Analysis complete using langchain fallback."},
+			&agent.UsageChunk{InputTokens: 50, OutputTokens: 20, TotalTokens: 70},
+		},
+	})
+	// Executive summary
+	llm.AddSequential(LLMScriptEntry{Text: "Summary: analysis done via fallback."})
+
+	app := NewTestApp(t,
+		WithConfig(configs.Load(t, "native-tool-fallback")),
+		WithLLMClient(llm),
+	)
+
+	_, sessionID := submitAndSubscribe(t, app, "test-non-native", "Simple alert needs analysis")
+
+	app.WaitForSessionStatus(t, sessionID, "completed")
+
+	// ── Session completed ──
+	session := app.GetSession(t, sessionID)
+	assert.Equal(t, "completed", session["status"])
+
+	// ── Execution fell back to langchain (not blocked) ──
+	execs := app.QueryExecutions(t, sessionID)
+	plain := findExecution(execs, "PlainAgent")
+	require.NotNil(t, plain)
+	assert.Equal(t, "completed", string(plain.Status))
+	require.NotNil(t, plain.OriginalLlmProvider)
+	assert.Equal(t, "gemini-primary", *plain.OriginalLlmProvider)
+	require.NotNil(t, plain.LlmProvider)
+	assert.Equal(t, "langchain-incompatible", *plain.LlmProvider)
+
+	// ── Provider fallback event exists (langchain was NOT skipped for non-native agent) ──
+	timeline := app.QueryTimeline(t, sessionID)
+	fallbackEvents := filterTimelineByType(timeline, timelineevent.EventTypeProviderFallback)
+	require.Len(t, fallbackEvents, 1)
+	assert.Equal(t, "langchain-incompatible", fallbackEvents[0].Metadata["fallback_provider"])
+}
+
+// ────────────────────────────────────────────────────────────
 // Helpers
 // ────────────────────────────────────────────────────────────
 

--- a/test/e2e/testdata/configs/native-tool-fallback/llm-providers.yaml
+++ b/test/e2e/testdata/configs/native-tool-fallback/llm-providers.yaml
@@ -1,0 +1,13 @@
+llm_providers:
+  gemini-primary:
+    type: google
+    model: gemini-primary-model
+    max_tool_result_tokens: 10000
+  langchain-incompatible:
+    type: openai
+    model: gpt-incompatible
+    max_tool_result_tokens: 10000
+  gemini-compatible:
+    type: google
+    model: gemini-compatible-model
+    max_tool_result_tokens: 10000

--- a/test/e2e/testdata/configs/native-tool-fallback/tarsy.yaml
+++ b/test/e2e/testdata/configs/native-tool-fallback/tarsy.yaml
@@ -1,0 +1,52 @@
+defaults:
+  llm_provider: "gemini-primary"
+  llm_backend: "google-native"
+  max_iterations: 3
+  fallback_providers:
+    - provider: "langchain-incompatible"
+      backend: "langchain"
+    - provider: "gemini-compatible"
+      backend: "google-native"
+
+mcp_servers:
+  kubernetes-server:
+    transport:
+      type: stdio
+      command: mock
+
+agents:
+  NativeResearcher:
+    native_tools:
+      google_search: true
+      url_context: true
+    custom_instructions: "You are NativeResearcher, performing web research using native tools."
+  PlainAgent:
+    custom_instructions: "You are PlainAgent, a simple agent with no native tool requirements."
+
+agent_chains:
+  # Used by: TestE2E_NativeToolFallbackSkipsIncompatible
+  native-skip:
+    alert_types: [test-native-skip]
+    stages:
+      - name: research
+        agents:
+          - name: NativeResearcher
+
+  # Used by: TestE2E_NativeToolFallbackAllIncompatible
+  native-exhausted:
+    alert_types: [test-native-exhausted]
+    fallback_providers:
+      - provider: "langchain-incompatible"
+        backend: "langchain"
+    stages:
+      - name: research
+        agents:
+          - name: NativeResearcher
+
+  # Used by: TestE2E_NativeToolFallbackNonNativeAgent
+  non-native:
+    alert_types: [test-non-native]
+    stages:
+      - name: analysis
+        agents:
+          - name: PlainAgent


### PR DESCRIPTION
- Skip incompatible fallback entries (non-google-native backends) when an agent requires native tools, preventing silent capability loss
- Add RequiresNativeTools field to ResolvedAgentConfig, set from agent definition's NativeTools at resolution time
- Include skipped_incompatible provider names in timeline event metadata
- Add startup validation warning for chains with native-tool agents that have no compatible fallback entry
- Promote proposal to ADR-0017

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Native-tool fallback safety: incompatible fallback providers are skipped for agents that declare native tools; startup now warns when no compatible fallback exists.

* **Documentation**
  * Added ADR describing native-tool fallback safety.
  * Updated reviewer guidance to a stricter "fix what you can, then ask" flow and replaced the previous output format with an "Act on findings" section.

* **Tests**
  * Added extensive unit and end-to-end tests covering native-tool fallback behaviors and warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->