### PR TITLE
Default Anthropic/VertexAI providers to Claude Sonnet 5

### DIFF
--- a/deploy/config/llm-providers.yaml.example
+++ b/deploy/config/llm-providers.yaml.example
@@ -90,12 +90,19 @@ llm_providers:
 # ANTHROPIC / CLAUDE PROVIDERS
 # =============================================================================
 
-  # Claude Sonnet 4.6 for balanced performance (default)
+  # Claude Sonnet 5 for balanced performance (default)
+  claude-sonnet-5:
+    type: anthropic
+    model: claude-sonnet-5
+    api_key_env: ANTHROPIC_API_KEY
+    max_tool_result_tokens: 950000  # Conservative for 1M context
+
+  # Claude Sonnet 4.6 (previous generation, pinned)
   claude-sonnet-4-6:
     type: anthropic
     model: claude-sonnet-4-6-20260217
     api_key_env: ANTHROPIC_API_KEY
-    max_tool_result_tokens: 900000  # Conservative for 1M context (beta)
+    max_tool_result_tokens: 900000  # Conservative for 1M context
 
   # Claude Opus for maximum capability
   claude-opus:
@@ -133,13 +140,13 @@ llm_providers:
 # VERTEX AI PROVIDERS (GCP)
 # =============================================================================
 
-  # Claude Sonnet 4.6 on Vertex AI
+  # Claude Sonnet 5 on Vertex AI
   vertexai-claude-sonnet:
     type: vertexai
-    model: claude-sonnet-4-6@20260217
+    model: claude-sonnet-5
     project_env: GCP_PROJECT
     location_env: GCP_LOCATION
-    max_tool_result_tokens: 900000  # Conservative for 1M context (beta)
+    max_tool_result_tokens: 950000  # Conservative for 1M context
 
   # Gemini on Vertex AI
   vertexai-gemini-pro:

--- a/llm-service/llm/providers/langchain_provider.py
+++ b/llm-service/llm/providers/langchain_provider.py
@@ -10,6 +10,7 @@ import enum
 import json
 import logging
 import os
+import re
 import uuid
 from typing import AsyncIterator, Dict, List, Optional, Tuple
 
@@ -111,14 +112,26 @@ class LangChainProvider(LLMProvider):
             "reasoning": {"effort": "high", "summary": "auto"},
         }
 
