### PR TITLE
Expose estimated cost on session and execution APIs

### DIFF
--- a/cmd/tarsy/main.go
+++ b/cmd/tarsy/main.go
@@ -152,6 +152,9 @@ func main() {
 
 	alertService := services.NewAlertService(dbClient.Client, cfg.ChainRegistry, cfg.Defaults, maskingService)
 	sessionService := services.NewSessionService(dbClient.Client, cfg.ChainRegistry, cfg.MCPServerRegistry)
+	if cfg.CostEstimation != nil {
+		sessionService.SetCostEstimationEnabled(cfg.CostEstimation.Enabled)
+	}
 	slog.Info("Services initialized")
 
 	// 4a. Start cleanup service (retention + event TTL)

--- a/docs/proposals/session-usage-cost-design.md
+++ b/docs/proposals/session-usage-cost-design.md
@@ -277,7 +277,7 @@ Cost is computed and stored, but not yet exposed by any API — a safe, invisibl
 4. **Write path:** extend `CreateLLMInteractionRequest` + `InteractionService`; set thinking + cost in `recordLLMInteraction` and `summarize.go` (skip cost when estimation disabled).
 5. **Operator docs:** estimate caveats, tiers, thinking/LangChain/cache gaps, airgap/snapshot fallback, completeness semantics — the backend behavior this PR introduces.
 
-### PR 2 — Session & execution API enrichment
+### PR 2 — Session & execution API enrichment ✅ Done
 
 Depends on PR 1's columns. Mechanical extension of existing aggregation code to add cost alongside tokens — reviewed independently of the estimator internals.
 

--- a/docs/session-usage-cost.md
+++ b/docs/session-usage-cost.md
@@ -2,7 +2,7 @@
 
 TARSy can attach an **estimated USD cost** to each LLM interaction at write time, using list prices from a price book. Estimates are for operator judgment — they are **not** invoice truth.
 
-Cost fields are persisted on `llm_interactions` in this release. Session list/detail and the Usage dashboard surfaces that *display* estimated cost land in follow-up work; Config Viewer already exposes the effective toggle, overrides, and catalog status via `GET /api/v1/system/config`.
+Cost is persisted on each `llm_interaction` at write time. Session list, detail, summary, and `ExecutionOverview` APIs expose estimated cost + completeness when estimation is enabled. The Usage dashboard page and `GET /api/v1/usage/summary` land in follow-up work. Config Viewer already exposes the effective toggle, overrides, and catalog status via `GET /api/v1/system/config`.
 
 ## Table of Contents
 
@@ -10,6 +10,7 @@ Cost fields are persisted on `llm_interactions` in this release. Session list/de
 - [Configuration](#configuration)
 - [Price book](#price-book)
 - [How estimates are computed](#how-estimates-are-computed)
+- [Session APIs](#session-apis)
 - [Thinking tokens](#thinking-tokens)
 - [Known gaps](#known-gaps)
 - [Completeness](#completeness)
@@ -80,6 +81,18 @@ Reasoning rate = LiteLLM `output_cost_per_reasoning_token` when present, otherwi
 
 Priority / flex / batch rates and YAML override tiers are out of scope for v1.
 
+## Session APIs
+
+When cost estimation is **enabled**, these responses include cost fields next to existing token totals:
+
+| Response | Fields |
+|----------|--------|
+| `GET /api/v1/sessions` (`DashboardListResponse`) | root `cost_estimation_enabled`; each item: `estimated_cost_usd`, `cost_completeness` |
+| `GET /api/v1/sessions/:id` (`SessionDetailResponse`) | root `cost_estimation_enabled` + session-level `estimated_cost_usd`, `cost_completeness`, `unpriced_interaction_count`; same on each `ExecutionOverview` (parent rollup includes nested sub-agents) |
+| `GET /api/v1/sessions/:id/summary` (`SessionSummaryResponse`) | same session-level cost fields as detail |
+
+When estimation is **disabled**: responses set `cost_estimation_enabled: false` and omit the other cost keys. Aggregates use `SUM(estimated_cost_usd)` of non-null values; completeness uses priced vs token-bearing interaction counts (see [Completeness](#completeness)).
+
 ## Thinking tokens
 
 - Column: `llm_interactions.thinking_tokens` (nullable).
@@ -98,7 +111,7 @@ Priority / flex / batch rates and YAML override tiers are out of scope for v1.
 
 ## Completeness
 
-Session/Usage APIs will expose completeness separately (follow-up). Semantics:
+Session list/detail/summary and `ExecutionOverview` expose `cost_completeness` (Usage API follows later). Semantics:
 
 | Completeness | Meaning |
 |--------------|---------|
@@ -106,4 +119,4 @@ Session/Usage APIs will expose completeness separately (follow-up). Semantics:
 | `partial` | Some token-bearing rows are unpriced (null cost) |
 | `none` | No priced token-bearing rows |
 
-Unpriced includes: unknown models, heuristic conflicts, estimation disabled at write time, and pre-feature rows. Completeness is derived from **counts**, not from `COALESCE(SUM(estimated_cost_usd), 0)`.
+A **token-bearing** interaction has any of `input_tokens`, `output_tokens`, or `thinking_tokens` > 0. Explicit `$0` is priced (complete); SQL `NULL` is unpriced. Unpriced includes: unknown models, heuristic conflicts, estimation disabled at write time, and pre-feature rows. Completeness is derived from **counts**, not from `COALESCE(SUM(estimated_cost_usd), 0)`.

--- a/pkg/models/session.go
+++ b/pkg/models/session.go
@@ -70,49 +70,52 @@ type DashboardListParams struct {
 
 // DashboardSessionItem is a single session in the dashboard list with pre-computed stats.
 type DashboardSessionItem struct {
-	ID                    string     `json:"id"`
-	AlertType             *string    `json:"alert_type"`
-	ChainID               string     `json:"chain_id"`
-	Status                string     `json:"status"`
-	Author                *string    `json:"author"`
-	CreatedAt             time.Time  `json:"created_at"`
-	StartedAt             *time.Time `json:"started_at"`
-	CompletedAt           *time.Time `json:"completed_at"`
-	DurationMs            *int64     `json:"duration_ms"`
-	ErrorMessage          *string    `json:"error_message"`
-	ExecutiveSummary      *string    `json:"executive_summary"`
-	LLMInteractionCount   int        `json:"llm_interaction_count"`
-	MCPInteractionCount   int        `json:"mcp_interaction_count"`
-	InputTokens           int64      `json:"input_tokens"`
-	OutputTokens          int64      `json:"output_tokens"`
-	TotalTokens           int64      `json:"total_tokens"`
-	TotalStages           int        `json:"total_stages"`
-	CompletedStages       int        `json:"completed_stages"`
-	HasParallelStages     bool       `json:"has_parallel_stages"`
-	HasSubAgents          bool       `json:"has_sub_agents"`
-	HasActionStages       bool       `json:"has_action_stages"`
-	ActionsExecuted       *bool      `json:"actions_executed"`
-	ChatMessageCount      int        `json:"chat_message_count"`
-	ProviderFallbackCount int        `json:"provider_fallback_count"`
-	CurrentStageIndex     *int       `json:"current_stage_index"`
-	CurrentStageID        *string    `json:"current_stage_id"`
-	MatchedInContent      bool       `json:"matched_in_content"`
-	LatestScore           *int       `json:"latest_score"`
-	ScoringStatus         *string    `json:"scoring_status"`
-	ReviewStatus          *string    `json:"review_status"`
-	Assignee              *string    `json:"assignee"`
-	QualityRating         *string    `json:"quality_rating"`
-	ActionTaken           *string    `json:"action_taken"`
-	InvestigationFeedback *string    `json:"investigation_feedback"`
-	FeedbackEdited        bool       `json:"feedback_edited"`
-	FeedbackEditedBy      *string    `json:"feedback_edited_by"`
-	FeedbackEditedAt      *time.Time `json:"feedback_edited_at"`
+	ID                    string           `json:"id"`
+	AlertType             *string          `json:"alert_type"`
+	ChainID               string           `json:"chain_id"`
+	Status                string           `json:"status"`
+	Author                *string          `json:"author"`
+	CreatedAt             time.Time        `json:"created_at"`
+	StartedAt             *time.Time       `json:"started_at"`
+	CompletedAt           *time.Time       `json:"completed_at"`
+	DurationMs            *int64           `json:"duration_ms"`
+	ErrorMessage          *string          `json:"error_message"`
+	ExecutiveSummary      *string          `json:"executive_summary"`
+	LLMInteractionCount   int              `json:"llm_interaction_count"`
+	MCPInteractionCount   int              `json:"mcp_interaction_count"`
+	InputTokens           int64            `json:"input_tokens"`
+	OutputTokens          int64            `json:"output_tokens"`
+	TotalTokens           int64            `json:"total_tokens"`
+	EstimatedCostUsd      *float64         `json:"estimated_cost_usd,omitempty"`
+	CostCompleteness      CostCompleteness `json:"cost_completeness,omitempty"`
+	TotalStages           int              `json:"total_stages"`
+	CompletedStages       int              `json:"completed_stages"`
+	HasParallelStages     bool             `json:"has_parallel_stages"`
+	HasSubAgents          bool             `json:"has_sub_agents"`
+	HasActionStages       bool             `json:"has_action_stages"`
+	ActionsExecuted       *bool            `json:"actions_executed"`
+	ChatMessageCount      int              `json:"chat_message_count"`
+	ProviderFallbackCount int              `json:"provider_fallback_count"`
+	CurrentStageIndex     *int             `json:"current_stage_index"`
+	CurrentStageID        *string          `json:"current_stage_id"`
+	MatchedInContent      bool             `json:"matched_in_content"`
+	LatestScore           *int             `json:"latest_score"`
+	ScoringStatus         *string          `json:"scoring_status"`
+	ReviewStatus          *string          `json:"review_status"`
+	Assignee              *string          `json:"assignee"`
+	QualityRating         *string          `json:"quality_rating"`
+	ActionTaken           *string          `json:"action_taken"`
+	InvestigationFeedback *string          `json:"investigation_feedback"`
+	FeedbackEdited        bool             `json:"feedback_edited"`
+	FeedbackEditedBy      *string          `json:"feedback_edited_by"`
+	FeedbackEditedAt      *time.Time       `json:"feedback_edited_at"`
 }
 
 // DashboardListResponse is the paginated session list response for the dashboard.
 type DashboardListResponse struct {
-	Sessions   []DashboardSessionItem `json:"sessions"`
-	Pagination PaginationInfo         `json:"pagination"`
+	Sessions              []DashboardSessionItem `json:"sessions"`
+	Pagination            PaginationInfo         `json:"pagination"`
+	CostEstimationEnabled bool                   `json:"cost_estimation_enabled"`
 }
 
 // PaginationInfo describes pagination state.
@@ -178,23 +181,27 @@ type SessionDetailResponse struct {
 	CompletedAt *time.Time `json:"completed_at"`
 
 	// Computed fields
-	DurationMs          *int64  `json:"duration_ms"`
-	ChatEnabled         bool    `json:"chat_enabled"`
-	ChatID              *string `json:"chat_id"`
-	ChatMessageCount    int     `json:"chat_message_count"`
-	TotalStages         int     `json:"total_stages"`
-	CompletedStages     int     `json:"completed_stages"`
-	FailedStages        int     `json:"failed_stages"`
-	HasParallelStages   bool    `json:"has_parallel_stages"`
-	HasActionStages     bool    `json:"has_action_stages"`
-	ActionsExecuted     *bool   `json:"actions_executed"`
-	InputTokens         int64   `json:"input_tokens"`
-	OutputTokens        int64   `json:"output_tokens"`
-	TotalTokens         int64   `json:"total_tokens"`
-	LLMInteractionCount int     `json:"llm_interaction_count"`
-	MCPInteractionCount int     `json:"mcp_interaction_count"`
-	CurrentStageIndex   *int    `json:"current_stage_index"`
-	CurrentStageID      *string `json:"current_stage_id"`
+	DurationMs               *int64           `json:"duration_ms"`
+	ChatEnabled              bool             `json:"chat_enabled"`
+	ChatID                   *string          `json:"chat_id"`
+	ChatMessageCount         int              `json:"chat_message_count"`
+	TotalStages              int              `json:"total_stages"`
+	CompletedStages          int              `json:"completed_stages"`
+	FailedStages             int              `json:"failed_stages"`
+	HasParallelStages        bool             `json:"has_parallel_stages"`
+	HasActionStages          bool             `json:"has_action_stages"`
+	ActionsExecuted          *bool            `json:"actions_executed"`
+	InputTokens              int64            `json:"input_tokens"`
+	OutputTokens             int64            `json:"output_tokens"`
+	TotalTokens              int64            `json:"total_tokens"`
+	CostEstimationEnabled    bool             `json:"cost_estimation_enabled"`
+	EstimatedCostUsd         *float64         `json:"estimated_cost_usd,omitempty"`
+	CostCompleteness         CostCompleteness `json:"cost_completeness,omitempty"`
+	UnpricedInteractionCount *int             `json:"unpriced_interaction_count,omitempty"`
+	LLMInteractionCount      int              `json:"llm_interaction_count"`
+	MCPInteractionCount      int              `json:"mcp_interaction_count"`
+	CurrentStageIndex        *int             `json:"current_stage_index"`
+	CurrentStageID           *string          `json:"current_stage_id"`
 
 	// Scoring fields
 	LatestScore   *int    `json:"latest_score"`
@@ -232,40 +239,47 @@ type StageOverview struct {
 
 // ExecutionOverview is a summary of an agent execution within a stage.
 type ExecutionOverview struct {
-	ExecutionID         string              `json:"execution_id"`
-	AgentName           string              `json:"agent_name"`
-	AgentIndex          int                 `json:"agent_index"`
-	Status              string              `json:"status"`
-	LLMBackend          string              `json:"llm_backend"`
-	LLMProvider         *string             `json:"llm_provider"`
-	StartedAt           *time.Time          `json:"started_at"`
-	CompletedAt         *time.Time          `json:"completed_at"`
-	DurationMs          *int64              `json:"duration_ms"`
-	ErrorMessage        *string             `json:"error_message"`
-	InputTokens         int64               `json:"input_tokens"`
-	OutputTokens        int64               `json:"output_tokens"`
-	TotalTokens         int64               `json:"total_tokens"`
-	ParentExecutionID   *string             `json:"parent_execution_id,omitempty"`
-	Task                *string             `json:"task,omitempty"`
-	OriginalLLMProvider *string             `json:"original_llm_provider,omitempty"`
-	OriginalLLMBackend  *string             `json:"original_llm_backend,omitempty"`
-	FallbackReason      *string             `json:"fallback_reason,omitempty"`
-	FallbackErrorCode   *string             `json:"fallback_error_code,omitempty"`
-	FallbackAttempt     *int                `json:"fallback_attempt,omitempty"`
-	SubAgents           []ExecutionOverview `json:"sub_agents,omitempty"`
+	ExecutionID              string              `json:"execution_id"`
+	AgentName                string              `json:"agent_name"`
+	AgentIndex               int                 `json:"agent_index"`
+	Status                   string              `json:"status"`
+	LLMBackend               string              `json:"llm_backend"`
+	LLMProvider              *string             `json:"llm_provider"`
+	StartedAt                *time.Time          `json:"started_at"`
+	CompletedAt              *time.Time          `json:"completed_at"`
+	DurationMs               *int64              `json:"duration_ms"`
+	ErrorMessage             *string             `json:"error_message"`
+	InputTokens              int64               `json:"input_tokens"`
+	OutputTokens             int64               `json:"output_tokens"`
+	TotalTokens              int64               `json:"total_tokens"`
+	EstimatedCostUsd         *float64            `json:"estimated_cost_usd,omitempty"`
+	CostCompleteness         CostCompleteness    `json:"cost_completeness,omitempty"`
+	UnpricedInteractionCount *int                `json:"unpriced_interaction_count,omitempty"`
+	ParentExecutionID        *string             `json:"parent_execution_id,omitempty"`
+	Task                     *string             `json:"task,omitempty"`
+	OriginalLLMProvider      *string             `json:"original_llm_provider,omitempty"`
+	OriginalLLMBackend       *string             `json:"original_llm_backend,omitempty"`
+	FallbackReason           *string             `json:"fallback_reason,omitempty"`
+	FallbackErrorCode        *string             `json:"fallback_error_code,omitempty"`
+	FallbackAttempt          *int                `json:"fallback_attempt,omitempty"`
+	SubAgents                []ExecutionOverview `json:"sub_agents,omitempty"`
 }
 
 // SessionSummaryResponse is returned by GET /api/v1/sessions/:id/summary.
 type SessionSummaryResponse struct {
-	SessionID         string          `json:"session_id"`
-	TotalInteractions int             `json:"total_interactions"`
-	LLMInteractions   int             `json:"llm_interactions"`
-	MCPInteractions   int             `json:"mcp_interactions"`
-	InputTokens       int64           `json:"input_tokens"`
-	OutputTokens      int64           `json:"output_tokens"`
-	TotalTokens       int64           `json:"total_tokens"`
-	TotalDurationMs   *int64          `json:"total_duration_ms"`
-	ChainStatistics   ChainStatistics `json:"chain_statistics"`
+	SessionID                string           `json:"session_id"`
+	TotalInteractions        int              `json:"total_interactions"`
+	LLMInteractions          int              `json:"llm_interactions"`
+	MCPInteractions          int              `json:"mcp_interactions"`
+	InputTokens              int64            `json:"input_tokens"`
+	OutputTokens             int64            `json:"output_tokens"`
+	TotalTokens              int64            `json:"total_tokens"`
+	CostEstimationEnabled    bool             `json:"cost_estimation_enabled"`
+	EstimatedCostUsd         *float64         `json:"estimated_cost_usd,omitempty"`
+	CostCompleteness         CostCompleteness `json:"cost_completeness,omitempty"`
+	UnpricedInteractionCount *int             `json:"unpriced_interaction_count,omitempty"`
+	TotalDurationMs          *int64           `json:"total_duration_ms"`
+	ChainStatistics          ChainStatistics  `json:"chain_statistics"`
 
 	// Score fields — present only when a completed score exists for the session.
 	TotalScore    *int    `json:"total_score,omitempty"`
@@ -287,6 +301,29 @@ type ChainStatistics struct {
 	CompletedStages   int  `json:"completed_stages"`
 	FailedStages      int  `json:"failed_stages"`
 	CurrentStageIndex *int `json:"current_stage_index"`
+}
+
+// CostCompleteness describes whether all token-bearing LLM interactions have prices.
+type CostCompleteness string
+
+// Cost completeness values for session/execution cost aggregates.
+const (
+	CostCompletenessComplete CostCompleteness = "complete"
+	CostCompletenessPartial  CostCompleteness = "partial"
+	CostCompletenessNone     CostCompleteness = "none"
+)
+
+// DeriveCostCompleteness maps priced vs token-bearing interaction counts to a completeness enum.
+// tokenBearing is the count of interactions with any of input/output/thinking tokens > 0.
+// priced is the count of those with non-null estimated_cost_usd.
+func DeriveCostCompleteness(tokenBearing, priced int) CostCompleteness {
+	if priced == 0 {
+		return CostCompletenessNone
+	}
+	if priced == tokenBearing {
+		return CostCompletenessComplete
+	}
+	return CostCompletenessPartial
 }
 
 // --- Review workflow DTOs ---

--- a/pkg/models/session_test.go
+++ b/pkg/models/session_test.go
@@ -1,10 +1,54 @@
 package models
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestDeriveCostCompleteness(t *testing.T) {
+	tests := []struct {
+		name         string
+		tokenBearing int
+		priced       int
+		want         CostCompleteness
+	}{
+		{"none when no priced", 3, 0, CostCompletenessNone},
+		{"none when empty", 0, 0, CostCompletenessNone},
+		{"complete when all priced", 2, 2, CostCompletenessComplete},
+		{"partial when some priced", 3, 1, CostCompletenessPartial},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, DeriveCostCompleteness(tt.tokenBearing, tt.priced))
+		})
+	}
+}
+
+func TestSessionCostFieldsJSON(t *testing.T) {
+	t.Run("zero estimated cost is serialized", func(t *testing.T) {
+		zero := 0.0
+		item := DashboardSessionItem{
+			ID:               "s1",
+			EstimatedCostUsd: &zero,
+			CostCompleteness: CostCompletenessComplete,
+		}
+		raw, err := json.Marshal(item)
+		require.NoError(t, err)
+		assert.Contains(t, string(raw), `"estimated_cost_usd":0`)
+		assert.Contains(t, string(raw), `"cost_completeness":"complete"`)
+	})
+
+	t.Run("nil cost fields omitted", func(t *testing.T) {
+		item := DashboardSessionItem{ID: "s1"}
+		raw, err := json.Marshal(item)
+		require.NoError(t, err)
+		assert.NotContains(t, string(raw), "estimated_cost_usd")
+		assert.NotContains(t, string(raw), "cost_completeness")
+	})
+}
 
 func TestParseTriageGroupKey(t *testing.T) {
 	tests := []struct {

--- a/pkg/services/session_service.go
+++ b/pkg/services/session_service.go
@@ -26,9 +26,10 @@ import (
 
 // SessionService manages alert session lifecycle
 type SessionService struct {
-	client            *ent.Client
-	chainRegistry     *config.ChainRegistry
-	mcpServerRegistry *config.MCPServerRegistry
+	client                *ent.Client
+	chainRegistry         *config.ChainRegistry
+	mcpServerRegistry     *config.MCPServerRegistry
+	costEstimationEnabled bool // default true (YAML default); override via SetCostEstimationEnabled
 }
 
 // NewSessionService creates a new SessionService with configuration registries
@@ -37,10 +38,16 @@ func NewSessionService(client *ent.Client, chainRegistry *config.ChainRegistry, 
 		panic("NewSessionService: chainRegistry and mcpServerRegistry must not be nil")
 	}
 	return &SessionService{
-		client:            client,
-		chainRegistry:     chainRegistry,
-		mcpServerRegistry: mcpServerRegistry,
+		client:                client,
+		chainRegistry:         chainRegistry,
+		mcpServerRegistry:     mcpServerRegistry,
+		costEstimationEnabled: true,
 	}
+}
+
+// SetCostEstimationEnabled controls whether session/execution responses include cost fields.
+func (s *SessionService) SetCostEstimationEnabled(enabled bool) {
+	s.costEstimationEnabled = enabled
 }
 
 // CreateSession creates a new alert session with initial stage and agent execution
@@ -447,7 +454,7 @@ func (s *SessionService) GetSessionDetail(ctx context.Context, sessionID string)
 	}
 
 	// Compute token and interaction stats via aggregate queries.
-	llmCount, inputTokens, outputTokens, totalTokens, err := s.aggregateLLMStats(ctx, sessionID)
+	llmStats, err := s.aggregateLLMStats(ctx, sessionID)
 	if err != nil {
 		return nil, err
 	}
@@ -456,8 +463,8 @@ func (s *SessionService) GetSessionDetail(ctx context.Context, sessionID string)
 		return nil, err
 	}
 
-	// Aggregate per-execution token stats in a single query.
-	execTokens, err := s.aggregateExecutionTokenStats(ctx, sessionID)
+	// Aggregate per-execution usage stats in a single query.
+	execStats, err := s.aggregateExecutionUsageStats(ctx, sessionID)
 	if err != nil {
 		return nil, err
 	}
@@ -510,16 +517,24 @@ func (s *SessionService) GetSessionDetail(ctx context.Context, sessionID string)
 		if stg.Edges.AgentExecutions != nil {
 			execOverviews = make([]models.ExecutionOverview, 0, len(stg.Edges.AgentExecutions))
 			for _, exec := range stg.Edges.AgentExecutions {
-				overview := buildExecutionOverview(exec, execTokens, fallbackMeta)
+				overview := buildExecutionOverview(exec, execStats, fallbackMeta, s.costEstimationEnabled)
+				rolled := execStats[exec.ID]
 
 				if exec.Edges.SubAgents != nil {
 					overview.SubAgents = make([]models.ExecutionOverview, 0, len(exec.Edges.SubAgents))
 					for _, sub := range exec.Edges.SubAgents {
-						subOverview := buildExecutionOverview(sub, execTokens, fallbackMeta)
+						subOverview := buildExecutionOverview(sub, execStats, fallbackMeta, s.costEstimationEnabled)
 						overview.InputTokens += subOverview.InputTokens
 						overview.OutputTokens += subOverview.OutputTokens
 						overview.TotalTokens += subOverview.TotalTokens
+						subStats := execStats[sub.ID]
+						rolled.Cost += subStats.Cost
+						rolled.TokenBearing += subStats.TokenBearing
+						rolled.Priced += subStats.Priced
 						overview.SubAgents = append(overview.SubAgents, subOverview)
+					}
+					if s.costEstimationEnabled {
+						applyExecutionCostFields(&overview, rolled)
 					}
 				}
 
@@ -630,7 +645,7 @@ func (s *SessionService) GetSessionDetail(ctx context.Context, sessionID string)
 		feedbackEditedAt = &latestEdit.CreatedAt
 	}
 
-	return &models.SessionDetailResponse{
+	resp := &models.SessionDetailResponse{
 		ID:                      session.ID,
 		AlertData:               session.AlertData,
 		AlertType:               alertType,
@@ -657,10 +672,11 @@ func (s *SessionService) GetSessionDetail(ctx context.Context, sessionID string)
 		HasParallelStages:       hasParallel,
 		HasActionStages:         hasActionStages,
 		ActionsExecuted:         actionsExecuted,
-		InputTokens:             inputTokens,
-		OutputTokens:            outputTokens,
-		TotalTokens:             totalTokens,
-		LLMInteractionCount:     llmCount,
+		InputTokens:             llmStats.InputTokens,
+		OutputTokens:            llmStats.OutputTokens,
+		TotalTokens:             llmStats.TotalTokens,
+		CostEstimationEnabled:   s.costEstimationEnabled,
+		LLMInteractionCount:     llmStats.Count,
 		MCPInteractionCount:     mcpCount,
 		CurrentStageIndex:       session.CurrentStageIndex,
 		CurrentStageID:          session.CurrentStageID,
@@ -676,7 +692,11 @@ func (s *SessionService) GetSessionDetail(ctx context.Context, sessionID string)
 		FeedbackEditedBy:        feedbackEditedBy,
 		FeedbackEditedAt:        feedbackEditedAt,
 		Stages:                  stages,
-	}, nil
+	}
+	if s.costEstimationEnabled {
+		applySessionCostFields(resp, llmStats)
+	}
+	return resp, nil
 }
 
 // GetSessionSummary returns lightweight statistics for a session.
@@ -695,7 +715,7 @@ func (s *SessionService) GetSessionSummary(ctx context.Context, sessionID string
 		return nil, fmt.Errorf("failed to get session: %w", err)
 	}
 
-	llmCount, inputTokens, outputTokens, totalTokens, err := s.aggregateLLMStats(ctx, sessionID)
+	llmStats, err := s.aggregateLLMStats(ctx, sessionID)
 	if err != nil {
 		return nil, err
 	}
@@ -723,20 +743,28 @@ func (s *SessionService) GetSessionSummary(ctx context.Context, sessionID string
 	}
 
 	resp := &models.SessionSummaryResponse{
-		SessionID:         sessionID,
-		TotalInteractions: llmCount + mcpCount,
-		LLMInteractions:   llmCount,
-		MCPInteractions:   mcpCount,
-		InputTokens:       inputTokens,
-		OutputTokens:      outputTokens,
-		TotalTokens:       totalTokens,
-		TotalDurationMs:   durationMs,
+		SessionID:             sessionID,
+		TotalInteractions:     llmStats.Count + mcpCount,
+		LLMInteractions:       llmStats.Count,
+		MCPInteractions:       mcpCount,
+		InputTokens:           llmStats.InputTokens,
+		OutputTokens:          llmStats.OutputTokens,
+		TotalTokens:           llmStats.TotalTokens,
+		CostEstimationEnabled: s.costEstimationEnabled,
+		TotalDurationMs:       durationMs,
 		ChainStatistics: models.ChainStatistics{
 			TotalStages:       totalStages,
 			CompletedStages:   completedStages,
 			FailedStages:      failedStages,
 			CurrentStageIndex: session.CurrentStageIndex,
 		},
+	}
+	if s.costEstimationEnabled {
+		cost := llmStats.CostUsd
+		resp.EstimatedCostUsd = &cost
+		resp.CostCompleteness = models.DeriveCostCompleteness(llmStats.TokenBearing, llmStats.Priced)
+		unpriced := llmStats.TokenBearing - llmStats.Priced
+		resp.UnpricedInteractionCount = &unpriced
 	}
 
 	if scores := session.Edges.SessionScores; len(scores) > 0 {
@@ -869,6 +897,9 @@ type dashboardRow struct {
 	LLMInputTokens        int64      `sql:"llm_input_tokens"`
 	LLMOutputTokens       int64      `sql:"llm_output_tokens"`
 	LLMTotalTokens        int64      `sql:"llm_total_tokens"`
+	LLMCostUsd            float64    `sql:"llm_cost_usd"`
+	LLMTokenBearing       int        `sql:"llm_token_bearing"`
+	LLMPriced             int        `sql:"llm_priced"`
 	MCPCount              int        `sql:"mcp_count"`
 	TotalStages           int        `sql:"total_stages"`
 	CompletedStages       int        `sql:"completed_stages"`
@@ -1083,6 +1114,26 @@ func (s *SessionService) ListSessionsForDashboard(ctx context.Context, params mo
 				fmt.Sprintf("(SELECT COALESCE(SUM(total_tokens), 0) FROM llm_interactions WHERE session_id = %s)", sid),
 				"llm_total_tokens",
 			)
+			if s.costEstimationEnabled {
+				sel.AppendSelectAs(
+					fmt.Sprintf("(SELECT COALESCE(SUM(estimated_cost_usd), 0) FROM llm_interactions WHERE session_id = %s)", sid),
+					"llm_cost_usd",
+				)
+				sel.AppendSelectAs(
+					fmt.Sprintf(
+						"(SELECT COUNT(*) FROM llm_interactions WHERE session_id = %s AND %s)",
+						sid, tokenBearingPredicateSQL,
+					),
+					"llm_token_bearing",
+				)
+				sel.AppendSelectAs(
+					fmt.Sprintf(
+						"(SELECT COUNT(*) FROM llm_interactions WHERE session_id = %s AND %s AND estimated_cost_usd IS NOT NULL)",
+						sid, tokenBearingPredicateSQL,
+					),
+					"llm_priced",
+				)
+			}
 
 			// MCP interaction count.
 			sel.AppendSelectAs(
@@ -1196,7 +1247,7 @@ func (s *SessionService) ListSessionsForDashboard(ctx context.Context, params mo
 			durationMs = &ms
 		}
 
-		items = append(items, models.DashboardSessionItem{
+		item := models.DashboardSessionItem{
 			ID:                    row.ID,
 			AlertType:             row.AlertType,
 			ChainID:               row.ChainID,
@@ -1234,7 +1285,13 @@ func (s *SessionService) ListSessionsForDashboard(ctx context.Context, params mo
 			FeedbackEdited:        row.FeedbackEdited != 0,
 			FeedbackEditedBy:      row.FeedbackEditedBy,
 			FeedbackEditedAt:      row.FeedbackEditedAt,
-		})
+		}
+		if s.costEstimationEnabled {
+			cost := row.LLMCostUsd
+			item.EstimatedCostUsd = &cost
+			item.CostCompleteness = models.DeriveCostCompleteness(row.LLMTokenBearing, row.LLMPriced)
+		}
+		items = append(items, item)
 	}
 
 	totalPages := 0
@@ -1243,7 +1300,8 @@ func (s *SessionService) ListSessionsForDashboard(ctx context.Context, params mo
 	}
 
 	return &models.DashboardListResponse{
-		Sessions: items,
+		Sessions:              items,
+		CostEstimationEnabled: s.costEstimationEnabled,
 		Pagination: models.PaginationInfo{
 			Page:       page,
 			PageSize:   pageSize,
@@ -1255,50 +1313,88 @@ func (s *SessionService) ListSessionsForDashboard(ctx context.Context, params mo
 
 // --- Aggregate helpers ---
 
-// aggregateLLMStats returns LLM interaction count and token sums for a session.
-func (s *SessionService) aggregateLLMStats(ctx context.Context, sessionID string) (count int, inputTokens, outputTokens, totalTokens int64, err error) {
-	// SUM returns NULL when all values are NULL (nullable token columns).
-	// Use sql.NullInt64 to avoid scan errors and default to 0.
+// tokenBearingPredicateSQL matches LLM rows that contribute to cost completeness.
+const tokenBearingPredicateSQL = `(COALESCE(input_tokens, 0) > 0 OR COALESCE(output_tokens, 0) > 0 OR COALESCE(thinking_tokens, 0) > 0)`
+
+// llmSessionStats holds session-level LLM interaction aggregates.
+type llmSessionStats struct {
+	Count        int
+	InputTokens  int64
+	OutputTokens int64
+	TotalTokens  int64
+	CostUsd      float64
+	TokenBearing int
+	Priced       int
+}
+
+// aggregateLLMStats returns LLM interaction count, token sums, and cost completeness counts.
+func (s *SessionService) aggregateLLMStats(ctx context.Context, sessionID string) (llmSessionStats, error) {
+	// SUM returns NULL when all values are NULL (nullable columns).
 	var results []struct {
-		Count     int              `json:"count"`
-		InputSum  stdsql.NullInt64 `json:"input_sum"`
-		OutputSum stdsql.NullInt64 `json:"output_sum"`
-		TotalSum  stdsql.NullInt64 `json:"total_sum"`
+		Count        int                `json:"count"`
+		InputSum     stdsql.NullInt64   `json:"input_sum"`
+		OutputSum    stdsql.NullInt64   `json:"output_sum"`
+		TotalSum     stdsql.NullInt64   `json:"total_sum"`
+		CostSum      stdsql.NullFloat64 `json:"cost_sum"`
+		TokenBearing int                `json:"token_bearing"`
+		Priced       int                `json:"priced"`
 	}
 
-	err = s.client.LLMInteraction.Query().
+	err := s.client.LLMInteraction.Query().
 		Where(llminteraction.SessionIDEQ(sessionID)).
 		Aggregate(
 			ent.As(ent.Count(), "count"),
 			ent.As(ent.Sum(llminteraction.FieldInputTokens), "input_sum"),
 			ent.As(ent.Sum(llminteraction.FieldOutputTokens), "output_sum"),
 			ent.As(ent.Sum(llminteraction.FieldTotalTokens), "total_sum"),
+			ent.As(ent.Sum(llminteraction.FieldEstimatedCostUsd), "cost_sum"),
+			ent.As(func(_ *sql.Selector) string {
+				return "COUNT(*) FILTER (WHERE " + tokenBearingPredicateSQL + ")"
+			}, "token_bearing"),
+			ent.As(func(_ *sql.Selector) string {
+				return "COUNT(*) FILTER (WHERE " + tokenBearingPredicateSQL + " AND estimated_cost_usd IS NOT NULL)"
+			}, "priced"),
 		).
 		Scan(ctx, &results)
 	if err != nil {
-		return 0, 0, 0, 0, fmt.Errorf("failed to aggregate LLM stats: %w", err)
+		return llmSessionStats{}, fmt.Errorf("failed to aggregate LLM stats: %w", err)
 	}
 
-	if len(results) > 0 {
-		return results[0].Count, results[0].InputSum.Int64, results[0].OutputSum.Int64, results[0].TotalSum.Int64, nil
+	if len(results) == 0 {
+		return llmSessionStats{}, nil
 	}
-	return 0, 0, 0, 0, nil
+	r := results[0]
+	return llmSessionStats{
+		Count:        r.Count,
+		InputTokens:  r.InputSum.Int64,
+		OutputTokens: r.OutputSum.Int64,
+		TotalTokens:  r.TotalSum.Int64,
+		CostUsd:      r.CostSum.Float64,
+		TokenBearing: r.TokenBearing,
+		Priced:       r.Priced,
+	}, nil
 }
 
-// executionTokenStats holds per-execution token sums.
-type executionTokenStats struct {
-	Input  int64
-	Output int64
-	Total  int64
+// executionUsageStats holds per-execution token and cost aggregates.
+type executionUsageStats struct {
+	Input        int64
+	Output       int64
+	Total        int64
+	Cost         float64
+	TokenBearing int
+	Priced       int
 }
 
-// aggregateExecutionTokenStats returns per-execution token sums for a session.
-func (s *SessionService) aggregateExecutionTokenStats(ctx context.Context, sessionID string) (map[string]executionTokenStats, error) {
+// aggregateExecutionUsageStats returns per-execution token/cost sums for a session.
+func (s *SessionService) aggregateExecutionUsageStats(ctx context.Context, sessionID string) (map[string]executionUsageStats, error) {
 	var rows []struct {
-		ExecutionID stdsql.NullString `json:"execution_id"`
-		InputSum    stdsql.NullInt64  `json:"input_sum"`
-		OutputSum   stdsql.NullInt64  `json:"output_sum"`
-		TotalSum    stdsql.NullInt64  `json:"total_sum"`
+		ExecutionID  stdsql.NullString  `json:"execution_id"`
+		InputSum     stdsql.NullInt64   `json:"input_sum"`
+		OutputSum    stdsql.NullInt64   `json:"output_sum"`
+		TotalSum     stdsql.NullInt64   `json:"total_sum"`
+		CostSum      stdsql.NullFloat64 `json:"cost_sum"`
+		TokenBearing int                `json:"token_bearing"`
+		Priced       int                `json:"priced"`
 	}
 
 	err := s.client.LLMInteraction.Query().
@@ -1308,24 +1404,50 @@ func (s *SessionService) aggregateExecutionTokenStats(ctx context.Context, sessi
 			ent.As(ent.Sum(llminteraction.FieldInputTokens), "input_sum"),
 			ent.As(ent.Sum(llminteraction.FieldOutputTokens), "output_sum"),
 			ent.As(ent.Sum(llminteraction.FieldTotalTokens), "total_sum"),
+			ent.As(ent.Sum(llminteraction.FieldEstimatedCostUsd), "cost_sum"),
+			ent.As(func(_ *sql.Selector) string {
+				return "COUNT(*) FILTER (WHERE " + tokenBearingPredicateSQL + ")"
+			}, "token_bearing"),
+			ent.As(func(_ *sql.Selector) string {
+				return "COUNT(*) FILTER (WHERE " + tokenBearingPredicateSQL + " AND estimated_cost_usd IS NOT NULL)"
+			}, "priced"),
 		).
 		Scan(ctx, &rows)
 	if err != nil {
-		return nil, fmt.Errorf("failed to aggregate execution token stats: %w", err)
+		return nil, fmt.Errorf("failed to aggregate execution usage stats: %w", err)
 	}
 
-	result := make(map[string]executionTokenStats, len(rows))
+	result := make(map[string]executionUsageStats, len(rows))
 	for _, row := range rows {
 		if !row.ExecutionID.Valid {
 			continue
 		}
-		result[row.ExecutionID.String] = executionTokenStats{
-			Input:  row.InputSum.Int64,
-			Output: row.OutputSum.Int64,
-			Total:  row.TotalSum.Int64,
+		result[row.ExecutionID.String] = executionUsageStats{
+			Input:        row.InputSum.Int64,
+			Output:       row.OutputSum.Int64,
+			Total:        row.TotalSum.Int64,
+			Cost:         row.CostSum.Float64,
+			TokenBearing: row.TokenBearing,
+			Priced:       row.Priced,
 		}
 	}
 	return result, nil
+}
+
+func applySessionCostFields(resp *models.SessionDetailResponse, stats llmSessionStats) {
+	cost := stats.CostUsd
+	resp.EstimatedCostUsd = &cost
+	resp.CostCompleteness = models.DeriveCostCompleteness(stats.TokenBearing, stats.Priced)
+	unpriced := stats.TokenBearing - stats.Priced
+	resp.UnpricedInteractionCount = &unpriced
+}
+
+func applyExecutionCostFields(overview *models.ExecutionOverview, stats executionUsageStats) {
+	cost := stats.Cost
+	overview.EstimatedCostUsd = &cost
+	overview.CostCompleteness = models.DeriveCostCompleteness(stats.TokenBearing, stats.Priced)
+	unpriced := stats.TokenBearing - stats.Priced
+	overview.UnpricedInteractionCount = &unpriced
 }
 
 // countMCPInteractions returns the MCP interaction count for a session.
@@ -1425,8 +1547,13 @@ func (s *SessionService) loadFallbackMetadata(ctx context.Context, sessionID str
 }
 
 // buildExecutionOverview creates an ExecutionOverview from an AgentExecution entity.
-func buildExecutionOverview(exec *ent.AgentExecution, execTokens map[string]executionTokenStats, fallbackMeta map[string]fallbackEventMeta) models.ExecutionOverview {
-	tokens := execTokens[exec.ID]
+func buildExecutionOverview(
+	exec *ent.AgentExecution,
+	execStats map[string]executionUsageStats,
+	fallbackMeta map[string]fallbackEventMeta,
+	costEstimationEnabled bool,
+) models.ExecutionOverview {
+	stats := execStats[exec.ID]
 	var durationMs *int64
 	if exec.DurationMs != nil {
 		v := int64(*exec.DurationMs)
@@ -1443,13 +1570,16 @@ func buildExecutionOverview(exec *ent.AgentExecution, execTokens map[string]exec
 		CompletedAt:         exec.CompletedAt,
 		DurationMs:          durationMs,
 		ErrorMessage:        exec.ErrorMessage,
-		InputTokens:         tokens.Input,
-		OutputTokens:        tokens.Output,
-		TotalTokens:         tokens.Total,
+		InputTokens:         stats.Input,
+		OutputTokens:        stats.Output,
+		TotalTokens:         stats.Total,
 		ParentExecutionID:   exec.ParentExecutionID,
 		Task:                exec.Task,
 		OriginalLLMProvider: exec.OriginalLlmProvider,
 		OriginalLLMBackend:  exec.OriginalLlmBackend,
+	}
+	if costEstimationEnabled {
+		applyExecutionCostFields(&overview, stats)
 	}
 
 	if fm, ok := fallbackMeta[exec.ID]; ok {

--- a/pkg/services/session_service_test.go
+++ b/pkg/services/session_service_test.go
@@ -1670,6 +1670,433 @@ func TestSessionService_GetSessionSummary(t *testing.T) {
 	})
 }
 
+func TestSessionService_CostAggregation(t *testing.T) {
+	client := testdb.NewTestClient(t)
+	service := setupTestSessionService(t, client.Client)
+	ctx := context.Background()
+
+	t.Run("multi-model partial completeness on detail and summary", func(t *testing.T) {
+		sessionID, stageID, execID := seedSessionSkeleton(t, client.Client, "cost-partial")
+		seedLLMInteraction(t, client.Client, sessionID, stageID, execID, "priced-model", 100, 50, 150, floatPtr(0.012), 0)
+		seedLLMInteraction(t, client.Client, sessionID, stageID, execID, "unpriced-model", 200, 100, 300, nil, 0)
+
+		detail, err := service.GetSessionDetail(ctx, sessionID)
+		require.NoError(t, err)
+		assert.True(t, detail.CostEstimationEnabled)
+		require.NotNil(t, detail.EstimatedCostUsd)
+		assert.InDelta(t, 0.012, *detail.EstimatedCostUsd, 1e-9)
+		assert.Equal(t, models.CostCompletenessPartial, detail.CostCompleteness)
+		require.NotNil(t, detail.UnpricedInteractionCount)
+		assert.Equal(t, 1, *detail.UnpricedInteractionCount)
+
+		summary, err := service.GetSessionSummary(ctx, sessionID)
+		require.NoError(t, err)
+		assert.True(t, summary.CostEstimationEnabled)
+		require.NotNil(t, summary.EstimatedCostUsd)
+		assert.InDelta(t, 0.012, *summary.EstimatedCostUsd, 1e-9)
+		assert.Equal(t, models.CostCompletenessPartial, summary.CostCompleteness)
+		require.NotNil(t, summary.UnpricedInteractionCount)
+		assert.Equal(t, 1, *summary.UnpricedInteractionCount)
+
+		require.Len(t, detail.Stages, 1)
+		require.Len(t, detail.Stages[0].Executions, 1)
+		eo := detail.Stages[0].Executions[0]
+		require.NotNil(t, eo.EstimatedCostUsd)
+		assert.InDelta(t, 0.012, *eo.EstimatedCostUsd, 1e-9)
+		assert.Equal(t, models.CostCompletenessPartial, eo.CostCompleteness)
+		require.NotNil(t, eo.UnpricedInteractionCount)
+		assert.Equal(t, 1, *eo.UnpricedInteractionCount)
+	})
+
+	t.Run("pre-feature null cost rows yield none completeness", func(t *testing.T) {
+		sessionID, stageID, execID := seedSessionSkeleton(t, client.Client, "cost-none")
+		seedLLMInteraction(t, client.Client, sessionID, stageID, execID, "old-model", 100, 50, 150, nil, 0)
+
+		detail, err := service.GetSessionDetail(ctx, sessionID)
+		require.NoError(t, err)
+		require.NotNil(t, detail.EstimatedCostUsd)
+		assert.Equal(t, 0.0, *detail.EstimatedCostUsd)
+		assert.Equal(t, models.CostCompletenessNone, detail.CostCompleteness)
+		require.NotNil(t, detail.UnpricedInteractionCount)
+		assert.Equal(t, 1, *detail.UnpricedInteractionCount)
+	})
+
+	t.Run("explicit zero cost is complete not unpriced", func(t *testing.T) {
+		sessionID, stageID, execID := seedSessionSkeleton(t, client.Client, "cost-zero")
+		seedLLMInteraction(t, client.Client, sessionID, stageID, execID, "free-model", 10, 5, 15, floatPtr(0.0), 0)
+
+		detail, err := service.GetSessionDetail(ctx, sessionID)
+		require.NoError(t, err)
+		require.NotNil(t, detail.EstimatedCostUsd)
+		assert.Equal(t, 0.0, *detail.EstimatedCostUsd)
+		assert.Equal(t, models.CostCompletenessComplete, detail.CostCompleteness)
+		require.NotNil(t, detail.UnpricedInteractionCount)
+		assert.Equal(t, 0, *detail.UnpricedInteractionCount)
+
+		list, err := service.ListSessionsForDashboard(ctx, models.DashboardListParams{
+			Page: 1, PageSize: 50, SortBy: "created_at", SortOrder: "desc",
+		})
+		require.NoError(t, err)
+		assert.True(t, list.CostEstimationEnabled)
+		var item *models.DashboardSessionItem
+		for i := range list.Sessions {
+			if list.Sessions[i].ID == sessionID {
+				item = &list.Sessions[i]
+				break
+			}
+		}
+		require.NotNil(t, item, "session should appear in list")
+		require.NotNil(t, item.EstimatedCostUsd)
+		assert.Equal(t, 0.0, *item.EstimatedCostUsd)
+		assert.Equal(t, models.CostCompletenessComplete, item.CostCompleteness)
+	})
+
+	t.Run("parent execution rolls up sub-agent cost", func(t *testing.T) {
+		now := time.Now()
+		started := now.Add(-10 * time.Second)
+		completed := now
+		sessionID := uuid.New().String()
+
+		sess := client.AlertSession.Create().
+			SetID(sessionID).
+			SetAlertData("cost rollup").
+			SetAlertType("pod-crash").
+			SetChainID("k8s-analysis").
+			SetAgentType("kubernetes").
+			SetStatus(alertsession.StatusCompleted).
+			SetStartedAt(started).
+			SetCompletedAt(completed).
+			SaveX(ctx)
+
+		stg := client.Stage.Create().
+			SetID(uuid.New().String()).
+			SetSessionID(sess.ID).
+			SetStageName("Orchestration").
+			SetStageIndex(1).
+			SetExpectedAgentCount(1).
+			SetStatus(stage.StatusCompleted).
+			SetStartedAt(started).
+			SetCompletedAt(completed).
+			SaveX(ctx)
+
+		parent := client.AgentExecution.Create().
+			SetID(uuid.New().String()).
+			SetSessionID(sess.ID).
+			SetStageID(stg.ID).
+			SetAgentName("Orchestrator").
+			SetAgentIndex(1).
+			SetLlmBackend(string(config.LLMBackendLangChain)).
+			SetStatus("completed").
+			SetStartedAt(started).
+			SetCompletedAt(completed).
+			SaveX(ctx)
+
+		sub := client.AgentExecution.Create().
+			SetID(uuid.New().String()).
+			SetSessionID(sess.ID).
+			SetStageID(stg.ID).
+			SetAgentName("SubAgent").
+			SetAgentIndex(1).
+			SetLlmBackend(string(config.LLMBackendLangChain)).
+			SetParentExecutionID(parent.ID).
+			SetStatus("completed").
+			SetStartedAt(started).
+			SetCompletedAt(completed).
+			SaveX(ctx)
+
+		seedLLMInteraction(t, client.Client, sess.ID, stg.ID, parent.ID, "parent-model", 100, 30, 130, floatPtr(0.01), 0)
+		seedLLMInteraction(t, client.Client, sess.ID, stg.ID, sub.ID, "sub-model", 200, 50, 250, nil, 0)
+
+		detail, err := service.GetSessionDetail(ctx, sessionID)
+		require.NoError(t, err)
+		require.NotNil(t, detail.EstimatedCostUsd)
+		assert.InDelta(t, 0.01, *detail.EstimatedCostUsd, 1e-9)
+		assert.Equal(t, models.CostCompletenessPartial, detail.CostCompleteness)
+
+		require.Len(t, detail.Stages[0].Executions, 1)
+		orch := detail.Stages[0].Executions[0]
+		require.NotNil(t, orch.EstimatedCostUsd)
+		assert.InDelta(t, 0.01, *orch.EstimatedCostUsd, 1e-9, "parent should include sub-agent priced cost")
+		assert.Equal(t, models.CostCompletenessPartial, orch.CostCompleteness)
+		require.NotNil(t, orch.UnpricedInteractionCount)
+		assert.Equal(t, 1, *orch.UnpricedInteractionCount)
+
+		require.Len(t, orch.SubAgents, 1)
+		require.NotNil(t, orch.SubAgents[0].EstimatedCostUsd)
+		assert.Equal(t, 0.0, *orch.SubAgents[0].EstimatedCostUsd)
+		assert.Equal(t, models.CostCompletenessNone, orch.SubAgents[0].CostCompleteness)
+	})
+
+	t.Run("disabled estimation omits cost fields", func(t *testing.T) {
+		disabled := setupTestSessionService(t, client.Client)
+		disabled.SetCostEstimationEnabled(false)
+
+		sessionID, stageID, execID := seedSessionSkeleton(t, client.Client, "cost-disabled")
+		seedLLMInteraction(t, client.Client, sessionID, stageID, execID, "priced-model", 100, 50, 150, floatPtr(0.05), 0)
+
+		detail, err := disabled.GetSessionDetail(ctx, sessionID)
+		require.NoError(t, err)
+		assert.False(t, detail.CostEstimationEnabled)
+		assert.Nil(t, detail.EstimatedCostUsd)
+		assert.Empty(t, detail.CostCompleteness)
+		assert.Nil(t, detail.UnpricedInteractionCount)
+		require.Len(t, detail.Stages[0].Executions, 1)
+		assert.Nil(t, detail.Stages[0].Executions[0].EstimatedCostUsd)
+
+		summary, err := disabled.GetSessionSummary(ctx, sessionID)
+		require.NoError(t, err)
+		assert.False(t, summary.CostEstimationEnabled)
+		assert.Nil(t, summary.EstimatedCostUsd)
+		assert.Empty(t, summary.CostCompleteness)
+
+		list, err := disabled.ListSessionsForDashboard(ctx, models.DashboardListParams{
+			Page: 1, PageSize: 50, SortBy: "created_at", SortOrder: "desc",
+		})
+		require.NoError(t, err)
+		assert.False(t, list.CostEstimationEnabled)
+		for _, s := range list.Sessions {
+			if s.ID == sessionID {
+				assert.Nil(t, s.EstimatedCostUsd)
+				assert.Empty(t, s.CostCompleteness)
+				return
+			}
+		}
+		t.Fatal("session not found in list")
+	})
+
+	t.Run("list aggregates cost sum and completeness", func(t *testing.T) {
+		sessionID, stageID, execID := seedSessionSkeleton(t, client.Client, "cost-list")
+		seedLLMInteraction(t, client.Client, sessionID, stageID, execID, "m1", 100, 50, 150, floatPtr(0.02), 0)
+		seedLLMInteraction(t, client.Client, sessionID, stageID, execID, "m2", 50, 25, 75, floatPtr(0.03), 0)
+
+		list, err := service.ListSessionsForDashboard(ctx, models.DashboardListParams{
+			Page: 1, PageSize: 50, SortBy: "created_at", SortOrder: "desc",
+		})
+		require.NoError(t, err)
+		assert.True(t, list.CostEstimationEnabled)
+
+		for _, s := range list.Sessions {
+			if s.ID == sessionID {
+				require.NotNil(t, s.EstimatedCostUsd)
+				assert.InDelta(t, 0.05, *s.EstimatedCostUsd, 1e-9)
+				assert.Equal(t, models.CostCompletenessComplete, s.CostCompleteness)
+				return
+			}
+		}
+		t.Fatal("session not found in list")
+	})
+
+	t.Run("zero-token rows excluded from completeness denominator", func(t *testing.T) {
+		sessionID, stageID, execID := seedSessionSkeleton(t, client.Client, "cost-zero-tokens")
+		seedLLMInteraction(t, client.Client, sessionID, stageID, execID, "priced-model", 100, 50, 150, floatPtr(0.01), 0)
+		// Failed/empty call: no tokens, null cost — must not make completeness partial.
+		seedLLMInteraction(t, client.Client, sessionID, stageID, execID, "empty-call", 0, 0, 0, nil, 0)
+
+		detail, err := service.GetSessionDetail(ctx, sessionID)
+		require.NoError(t, err)
+		require.NotNil(t, detail.EstimatedCostUsd)
+		assert.InDelta(t, 0.01, *detail.EstimatedCostUsd, 1e-9)
+		assert.Equal(t, models.CostCompletenessComplete, detail.CostCompleteness)
+		require.NotNil(t, detail.UnpricedInteractionCount)
+		assert.Equal(t, 0, *detail.UnpricedInteractionCount)
+	})
+
+	t.Run("thinking-tokens-only row counts as token-bearing", func(t *testing.T) {
+		sessionID, stageID, execID := seedSessionSkeleton(t, client.Client, "cost-thinking")
+		seedLLMInteraction(t, client.Client, sessionID, stageID, execID, "thinking-model", 0, 0, 0, nil, 40)
+
+		detail, err := service.GetSessionDetail(ctx, sessionID)
+		require.NoError(t, err)
+		assert.Equal(t, models.CostCompletenessNone, detail.CostCompleteness)
+		require.NotNil(t, detail.UnpricedInteractionCount)
+		assert.Equal(t, 1, *detail.UnpricedInteractionCount)
+
+		list, err := service.ListSessionsForDashboard(ctx, models.DashboardListParams{
+			Page: 1, PageSize: 50, SortBy: "created_at", SortOrder: "desc",
+		})
+		require.NoError(t, err)
+		for _, s := range list.Sessions {
+			if s.ID == sessionID {
+				assert.Equal(t, models.CostCompletenessNone, s.CostCompleteness)
+				require.NotNil(t, s.EstimatedCostUsd)
+				assert.Equal(t, 0.0, *s.EstimatedCostUsd)
+				return
+			}
+		}
+		t.Fatal("session not found in list")
+	})
+
+	t.Run("list shows partial when some rows unpriced", func(t *testing.T) {
+		sessionID, stageID, execID := seedSessionSkeleton(t, client.Client, "cost-list-partial")
+		seedLLMInteraction(t, client.Client, sessionID, stageID, execID, "priced", 100, 50, 150, floatPtr(0.04), 0)
+		seedLLMInteraction(t, client.Client, sessionID, stageID, execID, "unpriced", 10, 5, 15, nil, 0)
+
+		list, err := service.ListSessionsForDashboard(ctx, models.DashboardListParams{
+			Page: 1, PageSize: 50, SortBy: "created_at", SortOrder: "desc",
+		})
+		require.NoError(t, err)
+		for _, s := range list.Sessions {
+			if s.ID == sessionID {
+				require.NotNil(t, s.EstimatedCostUsd)
+				assert.InDelta(t, 0.04, *s.EstimatedCostUsd, 1e-9)
+				assert.Equal(t, models.CostCompletenessPartial, s.CostCompleteness)
+				return
+			}
+		}
+		t.Fatal("session not found in list")
+	})
+
+	t.Run("parent rolls up priced sub-agent cost into complete", func(t *testing.T) {
+		now := time.Now()
+		started := now.Add(-10 * time.Second)
+		completed := now
+		sessionID := uuid.New().String()
+
+		sess := client.AlertSession.Create().
+			SetID(sessionID).
+			SetAlertData("cost rollup complete").
+			SetAlertType("pod-crash").
+			SetChainID("k8s-analysis").
+			SetAgentType("kubernetes").
+			SetStatus(alertsession.StatusCompleted).
+			SetStartedAt(started).
+			SetCompletedAt(completed).
+			SaveX(ctx)
+
+		stg := client.Stage.Create().
+			SetID(uuid.New().String()).
+			SetSessionID(sess.ID).
+			SetStageName("Orchestration").
+			SetStageIndex(1).
+			SetExpectedAgentCount(1).
+			SetStatus(stage.StatusCompleted).
+			SetStartedAt(started).
+			SetCompletedAt(completed).
+			SaveX(ctx)
+
+		parent := client.AgentExecution.Create().
+			SetID(uuid.New().String()).
+			SetSessionID(sess.ID).
+			SetStageID(stg.ID).
+			SetAgentName("Orchestrator").
+			SetAgentIndex(1).
+			SetLlmBackend(string(config.LLMBackendLangChain)).
+			SetStatus("completed").
+			SetStartedAt(started).
+			SetCompletedAt(completed).
+			SaveX(ctx)
+
+		sub := client.AgentExecution.Create().
+			SetID(uuid.New().String()).
+			SetSessionID(sess.ID).
+			SetStageID(stg.ID).
+			SetAgentName("SubAgent").
+			SetAgentIndex(1).
+			SetLlmBackend(string(config.LLMBackendLangChain)).
+			SetParentExecutionID(parent.ID).
+			SetStatus("completed").
+			SetStartedAt(started).
+			SetCompletedAt(completed).
+			SaveX(ctx)
+
+		seedLLMInteraction(t, client.Client, sess.ID, stg.ID, parent.ID, "parent-model", 100, 30, 130, floatPtr(0.01), 0)
+		seedLLMInteraction(t, client.Client, sess.ID, stg.ID, sub.ID, "sub-model", 200, 50, 250, floatPtr(0.02), 0)
+
+		detail, err := service.GetSessionDetail(ctx, sessionID)
+		require.NoError(t, err)
+		require.NotNil(t, detail.EstimatedCostUsd)
+		assert.InDelta(t, 0.03, *detail.EstimatedCostUsd, 1e-9)
+		assert.Equal(t, models.CostCompletenessComplete, detail.CostCompleteness)
+
+		orch := detail.Stages[0].Executions[0]
+		require.NotNil(t, orch.EstimatedCostUsd)
+		assert.InDelta(t, 0.03, *orch.EstimatedCostUsd, 1e-9)
+		assert.Equal(t, models.CostCompletenessComplete, orch.CostCompleteness)
+		require.NotNil(t, orch.UnpricedInteractionCount)
+		assert.Equal(t, 0, *orch.UnpricedInteractionCount)
+		require.Len(t, orch.SubAgents, 1)
+		require.NotNil(t, orch.SubAgents[0].EstimatedCostUsd)
+		assert.InDelta(t, 0.02, *orch.SubAgents[0].EstimatedCostUsd, 1e-9)
+		assert.Equal(t, models.CostCompletenessComplete, orch.SubAgents[0].CostCompleteness)
+	})
+}
+
+func seedSessionSkeleton(t *testing.T, client *ent.Client, alertData string) (sessionID, stageID, execID string) {
+	t.Helper()
+	ctx := context.Background()
+	now := time.Now()
+	started := now.Add(-5 * time.Second)
+	completed := now
+	sessionID = uuid.New().String()
+
+	sess := client.AlertSession.Create().
+		SetID(sessionID).
+		SetAlertData(alertData).
+		SetAlertType("pod-crash").
+		SetChainID("k8s-analysis").
+		SetAgentType("kubernetes").
+		SetStatus(alertsession.StatusCompleted).
+		SetStartedAt(started).
+		SetCompletedAt(completed).
+		SaveX(ctx)
+
+	stg := client.Stage.Create().
+		SetID(uuid.New().String()).
+		SetSessionID(sess.ID).
+		SetStageName("analysis").
+		SetStageIndex(1).
+		SetExpectedAgentCount(1).
+		SetStatus(stage.StatusCompleted).
+		SetStartedAt(started).
+		SetCompletedAt(completed).
+		SaveX(ctx)
+
+	exec := client.AgentExecution.Create().
+		SetID(uuid.New().String()).
+		SetSessionID(sess.ID).
+		SetStageID(stg.ID).
+		SetAgentName("TestAgent").
+		SetAgentIndex(1).
+		SetLlmBackend(string(config.LLMBackendLangChain)).
+		SetStartedAt(started).
+		SetStatus("completed").
+		SaveX(ctx)
+
+	return sess.ID, stg.ID, exec.ID
+}
+
+func seedLLMInteraction(
+	t *testing.T,
+	client *ent.Client,
+	sessionID, stageID, execID, modelName string,
+	inputTokens, outputTokens, totalTokens int,
+	costUSD *float64,
+	thinkingTokens int,
+) {
+	t.Helper()
+	create := client.LLMInteraction.Create().
+		SetID(uuid.New().String()).
+		SetSessionID(sessionID).
+		SetStageID(stageID).
+		SetExecutionID(execID).
+		SetInteractionType(llminteraction.InteractionTypeIteration).
+		SetModelName(modelName).
+		SetLlmRequest(map[string]interface{}{}).
+		SetLlmResponse(map[string]interface{}{}).
+		SetInputTokens(inputTokens).
+		SetOutputTokens(outputTokens).
+		SetTotalTokens(totalTokens)
+	if costUSD != nil {
+		create = create.SetEstimatedCostUsd(*costUSD)
+	}
+	if thinkingTokens > 0 {
+		create = create.SetThinkingTokens(thinkingTokens)
+	}
+	create.SaveX(context.Background())
+}
+
+func floatPtr(v float64) *float64 { return &v }
+
 func TestSessionService_GetActiveSessions(t *testing.T) {
 	client := testdb.NewTestClient(t)
 	service := setupTestSessionService(t, client.Client)

--- a/test/e2e/harness.go
+++ b/test/e2e/harness.go
@@ -218,6 +218,9 @@ func NewTestApp(t *testing.T, opts ...TestAppOption) *TestApp {
 	// 6. Domain services.
 	alertService := services.NewAlertService(entClient, tc.cfg.ChainRegistry, tc.cfg.Defaults, nil)
 	sessionService := services.NewSessionService(entClient, tc.cfg.ChainRegistry, tc.cfg.MCPServerRegistry)
+	if tc.cfg.CostEstimation != nil {
+		sessionService.SetCostEstimationEnabled(tc.cfg.CostEstimation.Enabled)
+	}
 	chatService := services.NewChatService(entClient)
 
 	// 7. RunbookService (nil config/token → uses defaults).

--- a/test/e2e/testdata/golden/action-chain/session.golden
+++ b/test/e2e/testdata/golden/action-chain/session.golden
@@ -11,11 +11,14 @@
   "chat_message_count": 0,
   "completed_at": "{TIMESTAMP}",
   "completed_stages": 3,
+  "cost_completeness": "none",
+  "cost_estimation_enabled": true,
   "created_at": "{TIMESTAMP}",
   "current_stage_id": "{STAGE_ID_3}",
   "current_stage_index": 3,
   "duration_ms": {DURATION_MS},
   "error_message": null,
+  "estimated_cost_usd": 0,
   "executive_summary": "api-gateway outage detected and remediated by automated restart.",
   "executive_summary_error": null,
   "failed_stages": 0,
@@ -45,8 +48,10 @@
           "agent_index": 1,
           "agent_name": "Investigator",
           "completed_at": "{TIMESTAMP}",
+          "cost_completeness": "none",
           "duration_ms": {DURATION_MS},
           "error_message": null,
+          "estimated_cost_usd": 0,
           "execution_id": "{EXEC_ID_1}",
           "input_tokens": 180,
           "llm_backend": "google-native",
@@ -54,7 +59,8 @@
           "output_tokens": 65,
           "started_at": "{TIMESTAMP}",
           "status": "completed",
-          "total_tokens": 245
+          "total_tokens": 245,
+          "unpriced_interaction_count": 2
         }
       ],
       "expected_agent_count": 1,
@@ -73,8 +79,10 @@
           "agent_index": 1,
           "agent_name": "Remediator",
           "completed_at": "{TIMESTAMP}",
+          "cost_completeness": "none",
           "duration_ms": {DURATION_MS},
           "error_message": null,
+          "estimated_cost_usd": 0,
           "execution_id": "{EXEC_ID_2}",
           "input_tokens": 220,
           "llm_backend": "google-native",
@@ -82,7 +90,8 @@
           "output_tokens": 80,
           "started_at": "{TIMESTAMP}",
           "status": "completed",
-          "total_tokens": 300
+          "total_tokens": 300,
+          "unpriced_interaction_count": 2
         }
       ],
       "expected_agent_count": 1,
@@ -101,8 +110,10 @@
           "agent_index": 1,
           "agent_name": "ExecSummaryAgent",
           "completed_at": "{TIMESTAMP}",
+          "cost_completeness": "none",
           "duration_ms": {DURATION_MS},
           "error_message": null,
+          "estimated_cost_usd": 0,
           "execution_id": "{EXEC_ID_3}",
           "input_tokens": 60,
           "llm_backend": "google-native",
@@ -110,7 +121,8 @@
           "output_tokens": 20,
           "started_at": "{TIMESTAMP}",
           "status": "completed",
-          "total_tokens": 80
+          "total_tokens": 80,
+          "unpriced_interaction_count": 1
         }
       ],
       "expected_agent_count": 1,
@@ -126,5 +138,6 @@
   "started_at": "{TIMESTAMP}",
   "status": "completed",
   "total_stages": 3,
-  "total_tokens": 625
+  "total_tokens": 625,
+  "unpriced_interaction_count": 5
 }

--- a/test/e2e/testdata/golden/orchestrator/session.golden
+++ b/test/e2e/testdata/golden/orchestrator/session.golden
@@ -11,11 +11,14 @@
   "chat_message_count": 0,
   "completed_at": "{TIMESTAMP}",
   "completed_stages": 2,
+  "cost_completeness": "none",
+  "cost_estimation_enabled": true,
   "created_at": "{TIMESTAMP}",
   "current_stage_id": "{UUID}",
   "current_stage_index": 2,
   "duration_ms": {DURATION_MS},
   "error_message": null,
+  "estimated_cost_usd": 0,
   "executive_summary": "Payment service alert: 2,847 5xx errors caused by memory pressure from recent deployment.",
   "executive_summary_error": null,
   "failed_stages": 0,
@@ -45,8 +48,10 @@
           "agent_index": 1,
           "agent_name": "SREOrchestrator",
           "completed_at": "{TIMESTAMP}",
+          "cost_completeness": "none",
           "duration_ms": {DURATION_MS},
           "error_message": null,
+          "estimated_cost_usd": 0,
           "execution_id": "{EXEC_ID_1}",
           "input_tokens": 1300,
           "llm_backend": "google-native",
@@ -59,8 +64,10 @@
               "agent_index": 1,
               "agent_name": "LogAnalyzer",
               "completed_at": "{TIMESTAMP}",
+              "cost_completeness": "none",
               "duration_ms": {DURATION_MS},
               "error_message": null,
+              "estimated_cost_usd": 0,
               "execution_id": "{EXEC_ID_2}",
               "input_tokens": 300,
               "llm_backend": "google-native",
@@ -70,10 +77,12 @@
               "started_at": "{TIMESTAMP}",
               "status": "completed",
               "task": "Find all error patterns in the last 30 minutes",
-              "total_tokens": 360
+              "total_tokens": 360,
+              "unpriced_interaction_count": 2
             }
           ],
-          "total_tokens": 1490
+          "total_tokens": 1490,
+          "unpriced_interaction_count": 5
         }
       ],
       "expected_agent_count": 1,
@@ -92,8 +101,10 @@
           "agent_index": 1,
           "agent_name": "ExecSummaryAgent",
           "completed_at": "{TIMESTAMP}",
+          "cost_completeness": "none",
           "duration_ms": {DURATION_MS},
           "error_message": null,
+          "estimated_cost_usd": 0,
           "execution_id": "{UUID}",
           "input_tokens": 10,
           "llm_backend": "google-native",
@@ -101,7 +112,8 @@
           "output_tokens": 5,
           "started_at": "{TIMESTAMP}",
           "status": "completed",
-          "total_tokens": 15
+          "total_tokens": 15,
+          "unpriced_interaction_count": 1
         }
       ],
       "expected_agent_count": 1,
@@ -117,5 +129,6 @@
   "started_at": "{TIMESTAMP}",
   "status": "completed",
   "total_stages": 2,
-  "total_tokens": 1505
+  "total_tokens": 1505,
+  "unpriced_interaction_count": 6
 }

--- a/test/e2e/testdata/golden/pipeline/session.golden
+++ b/test/e2e/testdata/golden/pipeline/session.golden
@@ -11,11 +11,14 @@
   "chat_message_count": 2,
   "completed_at": "{TIMESTAMP}",
   "completed_stages": 9,
+  "cost_completeness": "none",
+  "cost_estimation_enabled": true,
   "created_at": "{TIMESTAMP}",
   "current_stage_id": "{STAGE_ID_7}",
   "current_stage_index": 7,
   "duration_ms": {DURATION_MS},
   "error_message": null,
+  "estimated_cost_usd": 0,
   "executive_summary": "Pod-1 OOM killed due to memory leak. Recommend increasing memory limit.",
   "executive_summary_error": null,
   "failed_stages": 0,
@@ -45,8 +48,10 @@
           "agent_index": 1,
           "agent_name": "DataCollector",
           "completed_at": "{TIMESTAMP}",
+          "cost_completeness": "none",
           "duration_ms": {DURATION_MS},
           "error_message": null,
+          "estimated_cost_usd": 0,
           "execution_id": "{EXEC_ID_1}",
           "input_tokens": 460,
           "llm_backend": "google-native",
@@ -54,7 +59,8 @@
           "output_tokens": 115,
           "started_at": "{TIMESTAMP}",
           "status": "completed",
-          "total_tokens": 575
+          "total_tokens": 575,
+          "unpriced_interaction_count": 4
         }
       ],
       "expected_agent_count": 1,
@@ -73,8 +79,10 @@
           "agent_index": 1,
           "agent_name": "Remediator",
           "completed_at": "{TIMESTAMP}",
+          "cost_completeness": "none",
           "duration_ms": {DURATION_MS},
           "error_message": null,
+          "estimated_cost_usd": 0,
           "execution_id": "{EXEC_ID_2}",
           "input_tokens": 40,
           "llm_backend": "langchain",
@@ -82,7 +90,8 @@
           "output_tokens": 20,
           "started_at": "{TIMESTAMP}",
           "status": "completed",
-          "total_tokens": 60
+          "total_tokens": 60,
+          "unpriced_interaction_count": 4
         }
       ],
       "expected_agent_count": 1,
@@ -101,8 +110,10 @@
           "agent_index": 1,
           "agent_name": "ConfigValidator",
           "completed_at": "{TIMESTAMP}",
+          "cost_completeness": "none",
           "duration_ms": {DURATION_MS},
           "error_message": null,
+          "estimated_cost_usd": 0,
           "execution_id": "{EXEC_ID_3}",
           "input_tokens": 20,
           "llm_backend": "langchain",
@@ -110,14 +121,17 @@
           "output_tokens": 10,
           "started_at": "{TIMESTAMP}",
           "status": "completed",
-          "total_tokens": 30
+          "total_tokens": 30,
+          "unpriced_interaction_count": 2
         },
         {
           "agent_index": 2,
           "agent_name": "MetricsValidator",
           "completed_at": "{TIMESTAMP}",
+          "cost_completeness": "none",
           "duration_ms": {DURATION_MS},
           "error_message": null,
+          "estimated_cost_usd": 0,
           "execution_id": "{EXEC_ID_4}",
           "input_tokens": 180,
           "llm_backend": "google-native",
@@ -125,7 +139,8 @@
           "output_tokens": 50,
           "started_at": "{TIMESTAMP}",
           "status": "completed",
-          "total_tokens": 230
+          "total_tokens": 230,
+          "unpriced_interaction_count": 2
         }
       ],
       "expected_agent_count": 2,
@@ -144,8 +159,10 @@
           "agent_index": 1,
           "agent_name": "SynthesisAgent",
           "completed_at": "{TIMESTAMP}",
+          "cost_completeness": "none",
           "duration_ms": {DURATION_MS},
           "error_message": null,
+          "estimated_cost_usd": 0,
           "execution_id": "{EXEC_ID_5}",
           "input_tokens": 120,
           "llm_backend": "google-native",
@@ -153,7 +170,8 @@
           "output_tokens": 40,
           "started_at": "{TIMESTAMP}",
           "status": "completed",
-          "total_tokens": 160
+          "total_tokens": 160,
+          "unpriced_interaction_count": 1
         }
       ],
       "expected_agent_count": 1,
@@ -173,8 +191,10 @@
           "agent_index": 1,
           "agent_name": "ScalingReviewer-1",
           "completed_at": "{TIMESTAMP}",
+          "cost_completeness": "none",
           "duration_ms": {DURATION_MS},
           "error_message": null,
+          "estimated_cost_usd": 0,
           "execution_id": "{EXEC_ID_6}",
           "input_tokens": 80,
           "llm_backend": "google-native",
@@ -182,14 +202,17 @@
           "output_tokens": 25,
           "started_at": "{TIMESTAMP}",
           "status": "completed",
-          "total_tokens": 105
+          "total_tokens": 105,
+          "unpriced_interaction_count": 1
         },
         {
           "agent_index": 2,
           "agent_name": "ScalingReviewer-2",
           "completed_at": "{TIMESTAMP}",
+          "cost_completeness": "none",
           "duration_ms": {DURATION_MS},
           "error_message": null,
+          "estimated_cost_usd": 0,
           "execution_id": "{EXEC_ID_7}",
           "input_tokens": 80,
           "llm_backend": "google-native",
@@ -197,7 +220,8 @@
           "output_tokens": 25,
           "started_at": "{TIMESTAMP}",
           "status": "completed",
-          "total_tokens": 105
+          "total_tokens": 105,
+          "unpriced_interaction_count": 1
         }
       ],
       "expected_agent_count": 2,
@@ -216,8 +240,10 @@
           "agent_index": 1,
           "agent_name": "SynthesisAgent",
           "completed_at": "{TIMESTAMP}",
+          "cost_completeness": "none",
           "duration_ms": {DURATION_MS},
           "error_message": null,
+          "estimated_cost_usd": 0,
           "execution_id": "{EXEC_ID_8}",
           "input_tokens": 10,
           "llm_backend": "langchain",
@@ -225,7 +251,8 @@
           "output_tokens": 5,
           "started_at": "{TIMESTAMP}",
           "status": "completed",
-          "total_tokens": 15
+          "total_tokens": 15,
+          "unpriced_interaction_count": 1
         }
       ],
       "expected_agent_count": 1,
