### PR TITLE
Fix memory confidence compounding on review re-rating

### DIFF
--- a/docs/proposals/ack-in-review-dialog-design.md
+++ b/docs/proposals/ack-in-review-dialog-design.md
@@ -1,0 +1,163 @@
+# Move Acknowledge into Review Dialog
+
+**Status:** Final  
+**Related:** [Questions & decisions](ack-in-review-dialog-questions.md)
+
+## Overview
+
+Currently, "Acknowledge" (ack) and "Review" are two separate UX paths in the triage view:
+
+- **Ack** — inline icon button on the triage row, single click, no modal, no quality rating
+- **Review** — opens `CompleteReviewModal` with a 3-way quality rating plus optional feedback fields
+
+This proposal consolidates both into the review dialog. Every review interaction opens the same modal, which now includes a fourth "Acknowledge" option alongside the three quality ratings. The standalone "Ack" button is removed from the triage row.
+
+## Design Principles
+
+1. **Single review entry point** — All review decisions happen in one place (the review dialog). Reduces cognitive load.
+2. **Preserve ack semantics** — Acknowledge still means "I've seen this, no quality judgment." No metric pollution, no confidence adjustment.
+3. **Minimal backend changes** — The existing `acknowledge` action on `PATCH /sessions/review` stays unchanged. One backend addition: memory confidence is properly reversed when a rating is changed or removed.
+4. **Consistent across surfaces** — The same modal and options are available in triage, session list, session detail, and FinalAnalysisCard.
+
+## Architecture
+
+### Modal Layout
+
+The `CompleteReviewModal` gains a fourth radio option in the existing `RadioGroup`:
+
+| Value | Label | Icon | Description |
+|-------|-------|------|-------------|
+| `accurate` | Accurate | ThumbUp (green) | The investigation correctly identified the issue and root cause |
+| `partially_accurate` | Partially Accurate | ThumbsUpDown (warning) | Some findings were correct but missed key aspects |
+| `inaccurate` | Inaccurate | ThumbDown (red) | The investigation was wrong or misleading |
+| *(new)* `acknowledge` | Acknowledge | DoneAll (neutral) | I've reviewed this but won't judge investigation quality |
+
+**Conditional UI:** When "Acknowledge" is selected, feedback fields (action taken, investigation feedback) collapse/hide and the submit button relabels to "Acknowledge" (instead of "Complete Review").
+
+**Note on the `acknowledge` value:** This is NOT added to the `QUALITY_RATING` constant (since it's semantically not a quality rating). Instead, it uses a separate sentinel (e.g., `REVIEW_SELECTION.ACKNOWLEDGE = 'acknowledge'`) that the handler detects to dispatch `action: "acknowledge"` instead of `action: "complete"`. The radio group mixes true quality ratings with this action sentinel in the UI only.
+
+### ReviewCell for Acknowledged Sessions
+
+Currently, `ReviewCell` renders acknowledged sessions (reviewed + null `quality_rating`) as a non-interactive grey checkmark chip (`tabIndex={-1}`, `cursor: 'default'`). This changes to be clickable — clicking opens `CompleteReviewModal` so the user can upgrade from acknowledged to a quality rating (or re-acknowledge).
+
+The `getReviewModalMode` function in `types/api.ts` currently routes all `reviewed` sessions to EDIT mode. This must be updated to check `quality_rating`:
+- `reviewed` + has `quality_rating` → EDIT mode (existing `EditFeedbackModal`)
+- `reviewed` + null `quality_rating` (acknowledged) → COMPLETE mode (so user can rate or re-ack)
+
+### Bulk Actions
+
+The toolbar's separate "Ack All" and "Complete All" buttons merge into a single **"Review All"** button that opens the same modal (with all 4 options). The chosen action applies to all selected sessions.
+
+### FinalAnalysisCard
+
+A neutral acknowledge icon (e.g., `DoneAll`) is added alongside the existing inline thumb up/down shortcuts. Clicking it opens the review modal with "Acknowledge" pre-selected (`initialRating="acknowledge"`).
+
+### Auto-Claim Behavior
+
+No change. The backend already auto-claims on submit (not on modal open) for both `doComplete` and `doAcknowledge`. This remains unchanged.
+
+### Snackbars (Triage View)
+
+Existing differentiated snackbars remain, wired to the modal outcome:
+- Acknowledge → "Acknowledged" + Undo
+- Quality rating → rating chip + "Add note" + Undo
+
+### Data Flow
+
+1. User clicks ReviewCell chip (triage/session list) or inline icon (FinalAnalysisCard) → modal opens
+2. User selects one of four options
+3. If **Acknowledge** selected:
+   - Feedback fields hidden
+   - Submit button: "Acknowledge"
+   - API call: `PATCH /sessions/review` with `action: "acknowledge"`
+4. If **quality rating** selected:
+   - Feedback fields visible (optional)
+   - Submit button: "Complete Review"
+   - API call: `PATCH /sessions/review` with `action: "complete"`, `quality_rating: "..."`
+5. Backend handles auto-claim if session was in `needs_review`
+6. WebSocket event published → UI updates
+
+### Backend
+
+The `acknowledge` and `complete` actions already exist on the same endpoint — no new API routes needed. However, one backend change is required:
+
+**Memory confidence reset on rating change.** When a session's quality rating changes (re-rated or downgraded to acknowledge), the previous confidence adjustment must be reversed before applying the new one. New method in `pkg/memory/service.go`:
+
+```
+ReadjustConfidenceForRatingChange(ctx, project, sessionID, oldRating, newRating *QualityRating)
+```
+
+Logic:
+1. **Reverse old rating:**
+   - `accurate` → `confidence = confidence / 1.2` (approximate reversal; LEAST cap makes it imprecise for values that hit 1.0)
+   - `partially_accurate` → `confidence = confidence / 0.6`
+   - `inaccurate` → `deprecated = false` (confidence value was never changed)
+2. **Apply new rating (if non-nil):** same existing multipliers
+3. **If new rating is nil (acknowledge):** just reverse, done
+
+The handler (`handler_review.go`) is updated to pass old + new rating to this method on `update_feedback` and `acknowledge` actions where the session previously had a rating.
+
+## Affected Components
+
+| Component | Change |
+|-----------|--------|
+| `CompleteReviewModal` | Add "Acknowledge" radio option with description; conditional field collapse; dynamic submit button label |
+| `TriageSessionRow` | Remove ack `IconButton` from actions column |
+| `TriageGroupedList` | Remove "Ack All" button; rename "Complete All" → "Review All" |
+| `TriageView` | Remove `handleAcknowledge`; route modal ack through `handleReviewComplete`; update `handleBulkCompleteConfirm` to dispatch `acknowledge` action when selection is "acknowledge" |
+| `DashboardView` | Remove `onAcknowledge` / `onBulkAcknowledge` prop threading; update `handleTriageComplete` / `handleBulkTriageComplete` to detect "acknowledge" selection and call `updateReview` with `action: "acknowledge"` instead of `action: "complete"` |
+| `FinalAnalysisCard` | Add acknowledge icon (`DoneAll`) in the "Helpful?" pill alongside existing thumbs |
+| `EditFeedbackModal` | Add "Acknowledge" option (same as `CompleteReviewModal`); allow downgrading from rated → acknowledged |
+| `ReviewCell` | Make acknowledged sessions clickable (currently non-interactive: `tabIndex={-1}`, `cursor: 'default'`) so users can upgrade ack → rated |
+| `types/api.ts` | Update `getReviewModalMode` to route acknowledged sessions (reviewed + no `quality_rating`) to COMPLETE mode instead of EDIT |
+
+## Implementation Plan
+
+Two PRs, each independently shippable.
+
+### PR 1: Backend — Memory confidence reset on rating change
+
+Fixes a pre-existing bug where re-rating a session applies the new adjustment without reversing the old one. Also enables the upcoming "downgrade to acknowledge" flow.
+
+- Add `ReadjustConfidenceForRatingChange(ctx, project, sessionID, oldRating, newRating *QualityRating)` to `pkg/memory/service.go`
+- Update `handler_review.go` to call it when a session's rating changes (on `update_feedback` where rating differs, and on `acknowledge` where session previously had a rating)
+- The service layer already reads the current session state in `doUpdateFeedback`; extend `doAcknowledge` similarly to capture old rating
+- Unit tests for all transitions: accurate→inaccurate, accurate→ack, inaccurate→accurate, partially→ack, etc.
+
+### PR 2: Frontend — Consolidate acknowledge into review dialog
+
+All frontend changes as a single cohesive UX refactor.
+
+**Add acknowledge to CompleteReviewModal:**
+- Add a `REVIEW_SELECTION` constant with an `ACKNOWLEDGE` value for the radio group
+- Add fourth radio option with `DoneAll` icon and descriptive subtitle
+- Conditionally hide/collapse feedback fields when "Acknowledge" is selected
+- Dynamic submit button label: "Acknowledge" vs "Complete Review"
+- Update `onComplete` callback to handle the acknowledge value (callers detect it and dispatch `action: "acknowledge"` instead of `action: "complete"`)
+
+**Routing and ReviewCell:**
+- Update `getReviewModalMode` to route acknowledged sessions (reviewed + no quality_rating) to COMPLETE mode
+- Make `ReviewCell` clickable for acknowledged sessions
+
+**Remove standalone ack:**
+- Remove ack `IconButton` from `TriageSessionRow` (both `needs_review` and `in_progress` groups)
+- Remove `onAcknowledge` / `onBulkAcknowledge` handler chain and props through `TriageView` → `DashboardView`
+
+**Consolidate bulk actions:**
+- Remove "Ack All" toolbar button from `TriageGroupedList`
+- Rename "Complete All" → "Review All"
+
+**FinalAnalysisCard:**
+- Add `DoneAll` icon button in the "Helpful?" pill (rightmost, after thumb buttons)
+- Pass `initialRating="acknowledge"` when opening the review modal from it
+
+**EditFeedbackModal:**
+- Add "Acknowledge" as a radio option (same UI as `CompleteReviewModal`)
+- When switching from a quality rating to "Acknowledge", warn that this removes the rating
+- Update `onSave` handler to dispatch `action: "acknowledge"` when selected
+
+**Tests & cleanup:**
+- Update E2E tests in `test/e2e/review_workflow_test.go`
+- Update/remove frontend tests for the old ack button
+- Add tests for: acknowledge option in modal, conditional field collapse, bulk "Review All", acknowledged → rated upgrade via ReviewCell
+- Update ADR-0016 to note the UX consolidation

--- a/docs/proposals/ack-in-review-dialog-questions.md
+++ b/docs/proposals/ack-in-review-dialog-questions.md
@@ -1,0 +1,90 @@
+# Move Acknowledge into Review Dialog — Questions
+
+**Status:** Resolved — all decisions made  
+**Related:** [Design document](ack-in-review-dialog-design.md)
+
+Each question has options with trade-offs and a recommendation. Go through them one by one to form the design, then update the design document.
+
+---
+
+## Q1: How should "Acknowledge" be presented in the review dialog?
+
+The modal currently has a `RadioGroup` with three quality ratings. Acknowledge is semantically different — it's not a quality judgment. How it's visually integrated affects whether users perceive it as "a fourth rating" or "a separate action."
+
+### Option A: Fourth radio option in the same RadioGroup
+
+Add "Acknowledge" as a fourth `FormControlLabel` in the existing `RadioGroup`, visually separated (e.g., with a divider above it).
+
+- **Pro:** Simple implementation — just another radio option. Users scan one list of choices.
+- **Pro:** Clear that you must pick exactly one outcome before submitting.
+- **Con:** May conflate "I'm rating quality" with "I'm choosing not to rate." The grouping implies they're the same category.
+
+### Option B: Separate section below the ratings with its own button
+
+Keep the 3-option `RadioGroup` for quality ratings. Below (or above), add a distinct "Acknowledge" section with its own submit button (e.g., "Just Acknowledge — no quality judgment").
+
+- **Pro:** Visually distinct — makes it clear acknowledge is a different kind of action.
+- **Pro:** Can use a secondary/outlined button style to signal it's the lightweight path.
+- **Con:** Two submit paths in one dialog can confuse. Users might not notice it.
+- **Con:** More complex layout, especially on mobile.
+
+### Option C: Fourth radio option with conditional UI changes
+
+Like Option A (same RadioGroup), but when "Acknowledge" is selected, the feedback fields fade/collapse and the submit button label changes to "Acknowledge" (from "Complete Review").
+
+- **Pro:** Single selection mechanism — no confusion about which button to press.
+- **Pro:** Adaptive UI makes it obvious that acknowledge skips the detailed feedback step.
+- **Pro:** Maintains the "pick one, then submit" mental model.
+- **Con:** Slightly more complex than a plain fourth radio (conditional rendering).
+
+**Decision:** Option C — with a descriptive subtitle on the "Acknowledge" radio option (matching the pattern of the other three ratings) to clarify that it means "no quality judgment." E.g., *"I've reviewed this but won't judge investigation quality"*.
+
+_Considered and rejected: Option A (conflates rating with non-rating in a flat list), Option B (dual-submit paths confuse users)_
+
+---
+
+## Q2: What happens to bulk acknowledge?
+
+Currently, bulk "Ack All" is a toolbar button in `TriageGroupedList` for `needs_review` and `in_progress` groups. Without a standalone ack button, bulk ack needs a new home.
+
+### Option C: Merge "Ack All" and "Complete All" into a single "Review All" button
+
+Single bulk button opens the modal with all options (3 ratings + acknowledge). One dialog, one decision applied to all selected.
+
+- **Pro:** Reduces toolbar buttons. Cleaner UI.
+- **Pro:** Consistent with the per-session experience.
+- **Con:** Same "extra click" concern as Option B for pure acknowledge.
+
+**Decision:** Option C — merge both bulk buttons into a single "Review All" that opens the modal (with all 4 options including Acknowledge). Consistent with per-session flow. "Complete All" already required a modal, so the only net cost is that bulk-ack gains one extra click.
+
+_Considered and rejected: Option A (inconsistent — keeps a separate ack path for bulk only), Option B (same outcome as C but without consolidating the toolbar buttons)_
+
+---
+
+## Q3: Should ack from the modal still auto-claim unclaimed sessions?
+
+**Decision:** No change needed. The backend already auto-claims on submit (not on modal open). This behavior applies to both `doComplete` and `doAcknowledge` and remains unchanged by this proposal.
+
+---
+
+## Q4: Snackbar and undo behavior after acknowledging via modal
+
+**Decision:** No change needed. Keep existing differentiated snackbars (triage view only) — wire them to the modal outcome instead of the button source. "Acknowledged" + Undo for ack, rating chip + "Add note" + Undo for complete.
+
+---
+
+## Q5: Impact on FinalAnalysisCard inline review shortcuts
+
+`FinalAnalysisCard` on the session detail page has inline thumb up/down icon buttons that open the review modal with a pre-selected rating (`initialRating`). Should it also get an "acknowledge" shortcut?
+
+### Option A: Add an acknowledge icon button to FinalAnalysisCard
+
+Add a neutral icon (e.g., `DoneAll` or `CheckCircle`) alongside the thumbs that opens the review modal with "Acknowledge" pre-selected.
+
+- **Pro:** Consistency — acknowledge is available everywhere review is.
+- **Pro:** Quick path for detail-page reviewers who just want to ack.
+- **Con:** Adds visual clutter to the analysis card. Three buttons → four.
+
+**Decision:** Option A — add an acknowledge shortcut icon to `FinalAnalysisCard` for consistency. Acknowledge should be available everywhere review is.
+
+_Considered and rejected: Option B (inconsistency between surfaces), Option C (loses quick-rate convenience for power users)_

--- a/pkg/api/handler_review.go
+++ b/pkg/api/handler_review.go
@@ -48,15 +48,18 @@ func (s *Server) updateReviewHandler(c *echo.Context) error {
 
 	resp, updated := s.sessionService.UpdateReviewStatus(c.Request().Context(), req)
 
-	for _, session := range updated {
-		// Adjust memory confidence based on quality rating.
-		if s.memoryService != nil && session.QualityRating != nil {
+	for _, result := range updated {
+		session := result.Session
+
+		// Adjust memory confidence when a rating is added or changed.
+		if s.memoryService != nil && (result.PreviousRating != nil || session.QualityRating != nil) {
 			adjustCtx, adjustCancel := context.WithTimeout(context.Background(), 5*time.Second)
-			if err := s.memoryService.AdjustConfidenceForReview(
-				adjustCtx, "default", session.ID, *session.QualityRating,
+			if err := s.memoryService.ReadjustConfidenceForRatingChange(
+				adjustCtx, "default", session.ID,
+				result.PreviousRating, session.QualityRating,
 			); err != nil {
 				slog.Warn("Failed to adjust memory confidence on review",
-					"session_id", session.ID, "rating", *session.QualityRating, "error", err)
+					"session_id", session.ID, "error", err)
 			}
 			adjustCancel()
 		}
@@ -75,7 +78,8 @@ func (s *Server) updateReviewHandler(c *echo.Context) error {
 		pubCtx, pubCancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer pubCancel()
 
-		for _, session := range updated {
+		for _, result := range updated {
+			session := result.Session
 			payload := events.ReviewStatusPayload{
 				BasePayload: events.BasePayload{
 					Type:      events.EventTypeReviewStatus,

--- a/pkg/memory/service.go
+++ b/pkg/memory/service.go
@@ -367,6 +367,81 @@ func (s *Service) AdjustConfidenceForReview(ctx context.Context, project, sessio
 	}
 }
 
+// ReadjustConfidenceForRatingChange reverses the confidence effect of oldRating
+// and then applies newRating. Use this when a session's quality rating changes
+// (e.g. update_feedback with a different rating, or downgrade to acknowledge).
+//
+// Reversal is approximate: values that hit the 1.0 cap during the original
+// accurate boost cannot be precisely restored.
+//
+//   - oldRating nil, newRating non-nil: first-time rating (delegates to AdjustConfidenceForReview)
+//   - oldRating non-nil, newRating nil: rating removed (reverse only)
+//   - both non-nil and different: reverse old, apply new
+//   - both nil, or equal: no-op
+func (s *Service) ReadjustConfidenceForRatingChange(ctx context.Context, project, sessionID string, oldRating, newRating *alertsession.QualityRating) error {
+	if oldRating == nil && newRating == nil {
+		return nil
+	}
+	if oldRating != nil && newRating != nil && *oldRating == *newRating {
+		return nil
+	}
+
+	if oldRating != nil {
+		if err := s.reverseConfidenceAdjustment(ctx, project, sessionID, *oldRating); err != nil {
+			return fmt.Errorf("reverse old rating %q for session %s: %w", *oldRating, sessionID, err)
+		}
+	}
+
+	if newRating != nil {
+		return s.AdjustConfidenceForReview(ctx, project, sessionID, *newRating)
+	}
+	return nil
+}
+
+// reverseConfidenceAdjustment undoes the effect of a previous AdjustConfidenceForReview call.
+func (s *Service) reverseConfidenceAdjustment(ctx context.Context, project, sessionID string, rating alertsession.QualityRating) error {
+	switch rating {
+	case alertsession.QualityRatingAccurate:
+		_, err := s.db.ExecContext(ctx, `
+			UPDATE investigation_memories
+			SET confidence = confidence / 1.2,
+			    updated_at = NOW()
+			WHERE source_session_id = $1 AND project = $2 AND deprecated = false
+		`, sessionID, project)
+		if err != nil {
+			return fmt.Errorf("reverse accurate boost for session %s: %w", sessionID, err)
+		}
+		return nil
+
+	case alertsession.QualityRatingPartiallyAccurate:
+		_, err := s.db.ExecContext(ctx, `
+			UPDATE investigation_memories
+			SET confidence = LEAST(confidence / 0.6, 1.0),
+			    updated_at = NOW()
+			WHERE source_session_id = $1 AND project = $2 AND deprecated = false
+		`, sessionID, project)
+		if err != nil {
+			return fmt.Errorf("reverse partial degradation for session %s: %w", sessionID, err)
+		}
+		return nil
+
+	case alertsession.QualityRatingInaccurate:
+		_, err := s.db.ExecContext(ctx, `
+			UPDATE investigation_memories
+			SET deprecated = false,
+			    updated_at = NOW()
+			WHERE source_session_id = $1 AND project = $2 AND deprecated = true
+		`, sessionID, project)
+		if err != nil {
+			return fmt.Errorf("reverse deprecation for session %s: %w", sessionID, err)
+		}
+		return nil
+
+	default:
+		return fmt.Errorf("unknown quality rating %q", rating)
+	}
+}
+
 // GetByID returns a single memory by ID.
 func (s *Service) GetByID(ctx context.Context, memoryID string) (*Detail, error) {
 	m, err := s.entClient.InvestigationMemory.Get(ctx, memoryID)

--- a/pkg/memory/service_crud_integration_test.go
+++ b/pkg/memory/service_crud_integration_test.go
@@ -333,6 +333,212 @@ func TestService_AdjustConfidenceForReview(t *testing.T) {
 }
 
 // ─────────────────────────────────────────────────────────────
+// ReadjustConfidenceForRatingChange
+// ─────────────────────────────────────────────────────────────
+
+func ratingPtr(r alertsession.QualityRating) *alertsession.QualityRating { return &r }
+
+func TestService_ReadjustConfidenceForRatingChange(t *testing.T) {
+	tests := []struct {
+		name      string
+		oldRating *alertsession.QualityRating
+		newRating *alertsession.QualityRating
+		// original = before any adjustment; preReadjust = after old rating applied; final = after readjust
+		check func(t *testing.T, original, preReadjust, final float64, deprecated bool)
+	}{
+		{
+			name:      "accurate to inaccurate deprecates",
+			oldRating: ratingPtr(alertsession.QualityRatingAccurate),
+			newRating: ratingPtr(alertsession.QualityRatingInaccurate),
+			check: func(t *testing.T, _, _, _ float64, deprecated bool) {
+				assert.True(t, deprecated)
+			},
+		},
+		{
+			name:      "accurate to partially_accurate",
+			oldRating: ratingPtr(alertsession.QualityRatingAccurate),
+			newRating: ratingPtr(alertsession.QualityRatingPartiallyAccurate),
+			check: func(t *testing.T, original, _, final float64, deprecated bool) {
+				assert.InDelta(t, original*0.6, final, 0.01)
+				assert.False(t, deprecated)
+			},
+		},
+		{
+			name:      "accurate to nil reverses boost",
+			oldRating: ratingPtr(alertsession.QualityRatingAccurate),
+			newRating: nil,
+			check: func(t *testing.T, original, _, final float64, deprecated bool) {
+				assert.InDelta(t, original, final, 0.01)
+				assert.False(t, deprecated)
+			},
+		},
+		{
+			name:      "partially_accurate to accurate",
+			oldRating: ratingPtr(alertsession.QualityRatingPartiallyAccurate),
+			newRating: ratingPtr(alertsession.QualityRatingAccurate),
+			check: func(t *testing.T, original, _, final float64, deprecated bool) {
+				assert.InDelta(t, original*1.2, final, 0.01)
+				assert.False(t, deprecated)
+			},
+		},
+		{
+			name:      "inaccurate to accurate un-deprecates and boosts",
+			oldRating: ratingPtr(alertsession.QualityRatingInaccurate),
+			newRating: ratingPtr(alertsession.QualityRatingAccurate),
+			check: func(t *testing.T, original, _, final float64, deprecated bool) {
+				assert.InDelta(t, original*1.2, final, 0.01)
+				assert.False(t, deprecated)
+			},
+		},
+		{
+			name:      "nil to accurate is first-time rating",
+			oldRating: nil,
+			newRating: ratingPtr(alertsession.QualityRatingAccurate),
+			check: func(t *testing.T, original, _, final float64, deprecated bool) {
+				assert.InDelta(t, original*1.2, final, 0.01)
+				assert.False(t, deprecated)
+			},
+		},
+		{
+			name:      "same rating is no-op",
+			oldRating: ratingPtr(alertsession.QualityRatingAccurate),
+			newRating: ratingPtr(alertsession.QualityRatingAccurate),
+			check: func(t *testing.T, _, preReadjust, final float64, deprecated bool) {
+				assert.InDelta(t, preReadjust, final, 0.001)
+				assert.False(t, deprecated)
+			},
+		},
+		{
+			name:      "partially_accurate to nil reverses degradation",
+			oldRating: ratingPtr(alertsession.QualityRatingPartiallyAccurate),
+			newRating: nil,
+			check: func(t *testing.T, original, _, final float64, deprecated bool) {
+				assert.InDelta(t, original, final, 0.01)
+				assert.False(t, deprecated)
+			},
+		},
+		{
+			name:      "inaccurate to nil un-deprecates",
+			oldRating: ratingPtr(alertsession.QualityRatingInaccurate),
+			newRating: nil,
+			check: func(t *testing.T, original, _, final float64, deprecated bool) {
+				assert.InDelta(t, original, final, 0.01)
+				assert.False(t, deprecated)
+			},
+		},
+		{
+			name:      "both nil is no-op",
+			oldRating: nil,
+			newRating: nil,
+			check: func(t *testing.T, original, _, final float64, deprecated bool) {
+				assert.InDelta(t, original, final, 0.001)
+				assert.False(t, deprecated)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc, sessionID, memID := seedMemory(t)
+			ctx := t.Context()
+
+			original, err := svc.GetByID(ctx, memID)
+			require.NoError(t, err)
+
+			// Apply old rating first (to set up the pre-condition).
+			if tt.oldRating != nil {
+				err = svc.AdjustConfidenceForReview(ctx, "default", sessionID, *tt.oldRating)
+				require.NoError(t, err)
+			}
+
+			preReadjust, err := svc.GetByID(ctx, memID)
+			require.NoError(t, err)
+
+			// Now readjust from old → new.
+			err = svc.ReadjustConfidenceForRatingChange(ctx, "default", sessionID, tt.oldRating, tt.newRating)
+			require.NoError(t, err)
+
+			updated, err := svc.GetByID(ctx, memID)
+			require.NoError(t, err)
+			tt.check(t, original.Confidence, preReadjust.Confidence, updated.Confidence, updated.Deprecated)
+		})
+	}
+
+	t.Run("capped value reversal is imprecise", func(t *testing.T) {
+		svc, sessionID := newTestService(t, []float32{1, 0, 0})
+		ctx := t.Context()
+
+		// Create a memory with high initial confidence (0.9) that will hit the 1.0 cap.
+		err := svc.ApplyFeedbackReflectorActions(ctx, "default", sessionID, nil, nil, &memory.ReflectorResult{
+			Create: []memory.ReflectorCreateAction{
+				{Content: "High confidence memory", Category: "procedural", Valence: "positive"},
+			},
+		})
+		require.NoError(t, err)
+
+		memories, err := svc.FindSimilar(ctx, "default", "anything", 1)
+		require.NoError(t, err)
+		require.Len(t, memories, 1)
+		memID := memories[0].ID
+		assert.InDelta(t, 0.9, memories[0].Confidence, 0.01)
+
+		// Apply accurate → caps at 1.0 (0.9 * 1.2 = 1.08, LEAST → 1.0).
+		err = svc.AdjustConfidenceForReview(ctx, "default", sessionID, alertsession.QualityRatingAccurate)
+		require.NoError(t, err)
+
+		capped, err := svc.GetByID(ctx, memID)
+		require.NoError(t, err)
+		assert.InDelta(t, 1.0, capped.Confidence, 0.01)
+
+		// Reverse: 1.0 / 1.2 ≈ 0.833, NOT the original 0.9.
+		err = svc.ReadjustConfidenceForRatingChange(ctx, "default", sessionID,
+			ratingPtr(alertsession.QualityRatingAccurate), nil)
+		require.NoError(t, err)
+
+		reversed, err := svc.GetByID(ctx, memID)
+		require.NoError(t, err)
+		assert.InDelta(t, 1.0/1.2, reversed.Confidence, 0.01)
+		assert.Greater(t, 0.9-reversed.Confidence, 0.05, "capped reversal cannot restore original 0.9")
+	})
+
+	t.Run("adjusts all memories for a session", func(t *testing.T) {
+		svc, sessionID := newTestService(t, []float32{1, 0, 0})
+		ctx := t.Context()
+
+		err := svc.ApplyReflectorActions(ctx, "default", sessionID, nil, nil, &memory.ReflectorResult{
+			Create: []memory.ReflectorCreateAction{
+				{Content: "First memory", Category: "procedural", Valence: "positive"},
+				{Content: "Second memory", Category: "episodic", Valence: "neutral"},
+			},
+		})
+		require.NoError(t, err)
+
+		all, err := svc.GetBySessionID(ctx, sessionID)
+		require.NoError(t, err)
+		require.Len(t, all, 2)
+		origConf := [2]float64{all[0].Confidence, all[1].Confidence}
+
+		// Apply accurate, then readjust to partially_accurate.
+		err = svc.AdjustConfidenceForReview(ctx, "default", sessionID, alertsession.QualityRatingAccurate)
+		require.NoError(t, err)
+
+		err = svc.ReadjustConfidenceForRatingChange(ctx, "default", sessionID,
+			ratingPtr(alertsession.QualityRatingAccurate),
+			ratingPtr(alertsession.QualityRatingPartiallyAccurate))
+		require.NoError(t, err)
+
+		updated, err := svc.GetBySessionID(ctx, sessionID)
+		require.NoError(t, err)
+		require.Len(t, updated, 2)
+		for i, m := range updated {
+			assert.InDelta(t, origConf[i]*0.6, m.Confidence, 0.01,
+				"memory %d should reflect partially_accurate adjustment", i)
+			assert.False(t, m.Deprecated)
+		}
+	})
+}
+
+// ─────────────────────────────────────────────────────────────
 // ApplyFeedbackReflectorActions (fixed 0.9 confidence)
 // ─────────────────────────────────────────────────────────────
 

--- a/pkg/services/session_service_review.go
+++ b/pkg/services/session_service_review.go
@@ -22,7 +22,7 @@ import (
 // iterations so bulk operations abort early if the caller disconnects.
 // Returns the per-session results and the list of successfully updated
 // ent sessions (for event publishing).
-func (s *SessionService) UpdateReviewStatus(ctx context.Context, req models.UpdateReviewRequest) (models.UpdateReviewResponse, []*ent.AlertSession) {
+func (s *SessionService) UpdateReviewStatus(ctx context.Context, req models.UpdateReviewRequest) (models.UpdateReviewResponse, []ReviewResult) {
 	if err := validateReviewRequest(req); err != nil {
 		results := make([]models.UpdateReviewResult, len(req.SessionIDs))
 		for i, sid := range req.SessionIDs {
@@ -32,7 +32,7 @@ func (s *SessionService) UpdateReviewStatus(ctx context.Context, req models.Upda
 	}
 
 	results := make([]models.UpdateReviewResult, 0, len(req.SessionIDs))
-	var updated []*ent.AlertSession
+	var updated []ReviewResult
 	for _, sid := range req.SessionIDs {
 		if err := ctx.Err(); err != nil {
 			results = append(results, models.UpdateReviewResult{
@@ -42,7 +42,7 @@ func (s *SessionService) UpdateReviewStatus(ctx context.Context, req models.Upda
 			})
 			continue
 		}
-		session, err := s.updateSingleReview(sid, req)
+		result, err := s.updateSingleReview(sid, req)
 		if err != nil {
 			results = append(results, models.UpdateReviewResult{
 				SessionID: sid,
@@ -54,7 +54,7 @@ func (s *SessionService) UpdateReviewStatus(ctx context.Context, req models.Upda
 				SessionID: sid,
 				Success:   true,
 			})
-			updated = append(updated, session)
+			updated = append(updated, result)
 
 			if req.QualityRating != nil {
 				metrics.ReviewsCompletedTotal.WithLabelValues(*req.QualityRating).Inc()
@@ -103,11 +103,18 @@ func validateReviewRequest(req models.UpdateReviewRequest) error {
 	return nil
 }
 
+// ReviewResult holds the outcome of a single review status update, including
+// the previous quality rating so callers can adjust memory confidence correctly.
+type ReviewResult struct {
+	Session        *ent.AlertSession
+	PreviousRating *alertsession.QualityRating
+}
+
 // updateSingleReview performs an atomic compare-and-transition on one session's
 // review_status. Returns the updated session or ErrConflict if the precondition
 // (expected current review_status) was not met.
 // Caller must validate req via validateReviewRequest before calling.
-func (s *SessionService) updateSingleReview(sessionID string, req models.UpdateReviewRequest) (*ent.AlertSession, error) {
+func (s *SessionService) updateSingleReview(sessionID string, req models.UpdateReviewRequest) (ReviewResult, error) {
 	writeCtx, cancel := context.WithTimeoutCause(
 		context.Background(), 5*time.Second,
 		fmt.Errorf("update review status for %s: db write timed out", sessionID),
@@ -116,16 +123,17 @@ func (s *SessionService) updateSingleReview(sessionID string, req models.UpdateR
 
 	tx, err := s.client.Tx(writeCtx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to begin transaction: %w", err)
+		return ReviewResult{}, fmt.Errorf("failed to begin transaction: %w", err)
 	}
 	defer func() { _ = tx.Rollback() }()
 
 	now := time.Now()
+	var previousRating *alertsession.QualityRating
 
 	switch models.ReviewAction(req.Action) {
 	case models.ReviewActionClaim:
 		if err := s.doClaim(writeCtx, tx, sessionID, req.Actor, now); err != nil {
-			return nil, err
+			return ReviewResult{}, err
 		}
 
 	case models.ReviewActionUnclaim:
@@ -139,22 +147,22 @@ func (s *SessionService) updateSingleReview(sessionID string, req models.UpdateR
 			ClearAssignedAt().
 			Save(writeCtx)
 		if err != nil {
-			return nil, fmt.Errorf("failed to unclaim session: %w", err)
+			return ReviewResult{}, fmt.Errorf("failed to unclaim session: %w", err)
 		}
 		if affected == 0 {
-			return nil, ErrConflict
+			return ReviewResult{}, ErrConflict
 		}
 		if err := s.insertActivity(writeCtx, tx, sessionID, req.Actor,
 			sessionreviewactivity.ActionUnclaim,
 			ptrFromStatus(sessionreviewactivity.FromStatusInProgress),
 			sessionreviewactivity.ToStatusNeedsReview,
 			nil, nil, nil, now); err != nil {
-			return nil, err
+			return ReviewResult{}, err
 		}
 
 	case models.ReviewActionComplete:
 		if err := s.doComplete(writeCtx, tx, sessionID, req.Actor, *req.QualityRating, req.ActionTaken, req.InvestigationFeedback, now); err != nil {
-			return nil, err
+			return ReviewResult{}, err
 		}
 
 	case models.ReviewActionReopen:
@@ -172,28 +180,30 @@ func (s *SessionService) updateSingleReview(sessionID string, req models.UpdateR
 			ClearInvestigationFeedback().
 			Save(writeCtx)
 		if err != nil {
-			return nil, fmt.Errorf("failed to reopen session: %w", err)
+			return ReviewResult{}, fmt.Errorf("failed to reopen session: %w", err)
 		}
 		if affected == 0 {
-			return nil, ErrConflict
+			return ReviewResult{}, ErrConflict
 		}
 		if err := s.insertActivity(writeCtx, tx, sessionID, req.Actor,
 			sessionreviewactivity.ActionReopen,
 			ptrFromStatus(sessionreviewactivity.FromStatusReviewed),
 			sessionreviewactivity.ToStatusNeedsReview,
 			nil, nil, nil, now); err != nil {
-			return nil, err
+			return ReviewResult{}, err
 		}
 
 	case models.ReviewActionUpdateFeedback:
 		// Read current session to build a full post-update snapshot for the activity log.
 		current, err := tx.AlertSession.Get(writeCtx, sessionID)
 		if err != nil {
-			return nil, fmt.Errorf("failed to read session for feedback update: %w", err)
+			return ReviewResult{}, fmt.Errorf("failed to read session for feedback update: %w", err)
 		}
 		if current.ReviewStatus == nil || *current.ReviewStatus != alertsession.ReviewStatusReviewed {
-			return nil, ErrConflict
+			return ReviewResult{}, ErrConflict
 		}
+
+		previousRating = current.QualityRating
 
 		update := tx.AlertSession.Update().
 			Where(
@@ -219,10 +229,10 @@ func (s *SessionService) updateSingleReview(sessionID string, req models.UpdateR
 		}
 		affected, err := update.Save(writeCtx)
 		if err != nil {
-			return nil, fmt.Errorf("failed to update feedback: %w", err)
+			return ReviewResult{}, fmt.Errorf("failed to update feedback: %w", err)
 		}
 		if affected == 0 {
-			return nil, ErrConflict
+			return ReviewResult{}, ErrConflict
 		}
 
 		// Merge request values with existing session values for a complete snapshot.
@@ -249,25 +259,25 @@ func (s *SessionService) updateSingleReview(sessionID string, req models.UpdateR
 			ptrFromStatus(sessionreviewactivity.FromStatusReviewed),
 			sessionreviewactivity.ToStatusReviewed,
 			snapshotRating, snapshotActionTaken, snapshotFeedback, now); err != nil {
-			return nil, err
+			return ReviewResult{}, err
 		}
 
 	case models.ReviewActionAcknowledge:
 		if err := s.doAcknowledge(writeCtx, tx, sessionID, req.Actor, now); err != nil {
-			return nil, err
+			return ReviewResult{}, err
 		}
 	}
 
 	session, err := tx.AlertSession.Get(writeCtx, sessionID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read updated session: %w", err)
+		return ReviewResult{}, fmt.Errorf("failed to read updated session: %w", err)
 	}
 
 	if err := tx.Commit(); err != nil {
-		return nil, fmt.Errorf("failed to commit review status update: %w", err)
+		return ReviewResult{}, fmt.Errorf("failed to commit review status update: %w", err)
 	}
 
-	return session, nil
+	return ReviewResult{Session: session, PreviousRating: previousRating}, nil
 }
 
 // doClaim handles both initial claim (needs_review -> in_progress) and

--- a/pkg/services/session_service_review_test.go
+++ b/pkg/services/session_service_review_test.go
@@ -87,6 +87,17 @@ func doReview(t *testing.T, service *SessionService, id string, req models.Updat
 	require.Len(t, resp.Results, 1)
 	require.True(t, resp.Results[0].Success, "expected success, got error: %s", resp.Results[0].Error)
 	require.Len(t, updated, 1)
+	return updated[0].Session
+}
+
+// doReviewResult is like doReview but returns the full reviewResult (including PreviousRating).
+func doReviewResult(t *testing.T, service *SessionService, id string, req models.UpdateReviewRequest) ReviewResult {
+	t.Helper()
+	req.SessionIDs = []string{id}
+	resp, updated := service.UpdateReviewStatus(context.Background(), req)
+	require.Len(t, resp.Results, 1)
+	require.True(t, resp.Results[0].Success, "expected success, got error: %s", resp.Results[0].Error)
+	require.Len(t, updated, 1)
 	return updated[0]
 }
 
@@ -627,7 +638,7 @@ func TestSessionService_UpdateReviewStatus(t *testing.T) {
 		assert.False(t, resp.Results[1].Success)
 		assert.NotEmpty(t, resp.Results[1].Error)
 		assert.Len(t, updated, 1)
-		assert.Equal(t, goodID, updated[0].ID)
+		assert.Equal(t, goodID, updated[0].Session.ID)
 	})
 
 	t.Run("empty session IDs returns empty results", func(t *testing.T) {
@@ -638,6 +649,84 @@ func TestSessionService_UpdateReviewStatus(t *testing.T) {
 		})
 		assert.Empty(t, resp.Results)
 		assert.Empty(t, updated)
+	})
+}
+
+func TestUpdateReviewStatus_PreviousRating(t *testing.T) {
+	client := testdb.NewTestClient(t)
+	service := setupTestSessionService(t, client.Client)
+
+	t.Run("complete sets nil PreviousRating", func(t *testing.T) {
+		id := seedReviewSession(t, service, "needs_review", "")
+		rating := "accurate"
+		result := doReviewResult(t, service, id, models.UpdateReviewRequest{
+			Action:        "complete",
+			Actor:         "alice@test.com",
+			QualityRating: &rating,
+		})
+		assert.Nil(t, result.PreviousRating)
+		assert.NotNil(t, result.Session.QualityRating)
+	})
+
+	t.Run("update_feedback with rating change populates PreviousRating", func(t *testing.T) {
+		id := seedReviewSession(t, service, "needs_review", "")
+		rating := "accurate"
+		doReview(t, service, id, models.UpdateReviewRequest{
+			Action:        "complete",
+			Actor:         "alice@test.com",
+			QualityRating: &rating,
+		})
+
+		newRating := "inaccurate"
+		result := doReviewResult(t, service, id, models.UpdateReviewRequest{
+			Action:        "update_feedback",
+			Actor:         "alice@test.com",
+			QualityRating: &newRating,
+		})
+		require.NotNil(t, result.PreviousRating)
+		assert.Equal(t, alertsession.QualityRatingAccurate, *result.PreviousRating)
+		require.NotNil(t, result.Session.QualityRating)
+		assert.Equal(t, alertsession.QualityRatingInaccurate, *result.Session.QualityRating)
+	})
+
+	t.Run("update_feedback text only keeps PreviousRating matching current", func(t *testing.T) {
+		id := seedReviewSession(t, service, "needs_review", "")
+		rating := "partially_accurate"
+		doReview(t, service, id, models.UpdateReviewRequest{
+			Action:        "complete",
+			Actor:         "alice@test.com",
+			QualityRating: &rating,
+		})
+
+		note := "updated note"
+		result := doReviewResult(t, service, id, models.UpdateReviewRequest{
+			Action:      "update_feedback",
+			Actor:       "alice@test.com",
+			ActionTaken: &note,
+		})
+		require.NotNil(t, result.PreviousRating)
+		assert.Equal(t, alertsession.QualityRatingPartiallyAccurate, *result.PreviousRating)
+		require.NotNil(t, result.Session.QualityRating)
+		assert.Equal(t, alertsession.QualityRatingPartiallyAccurate, *result.Session.QualityRating)
+	})
+
+	t.Run("acknowledge sets nil PreviousRating", func(t *testing.T) {
+		id := seedReviewSession(t, service, "needs_review", "")
+		result := doReviewResult(t, service, id, models.UpdateReviewRequest{
+			Action: "acknowledge",
+			Actor:  "alice@test.com",
+		})
+		assert.Nil(t, result.PreviousRating)
+		assert.Nil(t, result.Session.QualityRating)
+	})
+
+	t.Run("claim sets nil PreviousRating", func(t *testing.T) {
+		id := seedReviewSession(t, service, "needs_review", "")
+		result := doReviewResult(t, service, id, models.UpdateReviewRequest{
+			Action: "claim",
+			Actor:  "alice@test.com",
+		})
+		assert.Nil(t, result.PreviousRating)
 	})
 }
 


### PR DESCRIPTION
- Add ReadjustConfidenceForRatingChange to reverse the old rating's confidence effect before applying the new one
- Thread PreviousRating through ReviewResult so the handler knows what to reverse on update_feedback
- Replace unconditional AdjustConfidenceForReview in handler with the new readjust method that short-circuits when rating is unchanged
- Add integration tests for all rating transitions and multi-memory bulk adjustment
- Include ack-in-review-dialog design proposals

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Acknowledge" option to the review dialog as a fourth radio choice
  * Acknowledge icon now visible on final analysis cards
  * Consolidated bulk review actions into a single "Review All" button
  * Review decisions for acknowledged sessions can now be upgraded or downgraded

<!-- end of auto-generated comment: release notes by coderabbit.ai -->