### PR TITLE
Default Google provider to Gemini 3.6 Flash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,9 @@ htmlcov/
 *.swo
 *~
 
+# Cursor (local-only commands)
+.cursor/commands/common/
+
 # OS
 .DS_Store
 Thumbs.db

--- a/docs/adr/0017-native-tool-fallback-safety.md
+++ b/docs/adr/0017-native-tool-fallback-safety.md
@@ -39,7 +39,7 @@ The skip is unconditional (hard guard). An agent without its native tools is bro
 
 The guard distinguishes between:
 - **Agent requires native tools** — agent definition declares `NativeTools` with at least one enabled tool (e.g. WebResearcher, CodeExecutor). Losing them breaks the agent.
-- **Provider happens to support native tools** — agent uses a Gemini provider but doesn't declare `NativeTools` in its definition (e.g. VMRemediationAgent, orchestrators running on `gemini-3.5-flash`). Falling back to langchain is fine.
+- **Provider happens to support native tools** — agent uses a Gemini provider but doesn't declare `NativeTools` in its definition (e.g. VMRemediationAgent, orchestrators running on `google-default`). Falling back to langchain is fine.
 
 Checking the provider's NativeTools alone is insufficient — all Gemini providers declare `google_search: true, url_context: true` by default, so any agent on a Gemini provider would trigger the guard incorrectly.
 

--- a/pkg/config/builtin.go
+++ b/pkg/config/builtin.go
@@ -208,7 +208,7 @@ func initBuiltinLLMProviders() map[string]LLMProviderConfig {
 		// --- Google Gemini ---
 		"google-default": {
 			Type:                LLMProviderTypeGoogle,
-			Model:               "gemini-3.5-flash",
+			Model:               "gemini-3.6-flash",
 			APIKeyEnv:           "GOOGLE_API_KEY",
 			MaxToolResultTokens: 950000, // Conservative for 1M context
 			NativeTools:         geminiNativeTools(),
@@ -237,6 +237,13 @@ func initBuiltinLLMProviders() map[string]LLMProviderConfig {
 		"gemini-3.1-flash": {
 			Type:                LLMProviderTypeGoogle,
 			Model:               "gemini-3.1-flash-lite",
+			APIKeyEnv:           "GOOGLE_API_KEY",
+			MaxToolResultTokens: 950000, // Conservative for 1M context
+			NativeTools:         geminiNativeTools(),
+		},
+		"gemini-3.6-flash": {
+			Type:                LLMProviderTypeGoogle,
+			Model:               "gemini-3.6-flash",
 			APIKeyEnv:           "GOOGLE_API_KEY",
 			MaxToolResultTokens: 950000, // Conservative for 1M context
 			NativeTools:         geminiNativeTools(),

--- a/pkg/config/builtin_test.go
+++ b/pkg/config/builtin_test.go
@@ -216,7 +216,7 @@ func TestBuiltinImageProviderDisablesURLContext(t *testing.T) {
 	}
 
 	nonImageProviders := []string{
-		"google-default", "gemini-3.5-flash", "gemini-3-flash", "gemini-3.1-pro", "gemini-3.1-flash", "gemini-2.5-flash", "gemini-2.5-pro",
+		"google-default", "gemini-3.6-flash", "gemini-3.5-flash", "gemini-3-flash", "gemini-3.1-pro", "gemini-3.1-flash", "gemini-2.5-flash", "gemini-2.5-pro",
 	}
 	for _, name := range nonImageProviders {
 		t.Run(name+" has url_context", func(t *testing.T) {
@@ -302,6 +302,13 @@ func TestBuiltinLLMProviders(t *testing.T) {
 		{
 			name:          "gemini-3.1-flash",
 			providerID:    "gemini-3.1-flash",
+			wantType:      LLMProviderTypeGoogle,
+			wantMinTokens: 900000,
+			checkAPIKey:   true,
+		},
+		{
+			name:          "gemini-3.6-flash",
+			providerID:    "gemini-3.6-flash",
 			wantType:      LLMProviderTypeGoogle,
 			wantMinTokens: 900000,
 			checkAPIKey:   true,


### PR DESCRIPTION
- Point google-default at gemini-3.6-flash
- Add builtin gemini-3.6-flash provider
- Keep gemini-3.5-flash for existing configs
- Ignore local .cursor/commands/common/ paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Gemini 3.6 Flash model as a built-in Google provider.
  * Updated the default Google model to Gemini 3.6 Flash.

* **Documentation**
  * Updated native tool fallback guidance to reference the current default Google model.

* **Chores**
  * Added local Cursor command files to the repository’s ignore rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->