@@ -245,8 +272,10 @@
           "agent_index": 1,
           "agent_name": "ExecSummaryAgent",
           "completed_at": "{TIMESTAMP}",
+          "cost_completeness": "none",
           "duration_ms": {DURATION_MS},
           "error_message": null,
+          "estimated_cost_usd": 0,
           "execution_id": "{EXEC_ID_9}",
           "input_tokens": 10,
           "llm_backend": "google-native",
@@ -254,7 +283,8 @@
           "output_tokens": 5,
           "started_at": "{TIMESTAMP}",
           "status": "completed",
-          "total_tokens": 15
+          "total_tokens": 15,
+          "unpriced_interaction_count": 1
         }
       ],
       "expected_agent_count": 1,
@@ -273,8 +303,10 @@
           "agent_index": 1,
           "agent_name": "ChatAgent",
           "completed_at": "{TIMESTAMP}",
+          "cost_completeness": "none",
           "duration_ms": {DURATION_MS},
           "error_message": null,
+          "estimated_cost_usd": 0,
           "execution_id": "{EXEC_ID_10}",
           "input_tokens": 460,
           "llm_backend": "google-native",
@@ -282,7 +314,8 @@
           "output_tokens": 85,
           "started_at": "{TIMESTAMP}",
           "status": "completed",
