### PR TITLE
Surface provider-fallback badges on parent timeline nodes

### DIFF
--- a/web/dashboard/src/components/session/ConversationTimeline.tsx
+++ b/web/dashboard/src/components/session/ConversationTimeline.tsx
@@ -17,6 +17,7 @@ import {
   KeyboardDoubleArrowDown,
   AccountTree,
   Forum,
+  SwapHoriz,
 } from '@mui/icons-material';
 import type { FlowItem, StageGroup } from '../../utils/timelineParser';
 import type { StageOverview } from '../../types/session';
@@ -27,6 +28,7 @@ import {
   isFlowItemCollapsible,
   isFlowItemTerminal,
   flowItemsToPlainText,
+  countProviderFallbacks,
 } from '../../utils/timelineParser';
 import { TIMELINE_EVENT_TYPES, STAGE_TYPE, COLLAPSIBLE_STAGE_TYPES } from '../../constants/eventTypes';
 import StageSeparator from '../timeline/StageSeparator';
@@ -298,6 +300,9 @@ export default function ConversationTimeline({
   // --- Copy ---
   const plainText = useMemo(() => flowItemsToPlainText(items), [items]);
 
+  // --- Provider fallback rollup (session-wide, for the collapsed header pill) ---
+  const totalFallbackCount = useMemo(() => countProviderFallbacks(items), [items]);
+
   // --- Stage lookup (for execution overviews) ---
   const stageMap = useMemo(() => {
     const map = new Map<string, StageOverview>();
@@ -474,6 +479,28 @@ export default function ConversationTimeline({
                 </Box>
               </Tooltip>
             )}
+            {totalFallbackCount > 0 && (
+              <Tooltip title={`Provider fallback${totalFallbackCount > 1 ? ` (${totalFallbackCount}×)` : ''} in this session`}>
+                <Box
+                  sx={(theme) => ({
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    gap: 0.5,
+                    px: 1,
+                    py: 0.5,
+                    backgroundColor: alpha(theme.palette.warning.main, 0.08),
+                    borderRadius: '16px',
+                    border: '1px solid',
+                    borderColor: alpha(theme.palette.warning.main, 0.35),
+                  })}
+                >
+                  <SwapHoriz sx={{ fontSize: 16, color: 'warning.main' }} />
+                  <Typography variant="body2" sx={{ fontWeight: 600, color: 'warning.main', minWidth: '1ch', textAlign: 'center' }}>
+                    {totalFallbackCount}
+                  </Typography>
+                </Box>
+              </Tooltip>
+            )}
           </Box>
           <Typography variant="body2" sx={{ color: 'text.secondary', fontSize: '0.85rem' }}>
             {timelineCollapsed
@@ -590,6 +617,7 @@ export default function ConversationTimeline({
                       return next;
                     });
                   }}
+                  fallbackCount={countProviderFallbacks(group.items)}
                 />
               )}
 

--- a/web/dashboard/src/components/timeline/StageContent.tsx
+++ b/web/dashboard/src/components/timeline/StageContent.tsx
@@ -6,8 +6,9 @@ import {
   PlayArrow,
   CallSplit,
   CancelOutlined,
+  SwapHoriz,
 } from '@mui/icons-material';
-import { FLOW_ITEM, type FlowItem } from '../../utils/timelineParser';
+import { FLOW_ITEM, countProviderFallbacks, type FlowItem } from '../../utils/timelineParser';
 import type { ExecutionOverview } from '../../types/session';
 import type { StreamingItem } from '../streaming/StreamingContentRenderer';
 import StreamingContentRenderer from '../streaming/StreamingContentRenderer';
@@ -465,6 +466,23 @@ const StageContent: React.FC<StageContentProps> = ({
     return byExec;
   }, [executions, subAgentIds]);
 
+  // Provider-fallback rollup per top-level execution: its own items plus any
+  // fallbacks from sub-agents it dispatched, so the agent card badge stays
+  // visible without digging into a nested SubAgentCard.
+  const fallbackCountByExec = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const execution of executions) {
+      counts.set(execution.executionId, countProviderFallbacks(execution.items));
+    }
+    for (const [subExecId, subItems] of subAgentItemsByExec) {
+      const parentId = subAgentParentMap.get(subExecId);
+      if (!parentId) continue;
+      const subCount = countProviderFallbacks(subItems);
+      counts.set(parentId, (counts.get(parentId) || 0) + subCount);
+    }
+    return counts;
+  }, [executions, subAgentItemsByExec, subAgentParentMap]);
+
   // Check if any parallel agent is still running (for "Waiting for other agents...")
   const hasOtherActiveAgents = useMemo(() => {
     if (!isMultiAgent) return false;
@@ -696,6 +714,21 @@ const StageContent: React.FC<StageContentProps> = ({
                     sx={{ height: 18, fontSize: '0.65rem', fontStyle: 'italic', opacity: 0.7 }}
                   />
                 ) : null}
+                {(() => {
+                  const fallbackCount = fallbackCountByExec.get(execution.executionId) || 0;
+                  if (fallbackCount === 0) return null;
+                  return (
+                    <Tooltip title={`Provider fallback${fallbackCount > 1 ? ` (${fallbackCount}×)` : ''}`}>
+                      <Chip
+                        icon={<SwapHoriz sx={{ fontSize: '0.8rem' }} />}
+                        size="small"
+                        color="warning"
+                        variant="outlined"
+                        sx={{ height: 18, minWidth: 18, '& .MuiChip-label': { px: 0, display: 'none' }, '& .MuiChip-icon': { mx: 0 } }}
+                      />
+                    </Tooltip>
+                  );
+                })()}
               </Box>
               {/* Row 2: model info (left) + tokens (right) */}
               <Box display="flex" alignItems="center" gap={1} mt={0.5}>

--- a/web/dashboard/src/components/timeline/StageSeparator.tsx
+++ b/web/dashboard/src/components/timeline/StageSeparator.tsx
@@ -1,8 +1,8 @@
 import { memo, useCallback } from 'react';
-import { Box, Typography, Divider, Alert } from '@mui/material';
+import { Box, Typography, Divider, Alert, Chip, Tooltip } from '@mui/material';
 import {
   Search, ExpandMore, ExpandLess,
-  MergeType, SmsOutlined, AutoAwesome, BuildOutlined,
+  MergeType, SmsOutlined, AutoAwesome, BuildOutlined, SwapHoriz,
 } from '@mui/icons-material';
 import type { FlowItem } from '../../utils/timelineParser';
 import { EXECUTION_STATUS, FAILED_EXECUTION_STATUSES, CANCELLED_EXECUTION_STATUSES } from '../../constants/sessionStatus';
@@ -13,6 +13,8 @@ interface StageSeparatorProps {
   item: FlowItem;
   isCollapsed?: boolean;
   onToggleCollapse?: () => void;
+  /** Total provider-fallback count within this stage (own items + all sub-agents) */
+  fallbackCount?: number;
 }
 
 function getStageTypeIcon(stageType: string | undefined) {
@@ -31,7 +33,7 @@ function getStageTypeIcon(stageType: string | undefined) {
  * StageSeparator — minimal stage boundary divider.
  * A single clickable line: icon + stage name + chevron.
  */
-function StageSeparator({ item, isCollapsed = false, onToggleCollapse }: StageSeparatorProps) {
+function StageSeparator({ item, isCollapsed = false, onToggleCollapse, fallbackCount = 0 }: StageSeparatorProps) {
   const stageStatus = (item.metadata?.stage_status as string) || '';
   const stageType = item.metadata?.stage_type as string | undefined;
   const isErrorStatus = FAILED_EXECUTION_STATUSES.has(stageStatus);
@@ -86,6 +88,21 @@ function StageSeparator({ item, isCollapsed = false, onToggleCollapse }: StageSe
         >
           {getStageTypeIcon(stageType)}
           {stageName}
+          {fallbackCount > 0 && (
+            <Tooltip title={`Provider fallback${fallbackCount > 1 ? ` (${fallbackCount}×)` : ''} in this stage`}>
+              <Chip
+                icon={<SwapHoriz sx={{ fontSize: '0.75rem' }} />}
+                size="small"
+                color="warning"
+                variant="outlined"
+                sx={{
+                  height: 16, minWidth: 16, ml: 0.5,
+                  '& .MuiChip-label': { px: 0, display: 'none' },
+                  '& .MuiChip-icon': { mx: 0 },
+                }}
+              />
+            </Tooltip>
+          )}
           {onToggleCollapse && (
             isCollapsed
               ? <ExpandMore sx={{ fontSize: 18, ml: 0.25, transition: 'transform 0.3s' }} />

--- a/web/dashboard/src/components/timeline/SubAgentCard.tsx
+++ b/web/dashboard/src/components/timeline/SubAgentCard.tsx
@@ -1,12 +1,13 @@
 import React, { useState, useEffect } from 'react';
-import { Box, Typography, Chip, Collapse, IconButton, Alert, alpha, keyframes, useTheme } from '@mui/material';
+import { Box, Typography, Chip, Collapse, IconButton, Alert, Tooltip, alpha, keyframes, useTheme } from '@mui/material';
 import {
   ExpandMore,
   ExpandLess,
   Hub,
   CheckCircle,
+  SwapHoriz,
 } from '@mui/icons-material';
-import { flowItemsToPlainText, type FlowItem } from '../../utils/timelineParser';
+import { flowItemsToPlainText, countProviderFallbacks, type FlowItem } from '../../utils/timelineParser';
 import type { ExecutionOverview } from '../../types/session';
 import type { StreamingItem } from '../streaming/StreamingContentRenderer';
 import StreamingContentRenderer from '../streaming/StreamingContentRenderer';
@@ -76,6 +77,7 @@ const SubAgentCard: React.FC<SubAgentCardProps> = ({
 
   const theme = useTheme();
   const hasContent = items.length > 0 || dedupedStreaming.length > 0;
+  const fallbackCount = React.useMemo(() => countProviderFallbacks(items), [items]);
 
   const copyText = React.useMemo(() => {
     const header = `Sub-agent: ${agentName}`;
@@ -133,6 +135,17 @@ const SubAgentCard: React.FC<SubAgentCardProps> = ({
           {agentName}
         </Typography>
         <Box sx={{ flex: 1 }} />
+        {fallbackCount > 0 && (
+          <Tooltip title={`Provider fallback${fallbackCount > 1 ? ` (${fallbackCount}×)` : ''}`}>
+            <Chip
+              icon={<SwapHoriz sx={{ fontSize: '0.8rem' }} />}
+              size="small"
+              color="warning"
+              variant="outlined"
+              sx={{ height: 18, minWidth: 18, flexShrink: 0, '& .MuiChip-label': { px: 0, display: 'none' }, '& .MuiChip-icon': { mx: 0 } }}
+            />
+          </Tooltip>
+        )}
         {isCompleted && (
           <CheckCircle sx={{ fontSize: 16, color: 'success.main', flexShrink: 0 }} />
         )}

--- a/web/dashboard/src/utils/timelineParser.ts
+++ b/web/dashboard/src/utils/timelineParser.ts
@@ -391,6 +391,20 @@ export function getTimelineStats(items: FlowItem[], stages: StageOverview[]): Ti
   return stats;
 }
 
+/**
+ * Count provider-fallback events within a flat list of FlowItems.
+ * Used to roll up fallback occurrences onto parent visual nodes (sub-agent
+ * cards, parallel-agent cards, stage separators) so they don't stay hidden
+ * until a user expands all the way down to the leaf item.
+ */
+export function countProviderFallbacks(items: FlowItem[]): number {
+  let count = 0;
+  for (const item of items) {
+    if (item.type === FLOW_ITEM.PROVIDER_FALLBACK) count++;
+  }
+  return count;
+}
+
 // --- Collapse helpers ---
 
 /** Types that support auto-collapse. */


### PR DESCRIPTION
- Add countProviderFallbacks() helper to roll up provider_fallback events within a flat FlowItem list
- SubAgentCard header shows a warning badge when its items include a fallback, visible even while collapsed
- StageContent parallel-agent cards roll up fallbacks from their own items plus any dispatched sub-agents
- StageSeparator shows a per-stage fallback badge next to the stage name, aggregating across all agents and sub-agents in that stage
- ConversationTimeline header shows a session-wide fallback pill so it's visible even when the whole timeline is collapsed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added provider fallback indicators throughout conversation timelines, stages, and agent cards.
  * Display fallback counts with warning badges, tooltips, and multipliers when multiple occurrences are detected.
  * Added a session-level fallback summary indicator for quick visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->