### PR TITLE
Fix orchestrator token counts to include sub-agent tokens

### DIFF
--- a/pkg/services/session_service.go
+++ b/pkg/services/session_service.go
@@ -515,7 +515,11 @@ func (s *SessionService) GetSessionDetail(ctx context.Context, sessionID string)
 				if exec.Edges.SubAgents != nil {
 					overview.SubAgents = make([]models.ExecutionOverview, 0, len(exec.Edges.SubAgents))
 					for _, sub := range exec.Edges.SubAgents {
-						overview.SubAgents = append(overview.SubAgents, buildExecutionOverview(sub, execTokens, fallbackMeta))
+						subOverview := buildExecutionOverview(sub, execTokens, fallbackMeta)
+						overview.InputTokens += subOverview.InputTokens
+						overview.OutputTokens += subOverview.OutputTokens
+						overview.TotalTokens += subOverview.TotalTokens
+						overview.SubAgents = append(overview.SubAgents, subOverview)
 					}
 				}
 

--- a/pkg/services/session_service_test.go
+++ b/pkg/services/session_service_test.go
@@ -1051,7 +1051,9 @@ func TestSessionService_GetSessionDetail(t *testing.T) {
 		assert.Equal(t, "TestOrchestrator", orch.AgentName)
 		assert.Nil(t, orch.ParentExecutionID)
 		assert.Nil(t, orch.Task)
-		assert.Equal(t, int64(100), orch.InputTokens)
+		assert.Equal(t, int64(450), orch.InputTokens, "parent should include sub-agent tokens")
+		assert.Equal(t, int64(120), orch.OutputTokens)
+		assert.Equal(t, int64(570), orch.TotalTokens)
 
 		require.Len(t, orch.SubAgents, 2)
 
@@ -1064,6 +1066,8 @@ func TestSessionService_GetSessionDetail(t *testing.T) {
 		require.NotNil(t, sa1.Task)
 		assert.Equal(t, task1, *sa1.Task)
 		assert.Equal(t, int64(200), sa1.InputTokens)
+		assert.Equal(t, int64(50), sa1.OutputTokens)
+		assert.Equal(t, int64(250), sa1.TotalTokens)
 
 		sa2 := orch.SubAgents[1]
 		assert.Equal(t, sub2.ID, sa2.ExecutionID)
@@ -1074,6 +1078,8 @@ func TestSessionService_GetSessionDetail(t *testing.T) {
 		require.NotNil(t, sa2.Task)
 		assert.Equal(t, task2, *sa2.Task)
 		assert.Equal(t, int64(150), sa2.InputTokens)
+		assert.Equal(t, int64(40), sa2.OutputTokens)
+		assert.Equal(t, int64(190), sa2.TotalTokens)
 	})
 
 	t.Run("chat_enabled false when chain explicitly disables chat", func(t *testing.T) {

--- a/test/e2e/testdata/golden/orchestrator/session.golden
+++ b/test/e2e/testdata/golden/orchestrator/session.golden
@@ -48,10 +48,10 @@
           "duration_ms": {DURATION_MS},
           "error_message": null,
           "execution_id": "{EXEC_ID_1}",
-          "input_tokens": 1000,
+          "input_tokens": 1300,
           "llm_backend": "google-native",
           "llm_provider": "test-provider",
-          "output_tokens": 130,
+          "output_tokens": 190,
           "started_at": "{TIMESTAMP}",
           "status": "completed",
           "sub_agents": [
@@ -73,7 +73,7 @@
               "total_tokens": 360
             }
           ],
-          "total_tokens": 1130
+          "total_tokens": 1490
         }
       ],
       "expected_agent_count": 1,


### PR DESCRIPTION
- Roll up sub-agent input/output/total tokens into parent execution overview
- Update integration test to assert rolled-up totals on parent and individual totals on each sub-agent
- Update orchestrator e2e golden file with new parent token values

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed token usage accounting in session details. Sub-agent execution token counts are now properly aggregated into parent execution summaries for accurate usage tracking across orchestrator patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->