-          "total_tokens": 545
+          "total_tokens": 545,
+          "unpriced_interaction_count": 3
         }
       ],
       "expected_agent_count": 1,
@@ -301,8 +334,10 @@
           "agent_index": 1,
           "agent_name": "ChatAgent",
           "completed_at": "{TIMESTAMP}",
+          "cost_completeness": "none",
           "duration_ms": {DURATION_MS},
           "error_message": null,
+          "estimated_cost_usd": 0,
           "execution_id": "{EXEC_ID_11}",
           "input_tokens": 650,
           "llm_backend": "google-native",
@@ -310,7 +345,8 @@
           "output_tokens": 65,
           "started_at": "{TIMESTAMP}",
           "status": "completed",
-          "total_tokens": 715
+          "total_tokens": 715,
+          "unpriced_interaction_count": 2
         }
       ],
       "expected_agent_count": 1,
@@ -326,5 +362,6 @@
   "started_at": "{TIMESTAMP}",
   "status": "completed",
   "total_stages": 9,
-  "total_tokens": 2555
+  "total_tokens": 2555,
+  "unpriced_interaction_count": 22
 }

--- a/test/e2e/testdata/golden/skills/session.golden
+++ b/test/e2e/testdata/golden/skills/session.golden
@@ -11,11 +11,14 @@
   "chat_message_count": 1,
   "completed_at": "{TIMESTAMP}",
   "completed_stages": 4,