-    @staticmethod
-    def _get_anthropic_thinking_kwargs(_model: str) -> dict:
-        """Return kwargs to enable extended thinking for Claude models.
+    # Matches bare-major-version-5 Claude model families (e.g. claude-sonnet-5,
+    # claude-sonnet-5-20260101, claude-fable-5). These generations only support
+    # adaptive thinking; the legacy manual budget_tokens control returns a 400.
+    # Does NOT match minor releases like claude-sonnet-4-5 (still on manual thinking).
+    _ADAPTIVE_ONLY_THINKING_RE = re.compile(r"claude-[a-z]+-5(?:-|$)")
 
-        Extended thinking is enabled by default. budget_tokens must be
-        less than max_tokens.  _model is accepted (but currently unused)
-        to match the signature of the other _get_*_kwargs helpers.
+    @classmethod
+    def _get_anthropic_thinking_kwargs(cls, model: str) -> dict:
+        """Return kwargs to enable thinking for Claude models.
+
+        budget_tokens must be less than max_tokens. Claude Sonnet 5 (and other
+        5th-generation models) removed manual budget_tokens thinking in favor
+        of always-on adaptive thinking; passing budget_tokens to those models
+        returns a 400 error, so they get the adaptive form instead.
         """
+        if cls._ADAPTIVE_ONLY_THINKING_RE.search(model.lower()):
+            return {
+                "thinking": {"type": "adaptive"},
+                "max_tokens": 64000,
+            }
         return {
             "thinking": {"type": "enabled", "budget_tokens": 32000},
             "max_tokens": 64000,

--- a/llm-service/tests/test_langchain_provider.py
+++ b/llm-service/tests/test_langchain_provider.py
@@ -174,15 +174,25 @@ class TestLangChainProviderReasoningConfig:
     def test_openai_no_reasoning(self, model):
         assert LangChainProvider._get_openai_reasoning_kwargs(model) == {}
 
-    # --- Anthropic: thinking enabled for all models ---
+    # --- Anthropic: manual budget-based thinking for pre-5th-gen models ---
     @pytest.mark.parametrize("model", [
         "claude-sonnet-4-5-20250929", "claude-opus-4-6",
-        "claude-haiku-4-5-20251001", "claude-sonnet-5-20260101",
+        "claude-haiku-4-5-20251001", "claude-sonnet-4-6-20260217",
     ])
     def test_anthropic_thinking(self, model):
         result = LangChainProvider._get_anthropic_thinking_kwargs(model)
         assert result["thinking"]["type"] == "enabled"
         assert result["thinking"]["budget_tokens"] == 32000
+        assert result["max_tokens"] == 64000
+
+    # --- Anthropic: 5th-gen models only support adaptive thinking (manual
+    # budget_tokens returns a 400 error on these) ---
+    @pytest.mark.parametrize("model", [
+        "claude-sonnet-5", "claude-sonnet-5-20260101",
+    ])
+    def test_anthropic_adaptive_thinking(self, model):
+        result = LangChainProvider._get_anthropic_thinking_kwargs(model)
+        assert result["thinking"] == {"type": "adaptive"}
         assert result["max_tokens"] == 64000
 
 

--- a/pkg/config/builtin.go
+++ b/pkg/config/builtin.go
@@ -274,9 +274,9 @@ func initBuiltinLLMProviders() map[string]LLMProviderConfig {
 		// --- Anthropic ---
 		"anthropic-default": {
 			Type:                LLMProviderTypeAnthropic,
-			Model:               "claude-sonnet-4-6-20260217",
+			Model:               "claude-sonnet-5", // Dateless canonical model ID
 			APIKeyEnv:           "ANTHROPIC_API_KEY",
-			MaxToolResultTokens: 900000, // Conservative for 1M context (beta)
+			MaxToolResultTokens: 950000, // Conservative for 1M context (GA)
 		},
 
 		// --- xAI ---
@@ -290,10 +290,10 @@ func initBuiltinLLMProviders() map[string]LLMProviderConfig {
 		// --- Vertex AI ---
 		"vertexai-default": {
 			Type:                LLMProviderTypeVertexAI,
-			Model:               "claude-sonnet-4-6",     // Claude Sonnet 4.6 on Vertex AI
+			Model:               "claude-sonnet-5",       // Claude Sonnet 5 on Vertex AI
 			ProjectEnv:          "GOOGLE_CLOUD_PROJECT",  // Standard GCP project ID env var
 			LocationEnv:         "GOOGLE_CLOUD_LOCATION", // Standard GCP location env var
-			MaxToolResultTokens: 900000,                  // Conservative for 1M context (beta)
+			MaxToolResultTokens: 950000,                  // Conservative for 1M context (GA)
 		},
 	}
 }

--- a/pkg/config/builtin_test.go
+++ b/pkg/config/builtin_test.go
@@ -282,7 +282,7 @@ func TestBuiltinLLMProviders(t *testing.T) {
 			name:          "anthropic-default",
 			providerID:    "anthropic-default",
 			wantType:      LLMProviderTypeAnthropic,
-			wantMinTokens: 800000,
+			wantMinTokens: 900000,
 			checkAPIKey:   true,
 		},
 		{
@@ -338,7 +338,7 @@ func TestBuiltinLLMProviders(t *testing.T) {
 			name:          "vertexai-default",
 			providerID:    "vertexai-default",
 			wantType:      LLMProviderTypeVertexAI,
-			wantMinTokens: 800000,
+			wantMinTokens: 900000,
 			checkAPIKey:   false, // VertexAI uses ProjectEnv/LocationEnv
 		},
 	}


### PR DESCRIPTION
- Point anthropic-default and vertexai-default at claude-sonnet-5 (GA 1M context, no beta header needed), bumping max_tool_result_tokens to 950000
- Fix _get_anthropic_thinking_kwargs: 5th-gen Claude models (e.g. Sonnet 5) removed manual budget_tokens thinking in favor of always-on adaptive thinking, and now return a 400 error for the old manual form. Detect these models and send thinking: {type: adaptive} instead
- Update deploy/config/llm-providers.yaml.example with a pinned claude-sonnet-4-6 entry alongside the new default

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated default Anthropic and Vertex AI Claude configurations to use Claude Sonnet 5 with higher tool-result token limits.
  * Added support for adaptive thinking behavior on newer Claude 5 models.

* **Bug Fixes**
  * Improved model handling so 5th-generation Anthropic models use the appropriate reasoning mode automatically.

* **Tests**
  * Updated configuration checks to reflect the new token limits.
  * Added coverage for adaptive thinking on Claude 5 models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->