### PR TITLE
Add GET /api/v1/usage/summary fleet aggregates

### DIFF
--- a/docs/proposals/session-usage-cost-design.md
+++ b/docs/proposals/session-usage-cost-design.md
@@ -286,7 +286,7 @@ Depends on PR 1's columns. Mechanical extension of existing aggregation code to 
 
 New fields are additive JSON; the dashboard doesn't consume them yet, so nothing changes visibly.
 
-### PR 3 — Usage API
+### PR 3 — Usage API ✅ Done
 
 Depends on PR 1's columns (independent of PR 2). A new endpoint with its own aggregation/ranking logic, not an extension of existing code — different review lens from PR 2.
 

--- a/docs/session-usage-cost.md
+++ b/docs/session-usage-cost.md
@@ -96,7 +96,7 @@ When estimation is **disabled**: responses set `cost_estimation_enabled: false` 
 
 ## Usage API
 
-```
+```text
 GET /api/v1/usage/summary?start_date=&end_date=&alert_type=&chain_id=&rank_by=cost|tokens
 ```
 
@@ -105,7 +105,7 @@ Server-side fleet aggregates for one date window (the Usage page does not load-a
 | Param | Required | Notes |
 |-------|----------|--------|
 | `start_date` | yes | RFC3339; session `created_at >= start_date` |
-| `end_date` | yes | RFC3339; session `created_at < end_date` (half-open, same as Alert History) |
+| `end_date` | yes | RFC3339; session `created_at < end_date` (half-open, same as Alert History). Window length (`end - start`) must not exceed 365 days. |
 | `alert_type` | no | Exact match filter |
 | `chain_id` | no | Exact match filter |
 | `rank_by` | no | `cost` or `tokens`. Default: `cost` when estimation enabled, else `tokens`. `rank_by=cost` is rejected when estimation is disabled. |

--- a/docs/session-usage-cost.md
+++ b/docs/session-usage-cost.md
@@ -2,7 +2,7 @@
 
 TARSy can attach an **estimated USD cost** to each LLM interaction at write time, using list prices from a price book. Estimates are for operator judgment — they are **not** invoice truth.
 
-Cost is persisted on each `llm_interaction` at write time. Session list, detail, summary, and `ExecutionOverview` APIs expose estimated cost + completeness when estimation is enabled. The Usage dashboard page and `GET /api/v1/usage/summary` land in follow-up work. Config Viewer already exposes the effective toggle, overrides, and catalog status via `GET /api/v1/system/config`.
+Cost is persisted on each `llm_interaction` at write time. Session list, detail, summary, and `ExecutionOverview` APIs expose estimated cost + completeness when estimation is enabled. Fleet dig-in uses `GET /api/v1/usage/summary` (Usage dashboard page lands in follow-up work). Config Viewer already exposes the effective toggle, overrides, and catalog status via `GET /api/v1/system/config`.
 
 ## Table of Contents
 
@@ -11,6 +11,7 @@ Cost is persisted on each `llm_interaction` at write time. Session list, detail,
 - [Price book](#price-book)
 - [How estimates are computed](#how-estimates-are-computed)
 - [Session APIs](#session-apis)
+- [Usage API](#usage-api)
 - [Thinking tokens](#thinking-tokens)
 - [Known gaps](#known-gaps)
 - [Completeness](#completeness)
@@ -93,6 +94,32 @@ When cost estimation is **enabled**, these responses include cost fields next to
 
 When estimation is **disabled**: responses set `cost_estimation_enabled: false` and omit the other cost keys. Aggregates use `SUM(estimated_cost_usd)` of non-null values; completeness uses priced vs token-bearing interaction counts (see [Completeness](#completeness)).
 
+## Usage API
+
+```
+GET /api/v1/usage/summary?start_date=&end_date=&alert_type=&chain_id=&rank_by=cost|tokens
+```
+
+Server-side fleet aggregates for one date window (the Usage page does not load-all-then-filter).
+
+| Param | Required | Notes |
+|-------|----------|--------|
+| `start_date` | yes | RFC3339; session `created_at >= start_date` |
+| `end_date` | yes | RFC3339; session `created_at < end_date` (half-open, same as Alert History) |
+| `alert_type` | no | Exact match filter |
+| `chain_id` | no | Exact match filter |
+| `rank_by` | no | `cost` or `tokens`. Default: `cost` when estimation enabled, else `tokens`. `rank_by=cost` is rejected when estimation is disabled. |
+
+Rules:
+
+- Soft-deleted sessions are always excluded.
+- All `interaction_type` values count (same as session token SUMs).
+- Response sections: `totals`, `by_model`, `by_alert_type`, `by_chain`, and capped `top_sessions` (hardcoded top **20**; no `limit` param).
+- Unpriced top sessions are included with `$0` + `cost_completeness` (not dropped).
+- When estimation is disabled: `cost_estimation_enabled: false` and cost fields are omitted; token rollups remain.
+
+Window edge case: a long-running session started before the window is excluded even if it burns tokens inside the window (and late chat on an in-window session is included). Same mental model as Alert History.
+
 ## Thinking tokens
 
 - Column: `llm_interactions.thinking_tokens` (nullable).
@@ -111,7 +138,7 @@ When estimation is **disabled**: responses set `cost_estimation_enabled: false` 
 
 ## Completeness
 
-Session list/detail/summary and `ExecutionOverview` expose `cost_completeness` (Usage API follows later). Semantics:
+Session list/detail/summary, `ExecutionOverview`, and `GET /api/v1/usage/summary` expose `cost_completeness`. Semantics:
 
 | Completeness | Meaning |
 |--------------|---------|

--- a/pkg/api/handler_usage.go
+++ b/pkg/api/handler_usage.go
@@ -9,6 +9,9 @@ import (
 	"github.com/codeready-toolchain/tarsy/pkg/models"
 )
 
+// maxUsageSummaryWindow is the maximum allowed end_date - start_date span.
+const maxUsageSummaryWindow = 365 * 24 * time.Hour
+
 // usageSummaryHandler handles GET /api/v1/usage/summary.
 func (s *Server) usageSummaryHandler(c *echo.Context) error {
 	startRaw := c.QueryParam("start_date")
@@ -31,6 +34,9 @@ func (s *Server) usageSummaryHandler(c *echo.Context) error {
 
 	if !start.Before(end) {
 		return echo.NewHTTPError(http.StatusBadRequest, "start_date must be before end_date")
+	}
+	if end.Sub(start) > maxUsageSummaryWindow {
+		return echo.NewHTTPError(http.StatusBadRequest, "date window must not exceed 365 days")
 	}
 
 	params := models.UsageSummaryParams{

--- a/pkg/api/handler_usage.go
+++ b/pkg/api/handler_usage.go
@@ -1,0 +1,59 @@
+package api
+
+import (
+	"net/http"
+	"time"
+
+	echo "github.com/labstack/echo/v5"
+
+	"github.com/codeready-toolchain/tarsy/pkg/models"
+)
+
+// usageSummaryHandler handles GET /api/v1/usage/summary.
+func (s *Server) usageSummaryHandler(c *echo.Context) error {
+	startRaw := c.QueryParam("start_date")
+	if startRaw == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "start_date is required")
+	}
+	start, err := time.Parse(time.RFC3339, startRaw)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid start_date: must be RFC3339")
+	}
+
+	endRaw := c.QueryParam("end_date")
+	if endRaw == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "end_date is required")
+	}
+	end, err := time.Parse(time.RFC3339, endRaw)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid end_date: must be RFC3339")
+	}
+
+	if !start.Before(end) {
+		return echo.NewHTTPError(http.StatusBadRequest, "start_date must be before end_date")
+	}
+
+	params := models.UsageSummaryParams{
+		StartDate: start,
+		EndDate:   end,
+		AlertType: c.QueryParam("alert_type"),
+		ChainID:   c.QueryParam("chain_id"),
+	}
+
+	if v := c.QueryParam("rank_by"); v != "" {
+		if !models.ValidUsageRankBy(v) {
+			return echo.NewHTTPError(http.StatusBadRequest, "invalid rank_by: must be cost or tokens")
+		}
+		rankBy := models.UsageRankBy(v)
+		if rankBy == models.UsageRankByCost && s.sessionService != nil && !s.sessionService.CostEstimationEnabled() {
+			return echo.NewHTTPError(http.StatusBadRequest, "rank_by=cost requires cost estimation to be enabled")
+		}
+		params.RankBy = rankBy
+	}
+
+	result, err := s.sessionService.GetUsageSummary(c.Request().Context(), params)
+	if err != nil {
+		return mapServiceError(err)
+	}
+	return c.JSON(http.StatusOK, result)
+}

--- a/pkg/api/handler_usage_test.go
+++ b/pkg/api/handler_usage_test.go
@@ -1,0 +1,162 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	echo "github.com/labstack/echo/v5"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/codeready-toolchain/tarsy/ent"
+	"github.com/codeready-toolchain/tarsy/pkg/config"
+	"github.com/codeready-toolchain/tarsy/pkg/services"
+)
+
+func TestUsageSummaryHandler_Validation(t *testing.T) {
+	s := &Server{}
+	validWindow := "start_date=2024-01-01T00:00:00Z&end_date=2024-02-01T00:00:00Z"
+
+	tests := []struct {
+		name    string
+		query   string
+		wantErr int
+		errMsg  string
+	}{
+		{
+			name:    "missing start_date",
+			query:   "end_date=2024-02-01T00:00:00Z",
+			wantErr: http.StatusBadRequest,
+			errMsg:  "start_date is required",
+		},
+		{
+			name:    "missing end_date",
+			query:   "start_date=2024-01-01T00:00:00Z",
+			wantErr: http.StatusBadRequest,
+			errMsg:  "end_date is required",
+		},
+		{
+			name:    "invalid start_date",
+			query:   "start_date=not-a-date&end_date=2024-02-01T00:00:00Z",
+			wantErr: http.StatusBadRequest,
+			errMsg:  "invalid start_date",
+		},
+		{
+			name:    "end_date wrong format",
+			query:   "start_date=2024-01-01T00:00:00Z&end_date=2024-01-01",
+			wantErr: http.StatusBadRequest,
+			errMsg:  "invalid end_date",
+		},
+		{
+			name:    "start_date equal to end_date",
+			query:   "start_date=2024-01-01T00:00:00Z&end_date=2024-01-01T00:00:00Z",
+			wantErr: http.StatusBadRequest,
+			errMsg:  "start_date must be before end_date",
+		},
+		{
+			name:    "start_date after end_date",
+			query:   "start_date=2024-02-01T00:00:00Z&end_date=2024-01-01T00:00:00Z",
+			wantErr: http.StatusBadRequest,
+			errMsg:  "start_date must be before end_date",
+		},
+		{
+			name:    "invalid rank_by",
+			query:   validWindow + "&rank_by=sessions",
+			wantErr: http.StatusBadRequest,
+			errMsg:  "invalid rank_by",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/usage/summary?"+tt.query, nil)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			err := s.usageSummaryHandler(c)
+			if assert.Error(t, err) {
+				he, ok := err.(*echo.HTTPError)
+				if assert.True(t, ok, "expected echo.HTTPError") {
+					assert.Equal(t, tt.wantErr, he.Code)
+					assert.Contains(t, he.Message, tt.errMsg)
+				}
+			}
+		})
+	}
+
+	t.Run("rank_by=cost rejected when estimation disabled", func(t *testing.T) {
+		svc := newUsageTestSessionService()
+		svc.SetCostEstimationEnabled(false)
+		disabled := &Server{sessionService: svc}
+
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/usage/summary?"+validWindow+"&rank_by=cost", nil)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+
+		err := disabled.usageSummaryHandler(c)
+		if assert.Error(t, err) {
+			he, ok := err.(*echo.HTTPError)
+			if assert.True(t, ok, "expected echo.HTTPError") {
+				assert.Equal(t, http.StatusBadRequest, he.Code)
+				assert.Contains(t, he.Message, "rank_by=cost requires cost estimation")
+			}
+		}
+	})
+
+	t.Run("valid rank_by values pass validation", func(t *testing.T) {
+		for _, v := range []string{"", "cost", "tokens"} {
+			t.Run("rank_by="+v, func(t *testing.T) {
+				query := validWindow
+				if v != "" {
+					query += "&rank_by=" + v
+				}
+				e := echo.New()
+				req := httptest.NewRequest(http.MethodGet, "/api/v1/usage/summary?"+query, nil)
+				rec := httptest.NewRecorder()
+				c := e.NewContext(req, rec)
+
+				err := func() (retErr error) {
+					defer func() { recover() }()
+					return s.usageSummaryHandler(c)
+				}()
+
+				if err != nil {
+					he, ok := err.(*echo.HTTPError)
+					if ok {
+						assert.NotContains(t, he.Message, "invalid rank_by",
+							"rank_by=%q should be accepted", v)
+						assert.NotContains(t, he.Message, "start_date",
+							"valid window should pass date validation")
+					}
+				}
+			})
+		}
+	})
+}
+
+func newUsageTestSessionService() *services.SessionService {
+	chainRegistry := config.NewChainRegistry(map[string]*config.ChainConfig{
+		"k8s-analysis": {
+			AlertTypes: []string{"kubernetes"},
+			Stages: []config.StageConfig{
+				{
+					Name: "analysis",
+					Agents: []config.StageAgentConfig{
+						{Name: config.AgentNameKubernetes},
+					},
+				},
+			},
+		},
+	})
+	mcpServerRegistry := config.NewMCPServerRegistry(map[string]*config.MCPServerConfig{
+		"kubernetes-server": {
+			Transport: config.TransportConfig{
+				Type:    config.TransportTypeStdio,
+				Command: "test-command",
+			},
+		},
+	})
+	return services.NewSessionService(&ent.Client{}, chainRegistry, mcpServerRegistry)
+}

--- a/pkg/api/handler_usage_test.go
+++ b/pkg/api/handler_usage_test.go
@@ -1,16 +1,20 @@
 package api
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	echo "github.com/labstack/echo/v5"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/codeready-toolchain/tarsy/ent"
 	"github.com/codeready-toolchain/tarsy/pkg/config"
+	"github.com/codeready-toolchain/tarsy/pkg/models"
 	"github.com/codeready-toolchain/tarsy/pkg/services"
+	testdb "github.com/codeready-toolchain/tarsy/test/database"
 )
 
 func TestUsageSummaryHandler_Validation(t *testing.T) {
@@ -65,6 +69,12 @@ func TestUsageSummaryHandler_Validation(t *testing.T) {
 			wantErr: http.StatusBadRequest,
 			errMsg:  "invalid rank_by",
 		},
+		{
+			name:    "window longer than 365 days",
+			query:   "start_date=2024-01-01T00:00:00Z&end_date=2025-01-02T00:00:00Z",
+			wantErr: http.StatusBadRequest,
+			errMsg:  "date window must not exceed 365 days",
+		},
 	}
 
 	for _, tt := range tests {
@@ -86,7 +96,7 @@ func TestUsageSummaryHandler_Validation(t *testing.T) {
 	}
 
 	t.Run("rank_by=cost rejected when estimation disabled", func(t *testing.T) {
-		svc := newUsageTestSessionService()
+		svc := newUsageTestSessionService(&ent.Client{})
 		svc.SetCostEstimationEnabled(false)
 		disabled := &Server{sessionService: svc}
 
@@ -106,6 +116,9 @@ func TestUsageSummaryHandler_Validation(t *testing.T) {
 	})
 
 	t.Run("valid rank_by values pass validation", func(t *testing.T) {
+		client := testdb.NewTestClient(t)
+		server := &Server{sessionService: newUsageTestSessionService(client.Client)}
+
 		for _, v := range []string{"", "cost", "tokens"} {
 			t.Run("rank_by="+v, func(t *testing.T) {
 				query := validWindow
@@ -117,26 +130,23 @@ func TestUsageSummaryHandler_Validation(t *testing.T) {
 				rec := httptest.NewRecorder()
 				c := e.NewContext(req, rec)
 
-				err := func() (retErr error) {
-					defer func() { recover() }()
-					return s.usageSummaryHandler(c)
-				}()
+				err := server.usageSummaryHandler(c)
+				require.NoError(t, err)
+				assert.Equal(t, http.StatusOK, rec.Code)
 
-				if err != nil {
-					he, ok := err.(*echo.HTTPError)
-					if ok {
-						assert.NotContains(t, he.Message, "invalid rank_by",
-							"rank_by=%q should be accepted", v)
-						assert.NotContains(t, he.Message, "start_date",
-							"valid window should pass date validation")
-					}
+				var resp models.UsageSummaryResponse
+				require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+				if v == "" {
+					assert.Equal(t, models.UsageRankByCost, resp.RankBy)
+				} else {
+					assert.Equal(t, models.UsageRankBy(v), resp.RankBy)
 				}
 			})
 		}
 	})
 }
 
-func newUsageTestSessionService() *services.SessionService {
+func newUsageTestSessionService(client *ent.Client) *services.SessionService {
 	chainRegistry := config.NewChainRegistry(map[string]*config.ChainConfig{
 		"k8s-analysis": {
 			AlertTypes: []string{"kubernetes"},
@@ -158,5 +168,5 @@ func newUsageTestSessionService() *services.SessionService {
 			},
 		},
 	})
-	return services.NewSessionService(&ent.Client{}, chainRegistry, mcpServerRegistry)
+	return services.NewSessionService(client, chainRegistry, mcpServerRegistry)
 }

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -278,6 +278,9 @@ func (s *Server) setupRoutes() {
 	v1.GET("/sessions/:id/review-activity", s.getReviewActivityHandler)
 	v1.GET("/sessions/:id/timeline", s.getTimelineHandler)
 
+	// Usage aggregation.
+	v1.GET("/usage/summary", s.usageSummaryHandler)
+
 	// System endpoints.
 	v1.GET("/system/warnings", s.systemWarningsHandler)
 	v1.GET("/system/mcp-servers", s.mcpServersHandler)

--- a/pkg/models/session.go
+++ b/pkg/models/session.go
@@ -326,6 +326,99 @@ func DeriveCostCompleteness(tokenBearing, priced int) CostCompleteness {
 	return CostCompletenessPartial
 }
 
+// --- Usage summary DTOs (GET /api/v1/usage/summary) ---
+
+// UsageRankBy selects how top_sessions are ordered.
+type UsageRankBy string
+
+// Usage ranking modes for top_sessions.
+const (
+	UsageRankByCost   UsageRankBy = "cost"
+	UsageRankByTokens UsageRankBy = "tokens"
+)
+
+// ValidUsageRankBy reports whether s is a known rank_by value.
+func ValidUsageRankBy(s string) bool {
+	switch UsageRankBy(s) {
+	case UsageRankByCost, UsageRankByTokens:
+		return true
+	default:
+		return false
+	}
+}
+
+// UsageSummaryParams holds query parameters for the usage summary endpoint.
+type UsageSummaryParams struct {
+	StartDate time.Time   // created_at >= start (required)
+	EndDate   time.Time   // created_at < end (required)
+	AlertType string      // optional exact filter
+	ChainID   string      // optional exact filter
+	RankBy    UsageRankBy // cost or tokens; empty means default from costEstimationEnabled
+}
+
+// UsageSummaryResponse is returned by GET /api/v1/usage/summary.
+type UsageSummaryResponse struct {
+	CostEstimationEnabled bool                  `json:"cost_estimation_enabled"`
+	Window                UsageWindow           `json:"window"`
+	RankBy                UsageRankBy           `json:"rank_by"`
+	Totals                UsageTotals           `json:"totals"`
+	ByModel               []UsageModelBreakdown `json:"by_model"`
+	ByAlertType           []UsageAlertBreakdown `json:"by_alert_type"`
+	ByChain               []UsageChainBreakdown `json:"by_chain"`
+	TopSessions           []UsageTopSession     `json:"top_sessions"`
+}
+
+// UsageWindow echoes the requested date range.
+type UsageWindow struct {
+	Start time.Time `json:"start"`
+	End   time.Time `json:"end"`
+}
+
+// UsageTotals is the fleet-wide token/cost rollup for the window.
+type UsageTotals struct {
+	InputTokens              int64            `json:"input_tokens"`
+	OutputTokens             int64            `json:"output_tokens"`
+	TotalTokens              int64            `json:"total_tokens"`
+	EstimatedCostUsd         *float64         `json:"estimated_cost_usd,omitempty"`
+	CostCompleteness         CostCompleteness `json:"cost_completeness,omitempty"`
+	UnpricedInteractionCount *int             `json:"unpriced_interaction_count,omitempty"`
+}
+
+// UsageModelBreakdown is a per-model rollup within the window.
+type UsageModelBreakdown struct {
+	ModelName        string   `json:"model_name"`
+	InputTokens      int64    `json:"input_tokens"`
+	OutputTokens     int64    `json:"output_tokens"`
+	TotalTokens      int64    `json:"total_tokens"`
+	EstimatedCostUsd *float64 `json:"estimated_cost_usd,omitempty"`
+	Priced           *bool    `json:"priced,omitempty"` // true when all token-bearing rows for the model are priced
+}
+
+// UsageAlertBreakdown is a per-alert-type rollup within the window.
+type UsageAlertBreakdown struct {
+	AlertType        string   `json:"alert_type"`
+	TotalTokens      int64    `json:"total_tokens"`
+	EstimatedCostUsd *float64 `json:"estimated_cost_usd,omitempty"`
+}
+
+// UsageChainBreakdown is a per-chain rollup within the window.
+type UsageChainBreakdown struct {
+	ChainID          string   `json:"chain_id"`
+	TotalTokens      int64    `json:"total_tokens"`
+	EstimatedCostUsd *float64 `json:"estimated_cost_usd,omitempty"`
+}
+
+// UsageTopSession is one of the capped top sessions in the window.
+type UsageTopSession struct {
+	SessionID        string           `json:"session_id"`
+	AlertType        *string          `json:"alert_type"`
+	ChainID          string           `json:"chain_id"`
+	TotalTokens      int64            `json:"total_tokens"`
+	EstimatedCostUsd *float64         `json:"estimated_cost_usd,omitempty"`
+	CostCompleteness CostCompleteness `json:"cost_completeness,omitempty"`
+	CreatedAt        time.Time        `json:"created_at"`
+}
+
 // --- Review workflow DTOs ---
 
 // ReviewAction represents a workflow transition action.

--- a/pkg/models/session_test.go
+++ b/pkg/models/session_test.go
@@ -104,3 +104,63 @@ func TestValidReviewAction(t *testing.T) {
 		})
 	}
 }
+
+func TestValidUsageRankBy(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"cost", "cost", true},
+		{"tokens", "tokens", true},
+		{"empty", "", false},
+		{"unknown", "sessions", false},
+		{"case sensitive", "Cost", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, ValidUsageRankBy(tt.input))
+		})
+	}
+}
+
+func TestUsageSummaryResponseJSON(t *testing.T) {
+	t.Run("zero cost and priced false are serialized", func(t *testing.T) {
+		zero := 0.0
+		priced := false
+		resp := UsageSummaryResponse{
+			CostEstimationEnabled: true,
+			RankBy:                UsageRankByCost,
+			Totals: UsageTotals{
+				EstimatedCostUsd: &zero,
+				CostCompleteness: CostCompletenessNone,
+			},
+			ByModel: []UsageModelBreakdown{{
+				ModelName:        "m",
+				EstimatedCostUsd: &zero,
+				Priced:           &priced,
+			}},
+		}
+		raw, err := json.Marshal(resp)
+		require.NoError(t, err)
+		assert.Contains(t, string(raw), `"estimated_cost_usd":0`)
+		assert.Contains(t, string(raw), `"cost_completeness":"none"`)
+		assert.Contains(t, string(raw), `"priced":false`)
+	})
+
+	t.Run("nil cost fields omitted when estimation disabled shape", func(t *testing.T) {
+		resp := UsageSummaryResponse{
+			CostEstimationEnabled: false,
+			RankBy:                UsageRankByTokens,
+			Totals:                UsageTotals{TotalTokens: 10},
+			ByModel:               []UsageModelBreakdown{{ModelName: "m", TotalTokens: 10}},
+			TopSessions:           []UsageTopSession{{SessionID: "s1", TotalTokens: 10}},
+		}
+		raw, err := json.Marshal(resp)
+		require.NoError(t, err)
+		assert.NotContains(t, string(raw), "estimated_cost_usd")
+		assert.NotContains(t, string(raw), "cost_completeness")
+		assert.NotContains(t, string(raw), `"priced"`)
+		assert.NotContains(t, string(raw), "unpriced_interaction_count")
+	})
+}

--- a/pkg/services/session_service.go
+++ b/pkg/services/session_service.go
@@ -50,6 +50,11 @@ func (s *SessionService) SetCostEstimationEnabled(enabled bool) {
 	s.costEstimationEnabled = enabled
 }
 
+// CostEstimationEnabled reports whether cost fields are included in API responses.
+func (s *SessionService) CostEstimationEnabled() bool {
+	return s.costEstimationEnabled
+}
+
 // CreateSession creates a new alert session with initial stage and agent execution
 func (s *SessionService) CreateSession(_ context.Context, req models.CreateSessionRequest) (*ent.AlertSession, error) {
 	// Validate input

--- a/pkg/services/session_service_usage.go
+++ b/pkg/services/session_service_usage.go
@@ -303,7 +303,30 @@ func (s *SessionService) usageTopSessions(
 		Limit(usageTopSessionsCap).
 		Modify(func(sel *sql.Selector) {
 			t := sel.TableName()
-			sid := fmt.Sprintf("%q.%q", t, alertsession.FieldID)
+			agg := sql.Table("agg")
+
+			// CTE aggregates llm_interactions once per session; SELECT and ORDER BY
+			// both read from those columns (no repeated correlated SUM/COUNT).
+			subq := sql.Select(llminteraction.FieldSessionID).
+				From(sql.Table(llminteraction.Table)).
+				GroupBy(llminteraction.FieldSessionID)
+			subq.AppendSelectExprAs(sql.Expr("COALESCE(SUM(total_tokens), 0)"), "total_sum")
+			if s.costEstimationEnabled {
+				subq.AppendSelectExprAs(sql.Expr("COALESCE(SUM(estimated_cost_usd), 0)"), "cost_sum")
+				subq.AppendSelectExprAs(
+					sql.Expr(fmt.Sprintf("COUNT(*) FILTER (WHERE %s)", tokenBearingPredicateSQL)),
+					"token_bearing",
+				)
+				subq.AppendSelectExprAs(
+					sql.Expr(fmt.Sprintf(
+						"COUNT(*) FILTER (WHERE %s AND estimated_cost_usd IS NOT NULL)",
+						tokenBearingPredicateSQL,
+					)),
+					"priced",
+				)
+			}
+			sel.Prefix(sql.With("agg").As(subq))
+			sel.LeftJoin(agg).On(sel.C(alertsession.FieldID), agg.C(llminteraction.FieldSessionID))
 
 			sel.Select(
 				sql.As(sel.C(alertsession.FieldID), "session_id"),
@@ -311,42 +334,18 @@ func (s *SessionService) usageTopSessions(
 				sel.C(alertsession.FieldChainID),
 				sel.C(alertsession.FieldCreatedAt),
 			)
-			sel.AppendSelectAs(
-				fmt.Sprintf("(SELECT COALESCE(SUM(total_tokens), 0) FROM llm_interactions WHERE session_id = %s)", sid),
-				"total_sum",
-			)
+			sel.AppendSelectExprAs(sql.Expr(fmt.Sprintf("COALESCE(%s, 0)", agg.C("total_sum"))), "total_sum")
 			if s.costEstimationEnabled {
-				sel.AppendSelectAs(
-					fmt.Sprintf("(SELECT COALESCE(SUM(estimated_cost_usd), 0) FROM llm_interactions WHERE session_id = %s)", sid),
-					"cost_sum",
-				)
-				sel.AppendSelectAs(
-					fmt.Sprintf(
-						"(SELECT COUNT(*) FROM llm_interactions WHERE session_id = %s AND %s)",
-						sid, tokenBearingPredicateSQL,
-					),
-					"token_bearing",
-				)
-				sel.AppendSelectAs(
-					fmt.Sprintf(
-						"(SELECT COUNT(*) FROM llm_interactions WHERE session_id = %s AND %s AND estimated_cost_usd IS NOT NULL)",
-						sid, tokenBearingPredicateSQL,
-					),
-					"priced",
-				)
+				sel.AppendSelectExprAs(sql.Expr(fmt.Sprintf("COALESCE(%s, 0)", agg.C("cost_sum"))), "cost_sum")
+				sel.AppendSelectExprAs(sql.Expr(fmt.Sprintf("COALESCE(%s, 0)", agg.C("token_bearing"))), "token_bearing")
+				sel.AppendSelectExprAs(sql.Expr(fmt.Sprintf("COALESCE(%s, 0)", agg.C("priced"))), "priced")
 			}
 
 			switch rankBy {
 			case models.UsageRankByCost:
-				sel.OrderExpr(sql.Expr(fmt.Sprintf(
-					"(SELECT COALESCE(SUM(estimated_cost_usd), 0) FROM llm_interactions WHERE session_id = %s) DESC",
-					sid,
-				)))
+				sel.OrderExpr(sql.Expr(fmt.Sprintf("COALESCE(%s, 0) DESC", agg.C("cost_sum"))))
 			default:
-				sel.OrderExpr(sql.Expr(fmt.Sprintf(
-					"(SELECT COALESCE(SUM(total_tokens), 0) FROM llm_interactions WHERE session_id = %s) DESC",
-					sid,
-				)))
+				sel.OrderExpr(sql.Expr(fmt.Sprintf("COALESCE(%s, 0) DESC", agg.C("total_sum"))))
 			}
 			sel.OrderExpr(sql.Expr(fmt.Sprintf("%q.%q DESC", t, alertsession.FieldCreatedAt)))
 		}).
@@ -357,9 +356,13 @@ func (s *SessionService) usageTopSessions(
 
 	out := make([]models.UsageTopSession, 0, len(rows))
 	for _, row := range rows {
+		alertType := row.AlertType
+		if alertType != nil && *alertType == "" {
+			alertType = nil
+		}
 		item := models.UsageTopSession{
 			SessionID:   row.ID,
-			AlertType:   row.AlertType,
+			AlertType:   alertType,
 			ChainID:     row.ChainID,
 			TotalTokens: row.TotalSum.Int64,
 			CreatedAt:   row.CreatedAt,

--- a/pkg/services/session_service_usage.go
+++ b/pkg/services/session_service_usage.go
@@ -1,0 +1,375 @@
+package services
+
+import (
+	"context"
+	stdsql "database/sql"
+	"fmt"
+	"time"
+
+	"entgo.io/ent/dialect/sql"
+	"github.com/codeready-toolchain/tarsy/ent"
+	"github.com/codeready-toolchain/tarsy/ent/alertsession"
+	"github.com/codeready-toolchain/tarsy/ent/llminteraction"
+	"github.com/codeready-toolchain/tarsy/ent/predicate"
+	"github.com/codeready-toolchain/tarsy/pkg/models"
+)
+
+const usageTopSessionsCap = 20
+
+// GetUsageSummary returns fleet token/cost aggregates for sessions created in the
+// given window (soft-deleted sessions excluded).
+func (s *SessionService) GetUsageSummary(ctx context.Context, params models.UsageSummaryParams) (*models.UsageSummaryResponse, error) {
+	rankBy := params.RankBy
+	if rankBy == "" {
+		if s.costEstimationEnabled {
+			rankBy = models.UsageRankByCost
+		} else {
+			rankBy = models.UsageRankByTokens
+		}
+	}
+
+	sessionPreds := usageSessionPreds(params)
+	interactionPred := llminteraction.HasSessionWith(sessionPreds...)
+
+	totals, err := s.usageTotals(ctx, interactionPred)
+	if err != nil {
+		return nil, err
+	}
+	byModel, err := s.usageByModel(ctx, interactionPred)
+	if err != nil {
+		return nil, err
+	}
+	byAlert, err := s.usageByAlertType(ctx, sessionPreds)
+	if err != nil {
+		return nil, err
+	}
+	byChain, err := s.usageByChain(ctx, sessionPreds)
+	if err != nil {
+		return nil, err
+	}
+	top, err := s.usageTopSessions(ctx, sessionPreds, rankBy)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := &models.UsageSummaryResponse{
+		CostEstimationEnabled: s.costEstimationEnabled,
+		Window: models.UsageWindow{
+			Start: params.StartDate,
+			End:   params.EndDate,
+		},
+		RankBy:      rankBy,
+		Totals:      totals,
+		ByModel:     byModel,
+		ByAlertType: byAlert,
+		ByChain:     byChain,
+		TopSessions: top,
+	}
+	return resp, nil
+}
+
+func usageSessionPreds(params models.UsageSummaryParams) []predicate.AlertSession {
+	preds := []predicate.AlertSession{
+		alertsession.DeletedAtIsNil(),
+		alertsession.CreatedAtGTE(params.StartDate),
+		alertsession.CreatedAtLT(params.EndDate),
+	}
+	if params.AlertType != "" {
+		preds = append(preds, alertsession.AlertTypeEQ(params.AlertType))
+	}
+	if params.ChainID != "" {
+		preds = append(preds, alertsession.ChainIDEQ(params.ChainID))
+	}
+	return preds
+}
+
+func (s *SessionService) usageTotals(ctx context.Context, interactionPred predicate.LLMInteraction) (models.UsageTotals, error) {
+	var results []struct {
+		InputSum     stdsql.NullInt64   `json:"input_sum"`
+		OutputSum    stdsql.NullInt64   `json:"output_sum"`
+		TotalSum     stdsql.NullInt64   `json:"total_sum"`
+		CostSum      stdsql.NullFloat64 `json:"cost_sum"`
+		TokenBearing int                `json:"token_bearing"`
+		Priced       int                `json:"priced"`
+	}
+
+	aggs := []ent.AggregateFunc{
+		ent.As(ent.Sum(llminteraction.FieldInputTokens), "input_sum"),
+		ent.As(ent.Sum(llminteraction.FieldOutputTokens), "output_sum"),
+		ent.As(ent.Sum(llminteraction.FieldTotalTokens), "total_sum"),
+		ent.As(func(_ *sql.Selector) string {
+			return "COUNT(*) FILTER (WHERE " + tokenBearingPredicateSQL + ")"
+		}, "token_bearing"),
+	}
+	if s.costEstimationEnabled {
+		aggs = append(aggs,
+			ent.As(ent.Sum(llminteraction.FieldEstimatedCostUsd), "cost_sum"),
+			ent.As(func(_ *sql.Selector) string {
+				return "COUNT(*) FILTER (WHERE " + tokenBearingPredicateSQL + " AND estimated_cost_usd IS NOT NULL)"
+			}, "priced"),
+		)
+	}
+
+	err := s.client.LLMInteraction.Query().
+		Where(interactionPred).
+		Aggregate(aggs...).
+		Scan(ctx, &results)
+	if err != nil {
+		return models.UsageTotals{}, fmt.Errorf("failed to aggregate usage totals: %w", err)
+	}
+
+	totals := models.UsageTotals{}
+	if len(results) == 0 {
+		return totals, nil
+	}
+	r := results[0]
+	totals.InputTokens = r.InputSum.Int64
+	totals.OutputTokens = r.OutputSum.Int64
+	totals.TotalTokens = r.TotalSum.Int64
+	if s.costEstimationEnabled {
+		cost := r.CostSum.Float64
+		totals.EstimatedCostUsd = &cost
+		totals.CostCompleteness = models.DeriveCostCompleteness(r.TokenBearing, r.Priced)
+		unpriced := r.TokenBearing - r.Priced
+		totals.UnpricedInteractionCount = &unpriced
+	}
+	return totals, nil
+}
+
+func (s *SessionService) usageByModel(ctx context.Context, interactionPred predicate.LLMInteraction) ([]models.UsageModelBreakdown, error) {
+	var rows []struct {
+		ModelName    string             `json:"model_name"`
+		InputSum     stdsql.NullInt64   `json:"input_sum"`
+		OutputSum    stdsql.NullInt64   `json:"output_sum"`
+		TotalSum     stdsql.NullInt64   `json:"total_sum"`
+		CostSum      stdsql.NullFloat64 `json:"cost_sum"`
+		TokenBearing int                `json:"token_bearing"`
+		Priced       int                `json:"priced"`
+	}
+
+	aggs := []ent.AggregateFunc{
+		ent.As(ent.Sum(llminteraction.FieldInputTokens), "input_sum"),
+		ent.As(ent.Sum(llminteraction.FieldOutputTokens), "output_sum"),
+		ent.As(ent.Sum(llminteraction.FieldTotalTokens), "total_sum"),
+		ent.As(func(_ *sql.Selector) string {
+			return "COUNT(*) FILTER (WHERE " + tokenBearingPredicateSQL + ")"
+		}, "token_bearing"),
+	}
+	if s.costEstimationEnabled {
+		aggs = append(aggs,
+			ent.As(ent.Sum(llminteraction.FieldEstimatedCostUsd), "cost_sum"),
+			ent.As(func(_ *sql.Selector) string {
+				return "COUNT(*) FILTER (WHERE " + tokenBearingPredicateSQL + " AND estimated_cost_usd IS NOT NULL)"
+			}, "priced"),
+		)
+	}
+
+	err := s.client.LLMInteraction.Query().
+		Where(interactionPred).
+		GroupBy(llminteraction.FieldModelName).
+		Aggregate(aggs...).
+		Scan(ctx, &rows)
+	if err != nil {
+		return nil, fmt.Errorf("failed to aggregate usage by model: %w", err)
+	}
+
+	out := make([]models.UsageModelBreakdown, 0, len(rows))
+	for _, row := range rows {
+		item := models.UsageModelBreakdown{
+			ModelName:    row.ModelName,
+			InputTokens:  row.InputSum.Int64,
+			OutputTokens: row.OutputSum.Int64,
+			TotalTokens:  row.TotalSum.Int64,
+		}
+		if s.costEstimationEnabled {
+			cost := row.CostSum.Float64
+			item.EstimatedCostUsd = &cost
+			priced := row.TokenBearing > 0 && row.Priced == row.TokenBearing
+			item.Priced = &priced
+		}
+		out = append(out, item)
+	}
+	return out, nil
+}
+
+func (s *SessionService) usageByAlertType(ctx context.Context, sessionPreds []predicate.AlertSession) ([]models.UsageAlertBreakdown, error) {
+	var rows []struct {
+		AlertType stdsql.NullString  `json:"alert_type"`
+		TotalSum  stdsql.NullInt64   `json:"total_sum"`
+		CostSum   stdsql.NullFloat64 `json:"cost_sum"`
+	}
+
+	err := s.client.AlertSession.Query().
+		Where(sessionPreds...).
+		Modify(func(sel *sql.Selector) {
+			li := sql.Table(llminteraction.Table).As("li")
+			sel.LeftJoin(li).On(sel.C(alertsession.FieldID), li.C(llminteraction.FieldSessionID))
+			sel.Select(sql.As(sel.C(alertsession.FieldAlertType), "alert_type"))
+			sel.AppendSelectAs(
+				fmt.Sprintf("COALESCE(SUM(%s), 0)", li.C(llminteraction.FieldTotalTokens)),
+				"total_sum",
+			)
+			if s.costEstimationEnabled {
+				sel.AppendSelectAs(
+					fmt.Sprintf("COALESCE(SUM(%s), 0)", li.C(llminteraction.FieldEstimatedCostUsd)),
+					"cost_sum",
+				)
+			}
+			sel.GroupBy(sel.C(alertsession.FieldAlertType))
+		}).
+		Scan(ctx, &rows)
+	if err != nil {
+		return nil, fmt.Errorf("failed to aggregate usage by alert type: %w", err)
+	}
+
+	out := make([]models.UsageAlertBreakdown, 0, len(rows))
+	for _, row := range rows {
+		item := models.UsageAlertBreakdown{
+			AlertType:   row.AlertType.String,
+			TotalTokens: row.TotalSum.Int64,
+		}
+		if s.costEstimationEnabled {
+			cost := row.CostSum.Float64
+			item.EstimatedCostUsd = &cost
+		}
+		out = append(out, item)
+	}
+	return out, nil
+}
+
+func (s *SessionService) usageByChain(ctx context.Context, sessionPreds []predicate.AlertSession) ([]models.UsageChainBreakdown, error) {
+	var rows []struct {
+		ChainID  string             `json:"chain_id"`
+		TotalSum stdsql.NullInt64   `json:"total_sum"`
+		CostSum  stdsql.NullFloat64 `json:"cost_sum"`
+	}
+
+	err := s.client.AlertSession.Query().
+		Where(sessionPreds...).
+		Modify(func(sel *sql.Selector) {
+			li := sql.Table(llminteraction.Table).As("li")
+			sel.LeftJoin(li).On(sel.C(alertsession.FieldID), li.C(llminteraction.FieldSessionID))
+			sel.Select(sql.As(sel.C(alertsession.FieldChainID), "chain_id"))
+			sel.AppendSelectAs(
+				fmt.Sprintf("COALESCE(SUM(%s), 0)", li.C(llminteraction.FieldTotalTokens)),
+				"total_sum",
+			)
+			if s.costEstimationEnabled {
+				sel.AppendSelectAs(
+					fmt.Sprintf("COALESCE(SUM(%s), 0)", li.C(llminteraction.FieldEstimatedCostUsd)),
+					"cost_sum",
+				)
+			}
+			sel.GroupBy(sel.C(alertsession.FieldChainID))
+		}).
+		Scan(ctx, &rows)
+	if err != nil {
+		return nil, fmt.Errorf("failed to aggregate usage by chain: %w", err)
+	}
+
+	out := make([]models.UsageChainBreakdown, 0, len(rows))
+	for _, row := range rows {
+		item := models.UsageChainBreakdown{
+			ChainID:     row.ChainID,
+			TotalTokens: row.TotalSum.Int64,
+		}
+		if s.costEstimationEnabled {
+			cost := row.CostSum.Float64
+			item.EstimatedCostUsd = &cost
+		}
+		out = append(out, item)
+	}
+	return out, nil
+}
+
+func (s *SessionService) usageTopSessions(
+	ctx context.Context,
+	sessionPreds []predicate.AlertSession,
+	rankBy models.UsageRankBy,
+) ([]models.UsageTopSession, error) {
+	var rows []struct {
+		ID           string             `json:"session_id"`
+		AlertType    *string            `json:"alert_type"`
+		ChainID      string             `json:"chain_id"`
+		CreatedAt    time.Time          `json:"created_at"`
+		TotalSum     stdsql.NullInt64   `json:"total_sum"`
+		CostSum      stdsql.NullFloat64 `json:"cost_sum"`
+		TokenBearing int                `json:"token_bearing"`
+		Priced       int                `json:"priced"`
+	}
+
+	err := s.client.AlertSession.Query().
+		Where(sessionPreds...).
+		Limit(usageTopSessionsCap).
+		Modify(func(sel *sql.Selector) {
+			t := sel.TableName()
+			sid := fmt.Sprintf("%q.%q", t, alertsession.FieldID)
+
+			sel.Select(
+				sql.As(sel.C(alertsession.FieldID), "session_id"),
+				sel.C(alertsession.FieldAlertType),
+				sel.C(alertsession.FieldChainID),
+				sel.C(alertsession.FieldCreatedAt),
+			)
+			sel.AppendSelectAs(
+				fmt.Sprintf("(SELECT COALESCE(SUM(total_tokens), 0) FROM llm_interactions WHERE session_id = %s)", sid),
+				"total_sum",
+			)
+			if s.costEstimationEnabled {
+				sel.AppendSelectAs(
+					fmt.Sprintf("(SELECT COALESCE(SUM(estimated_cost_usd), 0) FROM llm_interactions WHERE session_id = %s)", sid),
+					"cost_sum",
+				)
+				sel.AppendSelectAs(
+					fmt.Sprintf(
+						"(SELECT COUNT(*) FROM llm_interactions WHERE session_id = %s AND %s)",
+						sid, tokenBearingPredicateSQL,
+					),
+					"token_bearing",
+				)
+				sel.AppendSelectAs(
+					fmt.Sprintf(
+						"(SELECT COUNT(*) FROM llm_interactions WHERE session_id = %s AND %s AND estimated_cost_usd IS NOT NULL)",
+						sid, tokenBearingPredicateSQL,
+					),
+					"priced",
+				)
+			}
+
+			switch rankBy {
+			case models.UsageRankByCost:
+				sel.OrderExpr(sql.Expr(fmt.Sprintf(
+					"(SELECT COALESCE(SUM(estimated_cost_usd), 0) FROM llm_interactions WHERE session_id = %s) DESC",
+					sid,
+				)))
+			default:
+				sel.OrderExpr(sql.Expr(fmt.Sprintf(
+					"(SELECT COALESCE(SUM(total_tokens), 0) FROM llm_interactions WHERE session_id = %s) DESC",
+					sid,
+				)))
+			}
+			sel.OrderExpr(sql.Expr(fmt.Sprintf("%q.%q DESC", t, alertsession.FieldCreatedAt)))
+		}).
+		Scan(ctx, &rows)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query top usage sessions: %w", err)
+	}
+
+	out := make([]models.UsageTopSession, 0, len(rows))
+	for _, row := range rows {
+		item := models.UsageTopSession{
+			SessionID:   row.ID,
+			AlertType:   row.AlertType,
+			ChainID:     row.ChainID,
+			TotalTokens: row.TotalSum.Int64,
+			CreatedAt:   row.CreatedAt,
+		}
+		if s.costEstimationEnabled {
+			cost := row.CostSum.Float64
+			item.EstimatedCostUsd = &cost
+			item.CostCompleteness = models.DeriveCostCompleteness(row.TokenBearing, row.Priced)
+		}
+		out = append(out, item)
+	}
+	return out, nil
+}

--- a/pkg/services/session_service_usage_test.go
+++ b/pkg/services/session_service_usage_test.go
@@ -1,0 +1,512 @@
+package services
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/codeready-toolchain/tarsy/ent"
+	"github.com/codeready-toolchain/tarsy/ent/alertsession"
+	"github.com/codeready-toolchain/tarsy/ent/llminteraction"
+	"github.com/codeready-toolchain/tarsy/ent/stage"
+	"github.com/codeready-toolchain/tarsy/pkg/config"
+	"github.com/codeready-toolchain/tarsy/pkg/models"
+	testdb "github.com/codeready-toolchain/tarsy/test/database"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSessionService_GetUsageSummary(t *testing.T) {
+	client := testdb.NewTestClient(t)
+	service := setupTestSessionService(t, client.Client)
+	ctx := context.Background()
+
+	windowStart := time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)
+	windowEnd := time.Date(2024, 7, 1, 0, 0, 0, 0, time.UTC)
+	inWindow := time.Date(2024, 6, 15, 12, 0, 0, 0, time.UTC)
+	beforeWindow := time.Date(2024, 5, 15, 12, 0, 0, 0, time.UTC)
+	onEndBoundary := windowEnd // half-open: excluded
+
+	params := models.UsageSummaryParams{
+		StartDate: windowStart,
+		EndDate:   windowEnd,
+	}
+
+	t.Run("window includes only sessions by created_at", func(t *testing.T) {
+		inID, stageID, execID := seedUsageSession(t, client.Client, usageSeed{
+			AlertData: "in-window",
+			AlertType: "pod-crash",
+			ChainID:   "k8s-analysis",
+			CreatedAt: inWindow,
+		})
+		seedLLMInteraction(t, client.Client, inID, stageID, execID, "model-a", 100, 50, 150, floatPtr(0.01), 0)
+
+		outID, outStage, outExec := seedUsageSession(t, client.Client, usageSeed{
+			AlertData: "before-window",
+			AlertType: "pod-crash",
+			ChainID:   "k8s-analysis",
+			CreatedAt: beforeWindow,
+		})
+		seedLLMInteraction(t, client.Client, outID, outStage, outExec, "model-a", 999, 999, 1998, floatPtr(9.99), 0)
+
+		boundaryID, bStage, bExec := seedUsageSession(t, client.Client, usageSeed{
+			AlertData: "on-end-boundary",
+			AlertType: "pod-crash",
+			ChainID:   "k8s-analysis",
+			CreatedAt: onEndBoundary,
+		})
+		seedLLMInteraction(t, client.Client, boundaryID, bStage, bExec, "model-a", 500, 500, 1000, floatPtr(1.0), 0)
+
+		summary, err := service.GetUsageSummary(ctx, params)
+		require.NoError(t, err)
+		assert.Equal(t, int64(150), summary.Totals.TotalTokens)
+		require.NotNil(t, summary.Totals.EstimatedCostUsd)
+		assert.InDelta(t, 0.01, *summary.Totals.EstimatedCostUsd, 1e-9)
+		assert.Equal(t, models.UsageRankByCost, summary.RankBy)
+		assert.Equal(t, windowStart, summary.Window.Start)
+		assert.Equal(t, windowEnd, summary.Window.End)
+
+		require.Len(t, summary.TopSessions, 1)
+		assert.Equal(t, inID, summary.TopSessions[0].SessionID)
+	})
+
+	t.Run("excludes soft-deleted sessions", func(t *testing.T) {
+		delClient := testdb.NewTestClient(t)
+		delSvc := setupTestSessionService(t, delClient.Client)
+
+		sid, stageID, execID := seedUsageSession(t, delClient.Client, usageSeed{
+			AlertData: "soft-deleted",
+			AlertType: "pod-crash",
+			ChainID:   "k8s-analysis",
+			CreatedAt: inWindow,
+		})
+		seedLLMInteraction(t, delClient.Client, sid, stageID, execID, "model-a", 100, 50, 150, floatPtr(0.01), 0)
+		require.NoError(t, delClient.Client.AlertSession.UpdateOneID(sid).SetDeletedAt(time.Now()).Exec(ctx))
+
+		summary, err := delSvc.GetUsageSummary(ctx, params)
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), summary.Totals.TotalTokens)
+		assert.Empty(t, summary.TopSessions)
+		assert.Empty(t, summary.ByModel)
+	})
+
+	t.Run("multi-model partial completeness and by_model priced flags", func(t *testing.T) {
+		mc := testdb.NewTestClient(t)
+		svc := setupTestSessionService(t, mc.Client)
+
+		sid, stageID, execID := seedUsageSession(t, mc.Client, usageSeed{
+			AlertData: "multi-model",
+			AlertType: "pod-crash",
+			ChainID:   "k8s-analysis",
+			CreatedAt: inWindow,
+		})
+		seedLLMInteraction(t, mc.Client, sid, stageID, execID, "priced-model", 100, 50, 150, floatPtr(0.012), 0)
+		seedLLMInteraction(t, mc.Client, sid, stageID, execID, "unpriced-model", 200, 100, 300, nil, 0)
+
+		summary, err := svc.GetUsageSummary(ctx, params)
+		require.NoError(t, err)
+		assert.True(t, summary.CostEstimationEnabled)
+		assert.Equal(t, int64(450), summary.Totals.TotalTokens)
+		require.NotNil(t, summary.Totals.EstimatedCostUsd)
+		assert.InDelta(t, 0.012, *summary.Totals.EstimatedCostUsd, 1e-9)
+		assert.Equal(t, models.CostCompletenessPartial, summary.Totals.CostCompleteness)
+		require.NotNil(t, summary.Totals.UnpricedInteractionCount)
+		assert.Equal(t, 1, *summary.Totals.UnpricedInteractionCount)
+
+		byModel := map[string]models.UsageModelBreakdown{}
+		for _, m := range summary.ByModel {
+			byModel[m.ModelName] = m
+		}
+		require.Contains(t, byModel, "priced-model")
+		require.Contains(t, byModel, "unpriced-model")
+		require.NotNil(t, byModel["priced-model"].Priced)
+		assert.True(t, *byModel["priced-model"].Priced)
+		require.NotNil(t, byModel["unpriced-model"].Priced)
+		assert.False(t, *byModel["unpriced-model"].Priced)
+
+		require.Len(t, summary.TopSessions, 1)
+		assert.Equal(t, models.CostCompletenessPartial, summary.TopSessions[0].CostCompleteness)
+		require.NotNil(t, summary.TopSessions[0].EstimatedCostUsd)
+		assert.InDelta(t, 0.012, *summary.TopSessions[0].EstimatedCostUsd, 1e-9)
+	})
+
+	t.Run("null costs treated as zero with none completeness", func(t *testing.T) {
+		nc := testdb.NewTestClient(t)
+		svc := setupTestSessionService(t, nc.Client)
+
+		sid, stageID, execID := seedUsageSession(t, nc.Client, usageSeed{
+			AlertData: "all-null-cost",
+			AlertType: "pod-crash",
+			ChainID:   "k8s-analysis",
+			CreatedAt: inWindow,
+		})
+		seedLLMInteraction(t, nc.Client, sid, stageID, execID, "old-model", 10, 5, 15, nil, 0)
+
+		summary, err := svc.GetUsageSummary(ctx, params)
+		require.NoError(t, err)
+		require.NotNil(t, summary.Totals.EstimatedCostUsd)
+		assert.InDelta(t, 0.0, *summary.Totals.EstimatedCostUsd, 1e-9)
+		assert.Equal(t, models.CostCompletenessNone, summary.Totals.CostCompleteness)
+		require.NotNil(t, summary.Totals.UnpricedInteractionCount)
+		assert.Equal(t, 1, *summary.Totals.UnpricedInteractionCount)
+	})
+
+	t.Run("rank_by cost vs tokens", func(t *testing.T) {
+		rc := testdb.NewTestClient(t)
+		svc := setupTestSessionService(t, rc.Client)
+
+		cheapID, cheapStage, cheapExec := seedUsageSession(t, rc.Client, usageSeed{
+			AlertData: "cheap-high-tokens",
+			AlertType: "pod-crash",
+			ChainID:   "k8s-analysis",
+			CreatedAt: inWindow.Add(time.Hour),
+		})
+		seedLLMInteraction(t, rc.Client, cheapID, cheapStage, cheapExec, "m", 1000, 1000, 2000, floatPtr(0.001), 0)
+
+		priceyID, priceyStage, priceyExec := seedUsageSession(t, rc.Client, usageSeed{
+			AlertData: "pricey-low-tokens",
+			AlertType: "pod-crash",
+			ChainID:   "k8s-analysis",
+			CreatedAt: inWindow,
+		})
+		seedLLMInteraction(t, rc.Client, priceyID, priceyStage, priceyExec, "m", 10, 10, 20, floatPtr(5.0), 0)
+
+		byCost, err := svc.GetUsageSummary(ctx, models.UsageSummaryParams{
+			StartDate: windowStart,
+			EndDate:   windowEnd,
+			RankBy:    models.UsageRankByCost,
+		})
+		require.NoError(t, err)
+		require.GreaterOrEqual(t, len(byCost.TopSessions), 2)
+		assert.Equal(t, models.UsageRankByCost, byCost.RankBy)
+		assert.Equal(t, priceyID, byCost.TopSessions[0].SessionID)
+		assert.Equal(t, cheapID, byCost.TopSessions[1].SessionID)
+
+		byTokens, err := svc.GetUsageSummary(ctx, models.UsageSummaryParams{
+			StartDate: windowStart,
+			EndDate:   windowEnd,
+			RankBy:    models.UsageRankByTokens,
+		})
+		require.NoError(t, err)
+		require.GreaterOrEqual(t, len(byTokens.TopSessions), 2)
+		assert.Equal(t, models.UsageRankByTokens, byTokens.RankBy)
+		assert.Equal(t, cheapID, byTokens.TopSessions[0].SessionID)
+		assert.Equal(t, priceyID, byTokens.TopSessions[1].SessionID)
+	})
+
+	t.Run("alert_type and chain_id filters", func(t *testing.T) {
+		fc := testdb.NewTestClient(t)
+		svc := setupTestSessionService(t, fc.Client)
+
+		aID, aStage, aExec := seedUsageSession(t, fc.Client, usageSeed{
+			AlertData: "type-a",
+			AlertType: "type-a",
+			ChainID:   "chain-a",
+			CreatedAt: inWindow,
+		})
+		seedLLMInteraction(t, fc.Client, aID, aStage, aExec, "m", 100, 0, 100, floatPtr(0.1), 0)
+
+		bID, bStage, bExec := seedUsageSession(t, fc.Client, usageSeed{
+			AlertData: "type-b",
+			AlertType: "type-b",
+			ChainID:   "chain-b",
+			CreatedAt: inWindow,
+		})
+		seedLLMInteraction(t, fc.Client, bID, bStage, bExec, "m", 200, 0, 200, floatPtr(0.2), 0)
+
+		filtered, err := svc.GetUsageSummary(ctx, models.UsageSummaryParams{
+			StartDate: windowStart,
+			EndDate:   windowEnd,
+			AlertType: "type-a",
+			ChainID:   "chain-a",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, int64(100), filtered.Totals.TotalTokens)
+		require.Len(t, filtered.ByAlertType, 1)
+		assert.Equal(t, "type-a", filtered.ByAlertType[0].AlertType)
+		require.Len(t, filtered.ByChain, 1)
+		assert.Equal(t, "chain-a", filtered.ByChain[0].ChainID)
+		require.Len(t, filtered.TopSessions, 1)
+		assert.Equal(t, aID, filtered.TopSessions[0].SessionID)
+		_ = bID // ensured seeded but filtered out
+	})
+
+	t.Run("by_alert_type and by_chain rollups", func(t *testing.T) {
+		bc := testdb.NewTestClient(t)
+		svc := setupTestSessionService(t, bc.Client)
+
+		s1, st1, e1 := seedUsageSession(t, bc.Client, usageSeed{
+			AlertData: "rollup-1",
+			AlertType: "oom",
+			ChainID:   "chain-x",
+			CreatedAt: inWindow,
+		})
+		seedLLMInteraction(t, bc.Client, s1, st1, e1, "m", 50, 50, 100, floatPtr(0.5), 0)
+
+		s2, st2, e2 := seedUsageSession(t, bc.Client, usageSeed{
+			AlertData: "rollup-2",
+			AlertType: "oom",
+			ChainID:   "chain-y",
+			CreatedAt: inWindow.Add(time.Minute),
+		})
+		seedLLMInteraction(t, bc.Client, s2, st2, e2, "m", 25, 25, 50, floatPtr(0.25), 0)
+
+		// Session with no LLM rows still appears in breakdowns via LEFT JOIN.
+		seedUsageSession(t, bc.Client, usageSeed{
+			AlertData: "no-llm",
+			AlertType: "idle",
+			ChainID:   "chain-z",
+			CreatedAt: inWindow.Add(2 * time.Minute),
+		})
+
+		summary, err := svc.GetUsageSummary(ctx, params)
+		require.NoError(t, err)
+
+		alertMap := map[string]models.UsageAlertBreakdown{}
+		for _, row := range summary.ByAlertType {
+			alertMap[row.AlertType] = row
+		}
+		require.Contains(t, alertMap, "oom")
+		assert.Equal(t, int64(150), alertMap["oom"].TotalTokens)
+		require.NotNil(t, alertMap["oom"].EstimatedCostUsd)
+		assert.InDelta(t, 0.75, *alertMap["oom"].EstimatedCostUsd, 1e-9)
+		require.Contains(t, alertMap, "idle")
+		assert.Equal(t, int64(0), alertMap["idle"].TotalTokens)
+
+		chainMap := map[string]models.UsageChainBreakdown{}
+		for _, row := range summary.ByChain {
+			chainMap[row.ChainID] = row
+		}
+		require.Contains(t, chainMap, "chain-x")
+		assert.Equal(t, int64(100), chainMap["chain-x"].TotalTokens)
+		require.Contains(t, chainMap, "chain-z")
+		assert.Equal(t, int64(0), chainMap["chain-z"].TotalTokens)
+	})
+
+	t.Run("estimation disabled omits cost fields and defaults rank_by tokens", func(t *testing.T) {
+		dc := testdb.NewTestClient(t)
+		svc := setupTestSessionService(t, dc.Client)
+		svc.SetCostEstimationEnabled(false)
+
+		sid, stageID, execID := seedUsageSession(t, dc.Client, usageSeed{
+			AlertData: "disabled-cost",
+			AlertType: "pod-crash",
+			ChainID:   "k8s-analysis",
+			CreatedAt: inWindow,
+		})
+		seedLLMInteraction(t, dc.Client, sid, stageID, execID, "model-a", 100, 50, 150, floatPtr(0.01), 0)
+
+		summary, err := svc.GetUsageSummary(ctx, params)
+		require.NoError(t, err)
+		assert.False(t, summary.CostEstimationEnabled)
+		assert.Equal(t, models.UsageRankByTokens, summary.RankBy)
+		assert.Nil(t, summary.Totals.EstimatedCostUsd)
+		assert.Empty(t, summary.Totals.CostCompleteness)
+		assert.Nil(t, summary.Totals.UnpricedInteractionCount)
+		assert.Equal(t, int64(150), summary.Totals.TotalTokens)
+
+		require.Len(t, summary.ByModel, 1)
+		assert.Nil(t, summary.ByModel[0].EstimatedCostUsd)
+		assert.Nil(t, summary.ByModel[0].Priced)
+
+		require.Len(t, summary.TopSessions, 1)
+		assert.Nil(t, summary.TopSessions[0].EstimatedCostUsd)
+		assert.Empty(t, summary.TopSessions[0].CostCompleteness)
+	})
+
+	t.Run("empty window returns zero totals and empty sections", func(t *testing.T) {
+		ec := testdb.NewTestClient(t)
+		svc := setupTestSessionService(t, ec.Client)
+
+		summary, err := svc.GetUsageSummary(ctx, params)
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), summary.Totals.TotalTokens)
+		require.NotNil(t, summary.Totals.EstimatedCostUsd)
+		assert.InDelta(t, 0.0, *summary.Totals.EstimatedCostUsd, 1e-9)
+		assert.Equal(t, models.CostCompletenessNone, summary.Totals.CostCompleteness)
+		assert.Empty(t, summary.ByModel)
+		assert.Empty(t, summary.ByAlertType)
+		assert.Empty(t, summary.ByChain)
+		assert.Empty(t, summary.TopSessions)
+	})
+
+	t.Run("start boundary is inclusive", func(t *testing.T) {
+		sc := testdb.NewTestClient(t)
+		svc := setupTestSessionService(t, sc.Client)
+
+		sid, stageID, execID := seedUsageSession(t, sc.Client, usageSeed{
+			AlertData: "on-start",
+			AlertType: "pod-crash",
+			ChainID:   "k8s-analysis",
+			CreatedAt: windowStart,
+		})
+		seedLLMInteraction(t, sc.Client, sid, stageID, execID, "model-a", 40, 10, 50, floatPtr(0.02), 0)
+
+		summary, err := svc.GetUsageSummary(ctx, params)
+		require.NoError(t, err)
+		assert.Equal(t, int64(50), summary.Totals.TotalTokens)
+		require.Len(t, summary.TopSessions, 1)
+		assert.Equal(t, sid, summary.TopSessions[0].SessionID)
+	})
+
+	t.Run("explicit zero cost is priced complete", func(t *testing.T) {
+		zc := testdb.NewTestClient(t)
+		svc := setupTestSessionService(t, zc.Client)
+
+		sid, stageID, execID := seedUsageSession(t, zc.Client, usageSeed{
+			AlertData: "zero-cost",
+			AlertType: "pod-crash",
+			ChainID:   "k8s-analysis",
+			CreatedAt: inWindow,
+		})
+		seedLLMInteraction(t, zc.Client, sid, stageID, execID, "free-model", 10, 5, 15, floatPtr(0.0), 0)
+
+		summary, err := svc.GetUsageSummary(ctx, params)
+		require.NoError(t, err)
+		require.NotNil(t, summary.Totals.EstimatedCostUsd)
+		assert.InDelta(t, 0.0, *summary.Totals.EstimatedCostUsd, 1e-9)
+		assert.Equal(t, models.CostCompletenessComplete, summary.Totals.CostCompleteness)
+		require.NotNil(t, summary.Totals.UnpricedInteractionCount)
+		assert.Equal(t, 0, *summary.Totals.UnpricedInteractionCount)
+		require.Len(t, summary.ByModel, 1)
+		require.NotNil(t, summary.ByModel[0].Priced)
+		assert.True(t, *summary.ByModel[0].Priced)
+	})
+
+	t.Run("all interaction types count in totals", func(t *testing.T) {
+		ic := testdb.NewTestClient(t)
+		svc := setupTestSessionService(t, ic.Client)
+
+		sid, stageID, execID := seedUsageSession(t, ic.Client, usageSeed{
+			AlertData: "multi-type",
+			AlertType: "pod-crash",
+			ChainID:   "k8s-analysis",
+			CreatedAt: inWindow,
+		})
+		seedLLMInteraction(t, ic.Client, sid, stageID, execID, "m", 10, 10, 20, floatPtr(0.1), 0)
+		seedUsageLLMInteractionType(t, ic.Client, sid, stageID, execID,
+			llminteraction.InteractionTypeSummarization, "m", 30, 20, 50, floatPtr(0.2))
+		seedUsageLLMInteractionType(t, ic.Client, sid, stageID, execID,
+			llminteraction.InteractionTypeScoring, "m", 5, 5, 10, floatPtr(0.05))
+
+		summary, err := svc.GetUsageSummary(ctx, params)
+		require.NoError(t, err)
+		assert.Equal(t, int64(80), summary.Totals.TotalTokens)
+		require.NotNil(t, summary.Totals.EstimatedCostUsd)
+		assert.InDelta(t, 0.35, *summary.Totals.EstimatedCostUsd, 1e-9)
+	})
+
+	t.Run("top_sessions capped at 20", func(t *testing.T) {
+		tc := testdb.NewTestClient(t)
+		svc := setupTestSessionService(t, tc.Client)
+
+		var lowestID string
+		for i := range 21 {
+			tokens := (21 - i) * 10 // 210, 200, ..., 10
+			sid, stageID, execID := seedUsageSession(t, tc.Client, usageSeed{
+				AlertData: "top-cap",
+				AlertType: "pod-crash",
+				ChainID:   "k8s-analysis",
+				CreatedAt: inWindow.Add(time.Duration(i) * time.Minute),
+			})
+			seedLLMInteraction(t, tc.Client, sid, stageID, execID, "m", tokens, 0, tokens, floatPtr(float64(tokens)*0.001), 0)
+			if i == 20 {
+				lowestID = sid
+			}
+		}
+
+		summary, err := svc.GetUsageSummary(ctx, models.UsageSummaryParams{
+			StartDate: windowStart,
+			EndDate:   windowEnd,
+			RankBy:    models.UsageRankByTokens,
+		})
+		require.NoError(t, err)
+		require.Len(t, summary.TopSessions, 20)
+		assert.Equal(t, int64(210), summary.TopSessions[0].TotalTokens)
+		assert.Equal(t, int64(20), summary.TopSessions[19].TotalTokens)
+		for _, item := range summary.TopSessions {
+			assert.NotEqual(t, lowestID, item.SessionID)
+		}
+	})
+}
+
+type usageSeed struct {
+	AlertData string
+	AlertType string
+	ChainID   string
+	CreatedAt time.Time
+}
+
+func seedUsageSession(t *testing.T, client *ent.Client, seed usageSeed) (sessionID, stageID, execID string) {
+	t.Helper()
+	ctx := context.Background()
+	now := time.Now()
+	started := now.Add(-5 * time.Second)
+	completed := now
+	sessionID = uuid.New().String()
+
+	sess := client.AlertSession.Create().
+		SetID(sessionID).
+		SetAlertData(seed.AlertData).
+		SetAlertType(seed.AlertType).
+		SetChainID(seed.ChainID).
+		SetAgentType("kubernetes").
+		SetStatus(alertsession.StatusCompleted).
+		SetCreatedAt(seed.CreatedAt).
+		SetStartedAt(started).
+		SetCompletedAt(completed).
+		SaveX(ctx)
+
+	stg := client.Stage.Create().
+		SetID(uuid.New().String()).
+		SetSessionID(sess.ID).
+		SetStageName("analysis").
+		SetStageIndex(1).
+		SetExpectedAgentCount(1).
+		SetStatus(stage.StatusCompleted).
+		SetStartedAt(started).
+		SetCompletedAt(completed).
+		SaveX(ctx)
+
+	exec := client.AgentExecution.Create().
+		SetID(uuid.New().String()).
+		SetSessionID(sess.ID).
+		SetStageID(stg.ID).
+		SetAgentName("TestAgent").
+		SetAgentIndex(1).
+		SetLlmBackend(string(config.LLMBackendLangChain)).
+		SetStartedAt(started).
+		SetStatus("completed").
+		SaveX(ctx)
+
+	return sess.ID, stg.ID, exec.ID
+}
+
+func seedUsageLLMInteractionType(
+	t *testing.T,
+	client *ent.Client,
+	sessionID, stageID, execID string,
+	interactionType llminteraction.InteractionType,
+	modelName string,
+	inputTokens, outputTokens, totalTokens int,
+	costUSD *float64,
+) {
+	t.Helper()
+	create := client.LLMInteraction.Create().
+		SetID(uuid.New().String()).
+		SetSessionID(sessionID).
+		SetStageID(stageID).
+		SetExecutionID(execID).
+		SetInteractionType(interactionType).
+		SetModelName(modelName).
+		SetLlmRequest(map[string]any{}).
+		SetLlmResponse(map[string]any{}).
+		SetInputTokens(inputTokens).
+		SetOutputTokens(outputTokens).
+		SetTotalTokens(totalTokens)
+	if costUSD != nil {
+		create = create.SetEstimatedCostUsd(*costUSD)
+	}
+	create.SaveX(context.Background())
+}

--- a/pkg/services/session_service_usage_test.go
+++ b/pkg/services/session_service_usage_test.go
@@ -397,6 +397,24 @@ func TestSessionService_GetUsageSummary(t *testing.T) {
 		assert.InDelta(t, 0.35, *summary.Totals.EstimatedCostUsd, 1e-9)
 	})
 
+	t.Run("empty alert_type normalized to nil in top_sessions", func(t *testing.T) {
+		ac := testdb.NewTestClient(t)
+		svc := setupTestSessionService(t, ac.Client)
+
+		sid, stageID, execID := seedUsageSession(t, ac.Client, usageSeed{
+			AlertData: "empty-alert-type",
+			AlertType: "",
+			ChainID:   "k8s-analysis",
+			CreatedAt: inWindow,
+		})
+		seedLLMInteraction(t, ac.Client, sid, stageID, execID, "m", 10, 5, 15, floatPtr(0.01), 0)
+
+		summary, err := svc.GetUsageSummary(ctx, params)
+		require.NoError(t, err)
+		require.Len(t, summary.TopSessions, 1)
+		assert.Nil(t, summary.TopSessions[0].AlertType)
+	})
+
 	t.Run("top_sessions capped at 20", func(t *testing.T) {
 		tc := testdb.NewTestClient(t)
 		svc := setupTestSessionService(t, tc.Client)


### PR DESCRIPTION
- Aggregate tokens/cost by model, alert type, and chain for a session created_at window
- Cap top_sessions at 20 with server-side rank_by=cost|tokens
- Exclude soft-deleted sessions; omit cost fields when estimation is disabled
- Document the Usage API and cover window, filters, completeness, and ranking

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Usage Summary API (`GET /api/v1/usage/summary`) with start/end date filtering plus optional alert type and chain filters.
  * Returns fleet-wide totals, breakdowns (model/alert/chain), and a capped top-sessions list with selectable ranking.
  * Supports cost-based ranking and exposes cost completeness when cost estimation is enabled; cost-related fields are omitted when disabled.
* **Documentation**
  * Updated the Usage API docs with parameters, response structure, and window/edge-case behavior.
* **Tests**
  * Added handler and service tests covering validation, ranking behavior, and response JSON variations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->