+  "cost_completeness": "none",
+  "cost_estimation_enabled": true,
   "created_at": "{TIMESTAMP}",
   "current_stage_id": "{STAGE_ID_3}",
   "current_stage_index": 3,
   "duration_ms": {DURATION_MS},
   "error_message": null,
+  "estimated_cost_usd": 0,
   "executive_summary": "Pod-1 OOM killed. Memory limit increase to 1Gi recommended.",
   "executive_summary_error": null,
   "failed_stages": 0,
@@ -45,8 +48,10 @@
           "agent_index": 1,
           "agent_name": "SkillInvestigator",
           "completed_at": "{TIMESTAMP}",
+          "cost_completeness": "none",
           "duration_ms": {DURATION_MS},
           "error_message": null,
+          "estimated_cost_usd": 0,
           "execution_id": "{EXEC_ID_1}",
           "input_tokens": 450,
           "llm_backend": "google-native",
@@ -54,7 +59,8 @@
           "output_tokens": 100,
           "started_at": "{TIMESTAMP}",
           "status": "completed",
-          "total_tokens": 550
+          "total_tokens": 550,
+          "unpriced_interaction_count": 3
         }
       ],
       "expected_agent_count": 1,
@@ -73,8 +79,10 @@
           "agent_index": 1,
           "agent_name": "SkillRemediator",
           "completed_at": "{TIMESTAMP}",
+          "cost_completeness": "none",
           "duration_ms": {DURATION_MS},
           "error_message": null,
+          "estimated_cost_usd": 0,
           "execution_id": "{EXEC_ID_2}",
           "input_tokens": 100,
           "llm_backend": "google-native",
@@ -82,7 +90,8 @@
           "output_tokens": 30,
           "started_at": "{TIMESTAMP}",
           "status": "completed",
-          "total_tokens": 130
+          "total_tokens": 130,
+          "unpriced_interaction_count": 1
         }
       ],
       "expected_agent_count": 1,
@@ -101,8 +110,10 @@
           "agent_index": 1,
           "agent_name": "ExecSummaryAgent",
           "completed_at": "{TIMESTAMP}",
+          "cost_completeness": "none",
           "duration_ms": {DURATION_MS},
           "error_message": null,
+          "estimated_cost_usd": 0,
           "execution_id": "{EXEC_ID_3}",
           "input_tokens": 10,
           "llm_backend": "google-native",
@@ -110,7 +121,8 @@
           "output_tokens": 5,
           "started_at": "{TIMESTAMP}",
           "status": "completed",
-          "total_tokens": 15
+          "total_tokens": 15,
+          "unpriced_interaction_count": 1
         }
       ],
       "expected_agent_count": 1,
@@ -129,8 +141,10 @@
           "agent_index": 1,
           "agent_name": "ChatAgent",
           "completed_at": "{TIMESTAMP}",
+          "cost_completeness": "none",
           "duration_ms": {DURATION_MS},
           "error_message": null,
+          "estimated_cost_usd": 0,
           "execution_id": "{EXEC_ID_4}",
           "input_tokens": 450,
           "llm_backend": "google-native",
@@ -138,7 +152,8 @@
           "output_tokens": 65,
           "started_at": "{TIMESTAMP}",
           "status": "completed",
-          "total_tokens": 515
+          "total_tokens": 515,
+          "unpriced_interaction_count": 2
         }
       ],
       "expected_agent_count": 1,
@@ -154,5 +169,6 @@
   "started_at": "{TIMESTAMP}",
   "status": "completed",
   "total_stages": 4,
-  "total_tokens": 1210
+  "total_tokens": 1210,
+  "unpriced_interaction_count": 7
 }


### PR DESCRIPTION
- Aggregate SUM(estimated_cost_usd) and completeness counts on list, detail, summary, and ExecutionOverview
- Emit cost_estimation_enabled; omit cost fields when estimation is disabled
- Roll parent execution cost up from nested sub-agents like tokens
- Document session API cost fields and update e2e session goldens

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Session APIs now report estimated USD costs when cost estimation is enabled.
  - Added cost completeness indicators (`complete`, `partial`, or `none`) and counts of unpriced interactions.
  - Cost details are available in session lists, details, summaries, and execution overviews.
  - Cost estimation can be enabled or disabled through configuration.

- **Documentation**
  - Updated cost-estimation API documentation and marked the related design milestone complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->