### PR TITLE
Feat/dashboard usage cost UI

### DIFF
--- a/docs/proposals/session-usage-cost-design.md
+++ b/docs/proposals/session-usage-cost-design.md
@@ -293,7 +293,7 @@ Depends on PR 1's columns (independent of PR 2). A new endpoint with its own agg
 1. `GET /api/v1/usage/summary` (session `created_at` window, soft-delete exclusion, GROUP BYs, top-20 + `rank_by`).
 2. Service/integration tests (windows, multi-model, null costs, `rank_by`).
 
-### PR 4 — Dashboard: Est. $ surfaces, Usage page, Config Viewer
+### PR 4 — Dashboard: Est. $ surfaces, Usage page, Config Viewer ✅ Done
 
 Depends on PR 2 + PR 3 response fields.
 

--- a/docs/session-usage-cost.md
+++ b/docs/session-usage-cost.md
@@ -115,6 +115,7 @@ Rules:
 - Soft-deleted sessions are always excluded.
 - All `interaction_type` values count (same as session token SUMs).
 - Response sections: `totals`, `by_model`, `by_alert_type`, `by_chain`, and capped `top_sessions` (hardcoded top **20**; no `limit` param).
+- `by_model[]` rows carry `priced` (bool: all token-bearing rows for that model are priced) and `unpriced_interaction_count` (count of token-bearing rows for that model with no resolved rate); the dashboard surfaces the count in the "Incomplete" chip's tooltip.
 - Unpriced top sessions are included with `$0` + `cost_completeness` (not dropped).
 - When estimation is disabled: `cost_estimation_enabled: false` and cost fields are omitted; token rollups remain.
 

--- a/docs/session-usage-cost.md
+++ b/docs/session-usage-cost.md
@@ -2,7 +2,7 @@
 
 TARSy can attach an **estimated USD cost** to each LLM interaction at write time, using list prices from a price book. Estimates are for operator judgment — they are **not** invoice truth.
 
-Cost is persisted on each `llm_interaction` at write time. Session list, detail, summary, and `ExecutionOverview` APIs expose estimated cost + completeness when estimation is enabled. Fleet dig-in uses `GET /api/v1/usage/summary` (Usage dashboard page lands in follow-up work). Config Viewer already exposes the effective toggle, overrides, and catalog status via `GET /api/v1/system/config`.
+Cost is persisted on each `llm_interaction` at write time. Session list, detail, summary, and `ExecutionOverview` APIs expose estimated cost + completeness when estimation is enabled. The dashboard shows soft **Est. $** next to tokens on Alert History, session detail, and parallel/sub-agent surfaces when estimation is enabled. Fleet dig-in is available on the **Usage** page (`/usage`, hamburger → Usage) via `GET /api/v1/usage/summary`. Config Viewer exposes the effective toggle, overrides, and catalog status under System → Cost estimation (`GET /api/v1/system/config`).
 
 ## Table of Contents
 
@@ -100,7 +100,7 @@ When estimation is **disabled**: responses set `cost_estimation_enabled: false` 
 GET /api/v1/usage/summary?start_date=&end_date=&alert_type=&chain_id=&rank_by=cost|tokens
 ```
 
-Server-side fleet aggregates for one date window (the Usage page does not load-all-then-filter).
+Server-side fleet aggregates for one date window. The dashboard **Usage** page (`/usage`) calls this endpoint for the selected window (presets: Last 7d / 30d / MTD / last calendar month; default 30d) with optional `alert_type` / `chain_id` filters and server-side `rank_by` for the top-20 table — it does not load-all-then-filter.
 
 | Param | Required | Notes |
 |-------|----------|--------|

--- a/pkg/models/session.go
+++ b/pkg/models/session.go
@@ -386,12 +386,13 @@ type UsageTotals struct {
 
 // UsageModelBreakdown is a per-model rollup within the window.
 type UsageModelBreakdown struct {
-	ModelName        string   `json:"model_name"`
-	InputTokens      int64    `json:"input_tokens"`
-	OutputTokens     int64    `json:"output_tokens"`
-	TotalTokens      int64    `json:"total_tokens"`
-	EstimatedCostUsd *float64 `json:"estimated_cost_usd,omitempty"`
-	Priced           *bool    `json:"priced,omitempty"` // true when all token-bearing rows for the model are priced
+	ModelName                string   `json:"model_name"`
+	InputTokens              int64    `json:"input_tokens"`
+	OutputTokens             int64    `json:"output_tokens"`
+	TotalTokens              int64    `json:"total_tokens"`
+	EstimatedCostUsd         *float64 `json:"estimated_cost_usd,omitempty"`
+	Priced                   *bool    `json:"priced,omitempty"`                     // true when all token-bearing rows for the model are priced
+	UnpricedInteractionCount *int     `json:"unpriced_interaction_count,omitempty"` // count of token-bearing interactions for this model with no resolved rate
 }
 
 // UsageAlertBreakdown is a per-alert-type rollup within the window.

--- a/pkg/services/session_service_usage.go
+++ b/pkg/services/session_service_usage.go
@@ -186,6 +186,8 @@ func (s *SessionService) usageByModel(ctx context.Context, interactionPred predi
 			item.EstimatedCostUsd = &cost
 			priced := row.TokenBearing > 0 && row.Priced == row.TokenBearing
 			item.Priced = &priced
+			unpriced := row.TokenBearing - row.Priced
+			item.UnpricedInteractionCount = &unpriced
 		}
 		out = append(out, item)
 	}

--- a/pkg/services/session_service_usage_test.go
+++ b/pkg/services/session_service_usage_test.go
@@ -122,8 +122,12 @@ func TestSessionService_GetUsageSummary(t *testing.T) {
 		require.Contains(t, byModel, "unpriced-model")
 		require.NotNil(t, byModel["priced-model"].Priced)
 		assert.True(t, *byModel["priced-model"].Priced)
+		require.NotNil(t, byModel["priced-model"].UnpricedInteractionCount)
+		assert.Equal(t, 0, *byModel["priced-model"].UnpricedInteractionCount)
 		require.NotNil(t, byModel["unpriced-model"].Priced)
 		assert.False(t, *byModel["unpriced-model"].Priced)
+		require.NotNil(t, byModel["unpriced-model"].UnpricedInteractionCount)
+		assert.Equal(t, 1, *byModel["unpriced-model"].UnpricedInteractionCount)
 
 		require.Len(t, summary.TopSessions, 1)
 		assert.Equal(t, models.CostCompletenessPartial, summary.TopSessions[0].CostCompleteness)

--- a/test/e2e/harness.go
+++ b/test/e2e/harness.go
@@ -15,6 +15,7 @@ import (
 	"github.com/codeready-toolchain/tarsy/ent"
 	"github.com/codeready-toolchain/tarsy/pkg/api"
 	"github.com/codeready-toolchain/tarsy/pkg/config"
+	"github.com/codeready-toolchain/tarsy/pkg/cost"
 	"github.com/codeready-toolchain/tarsy/pkg/database"
 	"github.com/codeready-toolchain/tarsy/pkg/events"
 	"github.com/codeready-toolchain/tarsy/pkg/mcp"
@@ -226,16 +227,23 @@ func NewTestApp(t *testing.T, opts ...TestAppOption) *TestApp {
 	// 7. RunbookService (nil config/token → uses defaults).
 	runbookService := runbook.NewService(tc.cfg.Runbooks, "", tc.cfg.Defaults.Runbook)
 
-	// 8. Session executor.
-	sessionExecutor := queue.NewRealSessionExecutor(tc.cfg, entClient, tc.llmClient, eventPublisher, mcpFactory, runbookService, tc.memoryService, tc.memoryConfig)
+	// 8. Price book for LLM usage cost estimation.
+	// Skip Book.Start (remote catalog fetch) — overrides + bundled snapshot are enough for e2e.
+	costBook, err := cost.NewBook(costConfigFrom(tc.cfg.CostEstimation))
+	require.NoError(t, err, "initialize cost estimation price book")
 
-	// 8a. Scoring executor — created when any chain has scoring enabled.
+	// 9. Session executor.
+	sessionExecutor := queue.NewRealSessionExecutor(tc.cfg, entClient, tc.llmClient, eventPublisher, mcpFactory, runbookService, tc.memoryService, tc.memoryConfig)
+	sessionExecutor.SetCostBook(costBook)
+
+	// 9a. Scoring executor — created when any chain has scoring enabled.
 	var scoringExecutor *queue.ScoringExecutor
 	if hasScoringEnabled(tc.cfg) {
 		scoringExecutor = queue.NewScoringExecutor(tc.cfg, entClient, tc.llmClient, eventPublisher, runbookService, tc.memoryService)
+		scoringExecutor.SetCostBook(costBook)
 	}
 
-	// 9. Worker pool.
+	// 10. Worker pool.
 	podID := tc.podID
 	if podID == "" {
 		podID = fmt.Sprintf("e2e-test-%s", t.Name())
@@ -243,7 +251,7 @@ func NewTestApp(t *testing.T, opts ...TestAppOption) *TestApp {
 	workerPool := queue.NewWorkerPool(podID, entClient, tc.cfg.Queue, sessionExecutor, scoringExecutor, eventPublisher, tc.slackService)
 	require.NoError(t, workerPool.Start(ctx))
 
-	// 10. Chat executor.
+	// 11. Chat executor.
 	chatExecutor := queue.NewChatMessageExecutor(
 		tc.cfg, entClient, tc.llmClient, mcpFactory, eventPublisher,
 		queue.ChatMessageExecutorConfig{
@@ -252,16 +260,18 @@ func NewTestApp(t *testing.T, opts ...TestAppOption) *TestApp {
 		},
 		runbookService, tc.memoryService, tc.memoryConfig,
 	)
+	chatExecutor.SetCostBook(costBook)
 
-	// 11. HTTP server on random port.
+	// 12. HTTP server on random port.
 	server := api.NewServer(tc.cfg, dbClient, alertService, sessionService, workerPool, connManager)
 	server.SetChatService(chatService)
 	server.SetChatExecutor(chatExecutor)
 	server.SetEventPublisher(eventPublisher)
+	server.SetCostBook(costBook)
 
 	// Trace/observability and timeline endpoints.
 	messageService := services.NewMessageService(entClient)
-	interactionService := services.NewInteractionService(entClient, messageService, nil)
+	interactionService := services.NewInteractionService(entClient, messageService, costBook)
 	stageService := services.NewStageService(entClient)
 	timelineService := services.NewTimelineService(entClient)
 	server.SetInteractionService(interactionService)
@@ -351,4 +361,22 @@ func hasScoringEnabled(cfg *config.Config) bool {
 		}
 	}
 	return false
+}
+
+// costConfigFrom maps resolved YAML cost-estimation settings into pkg/cost.Config.
+func costConfigFrom(cfg *config.CostEstimationConfig) *cost.Config {
+	if cfg == nil {
+		return &cost.Config{Enabled: true}
+	}
+	rates := make(map[string]cost.ModelRateOverride, len(cfg.ModelRates))
+	for name, rate := range cfg.ModelRates {
+		rates[name] = cost.ModelRateOverride{
+			InputPerMillion:  rate.InputPerMillion,
+			OutputPerMillion: rate.OutputPerMillion,
+		}
+	}
+	return &cost.Config{
+		Enabled:    cfg.Enabled,
+		ModelRates: rates,
+	}
 }

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -190,6 +190,17 @@ func (app *TestApp) GetSystemConfig(t *testing.T) map[string]interface{} {
 	return app.getJSON(t, "/api/v1/system/config", http.StatusOK)
 }
 
+// GetUsageSummary calls GET /api/v1/usage/summary with the given query string
+// (e.g. "start_date=...&end_date=...&rank_by=cost").
+func (app *TestApp) GetUsageSummary(t *testing.T, queryParams string) map[string]interface{} {
+	t.Helper()
+	path := "/api/v1/usage/summary"
+	if queryParams != "" {
+		path += "?" + queryParams
+	}
+	return app.getJSON(t, path, http.StatusOK)
+}
+
 // GetSystemConfigSkill calls GET /api/v1/system/config/skills/:name.
 func (app *TestApp) GetSystemConfigSkill(t *testing.T, name string, expectedStatus int) map[string]interface{} {
 	t.Helper()
@@ -587,6 +598,26 @@ func toInt(v interface{}) int {
 	case json.Number:
 		i, _ := n.Int64()
 		return int(i)
+	default:
+		return 0
+	}
+}
+
+// toFloat converts a JSON-decoded numeric value to float64.
+// Returns 0 if the value is nil or not a recognized numeric type.
+func toFloat(v interface{}) float64 {
+	switch n := v.(type) {
+	case float64:
+		return n
+	case float32:
+		return float64(n)
+	case int:
+		return float64(n)
+	case int64:
+		return float64(n)
+	case json.Number:
+		f, _ := n.Float64()
+		return f
 	default:
 		return 0
 	}

--- a/test/e2e/testdata/configs/usage-cost/llm-providers.yaml
+++ b/test/e2e/testdata/configs/usage-cost/llm-providers.yaml
@@ -1,0 +1,6 @@
+llm_providers:
+  test-provider:
+    type: google
+    model: test-model
+    max_tool_result_tokens: 10000
+    base_url: "https://api:E2E_SENTINEL_BASE_URL@llm.example.com/v1?api_key=E2E_SENTINEL_BASE_QUERY"

--- a/test/e2e/testdata/configs/usage-cost/tarsy.yaml
+++ b/test/e2e/testdata/configs/usage-cost/tarsy.yaml
@@ -1,0 +1,33 @@
+defaults:
+  llm_provider: "test-provider"
+  llm_backend: "google-native"
+  max_iterations: 1
+
+# Deterministic per-million overrides for the scripted e2e model (test-model).
+# Avoids relying on LiteLLM catalog matching for cost assertions.
+system:
+  cost_estimation:
+    enabled: true
+    model_rates:
+      test-model:
+        input_per_million: 1.0
+        output_per_million: 2.0
+
+mcp_servers:
+  # Dummy entry so built-in agents pass validation.
+  kubernetes-server:
+    transport:
+      type: stdio
+      command: mock
+
+agents:
+  SimpleAgent:
+    custom_instructions: "You are SimpleAgent, performing a quick analysis."
+
+agent_chains:
+  usage-cost-chain:
+    alert_types: [test-usage-cost]
+    stages:
+      - name: analysis
+        agents:
+          - name: SimpleAgent

--- a/test/e2e/usage_cost_test.go
+++ b/test/e2e/usage_cost_test.go
@@ -37,10 +37,10 @@ func TestUsageCost_PipelinePersistsAndExposesCost(t *testing.T) {
 	// Session A: lower tokens, higher cost (thinking tokens priced at output rate).
 	// Session B: higher tokens, lower cost — separates rank_by=cost vs rank_by=tokens.
 	type sessionSpec struct {
-		alertData                                 string
-		investText, summaryText                   string
-		invIn, invOut, invTotal, invThinking      int
-		sumIn, sumOut, sumTotal                   int
+		alertData                            string
+		investText, summaryText              string
+		invIn, invOut, invTotal, invThinking int
+		sumIn, sumOut, sumTotal              int
 	}
 	specs := []sessionSpec{
 		{

--- a/test/e2e/usage_cost_test.go
+++ b/test/e2e/usage_cost_test.go
@@ -1,0 +1,314 @@
+package e2e
+
+import (
+	"fmt"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/codeready-toolchain/tarsy/pkg/agent"
+	"github.com/codeready-toolchain/tarsy/test/e2e/testdata/configs"
+)
+
+// usageCostRates match system.cost_estimation.model_rates in the usage-cost config.
+const (
+	usageCostInputPerMillion  = 1.0
+	usageCostOutputPerMillion = 2.0
+)
+
+// estimateUSD mirrors pkg/cost.Estimate for YAML overrides (thinking uses output rate).
+func estimateUSD(inputTokens, outputTokens, thinkingTokens int) float64 {
+	return float64(inputTokens)*usageCostInputPerMillion/1_000_000 +
+		float64(outputTokens)*usageCostOutputPerMillion/1_000_000 +
+		float64(thinkingTokens)*usageCostOutputPerMillion/1_000_000
+}
+
+// TestUsageCost_PipelinePersistsAndExposesCost runs a minimal single-stage chain
+// with scripted token usage (including thinking tokens) and YAML rate overrides.
+// It verifies the write path → DB → session APIs → usage summary → config viewer.
+func TestUsageCost_PipelinePersistsAndExposesCost(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test in short mode")
+	}
+
+	// Session A: lower tokens, higher cost (thinking tokens priced at output rate).
+	// Session B: higher tokens, lower cost — separates rank_by=cost vs rank_by=tokens.
+	type sessionSpec struct {
+		alertData                                 string
+		investText, summaryText                   string
+		invIn, invOut, invTotal, invThinking      int
+		sumIn, sumOut, sumTotal                   int
+	}
+	specs := []sessionSpec{
+		{
+			alertData:   "Usage session A",
+			investText:  "A investigation complete.",
+			summaryText: "A executive summary.",
+			invIn:       100, invOut: 50, invTotal: 150, invThinking: 1000,
+			sumIn: 30, sumOut: 10, sumTotal: 40,
+		},
+		{
+			alertData:   "Usage session B",
+			investText:  "B investigation complete.",
+			summaryText: "B executive summary.",
+			invIn:       500, invOut: 250, invTotal: 750, invThinking: 0,
+			sumIn: 100, sumOut: 50, sumTotal: 150,
+		},
+	}
+
+	llm := NewScriptedLLMClient()
+	for _, s := range specs {
+		llm.AddSequential(LLMScriptEntry{
+			Chunks: []agent.Chunk{
+				&agent.TextChunk{Content: s.investText},
+				&agent.UsageChunk{
+					InputTokens:    s.invIn,
+					OutputTokens:   s.invOut,
+					TotalTokens:    s.invTotal,
+					ThinkingTokens: s.invThinking,
+				},
+			},
+		})
+		llm.AddSequential(LLMScriptEntry{
+			Chunks: []agent.Chunk{
+				&agent.TextChunk{Content: s.summaryText},
+				&agent.UsageChunk{
+					InputTokens:  s.sumIn,
+					OutputTokens: s.sumOut,
+					TotalTokens:  s.sumTotal,
+				},
+			},
+		})
+	}
+
+	app := NewTestApp(t,
+		WithConfig(configs.Load(t, "usage-cost")),
+		WithLLMClient(llm),
+	)
+
+	ids := make([]string, len(specs))
+	for i, s := range specs {
+		result := app.SubmitAlert(t, "test-usage-cost", s.alertData)
+		ids[i] = result["session_id"].(string)
+		app.WaitForSessionStatus(t, ids[i], "completed")
+	}
+
+	type sessionExpected struct {
+		inputTokens, outputTokens, totalTokens int
+		estimatedCost                          float64
+	}
+	expectedByID := make(map[string]sessionExpected, len(specs))
+	var totalIn, totalOut, totalTok int
+	var totalCost float64
+	for i, s := range specs {
+		in := s.invIn + s.sumIn
+		out := s.invOut + s.sumOut
+		tok := s.invTotal + s.sumTotal
+		cost := estimateUSD(s.invIn, s.invOut, s.invThinking) +
+			estimateUSD(s.sumIn, s.sumOut, 0)
+		expectedByID[ids[i]] = sessionExpected{
+			inputTokens: in, outputTokens: out, totalTokens: tok,
+			estimatedCost: cost,
+		}
+		totalIn += in
+		totalOut += out
+		totalTok += tok
+		totalCost += cost
+	}
+
+	t.Run("SessionListCost", func(t *testing.T) {
+		list := app.GetSessionList(t, "")
+		assert.Equal(t, true, list["cost_estimation_enabled"])
+
+		items, ok := list["sessions"].([]interface{})
+		require.True(t, ok)
+		require.Len(t, items, 2)
+
+		for _, item := range items {
+			sess := item.(map[string]interface{})
+			id := sess["id"].(string)
+			exp := expectedByID[id]
+
+			assert.Equal(t, exp.inputTokens, toInt(sess["input_tokens"]), "session %s input_tokens", id)
+			assert.Equal(t, exp.outputTokens, toInt(sess["output_tokens"]), "session %s output_tokens", id)
+			assert.Equal(t, exp.totalTokens, toInt(sess["total_tokens"]), "session %s total_tokens", id)
+			assert.InDelta(t, exp.estimatedCost, toFloat(sess["estimated_cost_usd"]), 1e-12, "session %s cost", id)
+			assert.Equal(t, "complete", sess["cost_completeness"], "session %s completeness", id)
+		}
+	})
+
+	t.Run("SessionDetailAndSummaryCost", func(t *testing.T) {
+		id := ids[0]
+		exp := expectedByID[id]
+
+		detail := app.GetSession(t, id)
+		assert.Equal(t, true, detail["cost_estimation_enabled"])
+		assert.Equal(t, exp.inputTokens, toInt(detail["input_tokens"]))
+		assert.Equal(t, exp.outputTokens, toInt(detail["output_tokens"]))
+		assert.Equal(t, exp.totalTokens, toInt(detail["total_tokens"]))
+		assert.InDelta(t, exp.estimatedCost, toFloat(detail["estimated_cost_usd"]), 1e-12)
+		assert.Equal(t, "complete", detail["cost_completeness"])
+		assert.Equal(t, 0, toInt(detail["unpriced_interaction_count"]))
+
+		summary := app.GetSessionSummary(t, id)
+		assert.Equal(t, true, summary["cost_estimation_enabled"])
+		assert.InDelta(t, exp.estimatedCost, toFloat(summary["estimated_cost_usd"]), 1e-12)
+		assert.Equal(t, "complete", summary["cost_completeness"])
+	})
+
+	t.Run("UsageSummary", func(t *testing.T) {
+		start := time.Now().UTC().Add(-1 * time.Hour).Format(time.RFC3339)
+		end := time.Now().UTC().Add(1 * time.Hour).Format(time.RFC3339)
+		q := url.Values{
+			"start_date": {start},
+			"end_date":   {end},
+			"rank_by":    {"cost"},
+		}
+
+		usage := app.GetUsageSummary(t, q.Encode())
+		assert.Equal(t, true, usage["cost_estimation_enabled"])
+		assert.Equal(t, "cost", usage["rank_by"])
+
+		totals, ok := usage["totals"].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, totalIn, toInt(totals["input_tokens"]))
+		assert.Equal(t, totalOut, toInt(totals["output_tokens"]))
+		assert.Equal(t, totalTok, toInt(totals["total_tokens"]))
+		assert.InDelta(t, totalCost, toFloat(totals["estimated_cost_usd"]), 1e-12)
+		assert.Equal(t, "complete", totals["cost_completeness"])
+
+		byModel, ok := usage["by_model"].([]interface{})
+		require.True(t, ok)
+		require.Len(t, byModel, 1)
+		model := byModel[0].(map[string]interface{})
+		assert.Equal(t, "test-model", model["model_name"])
+		assert.Equal(t, true, model["priced"])
+		assert.Equal(t, 0, toInt(model["unpriced_interaction_count"]))
+		assert.InDelta(t, totalCost, toFloat(model["estimated_cost_usd"]), 1e-12)
+
+		byAlert, ok := usage["by_alert_type"].([]interface{})
+		require.True(t, ok)
+		require.Len(t, byAlert, 1)
+		assert.Equal(t, "test-usage-cost", byAlert[0].(map[string]interface{})["alert_type"])
+
+		byChain, ok := usage["by_chain"].([]interface{})
+		require.True(t, ok)
+		require.Len(t, byChain, 1)
+		assert.Equal(t, "usage-cost-chain", byChain[0].(map[string]interface{})["chain_id"])
+
+		top, ok := usage["top_sessions"].([]interface{})
+		require.True(t, ok)
+		require.Len(t, top, 2)
+		// rank_by=cost: A (thinking-heavy) before B
+		assert.Equal(t, ids[0], top[0].(map[string]interface{})["session_id"])
+		assert.Equal(t, ids[1], top[1].(map[string]interface{})["session_id"])
+		assert.InDelta(t, expectedByID[ids[0]].estimatedCost,
+			toFloat(top[0].(map[string]interface{})["estimated_cost_usd"]), 1e-12)
+
+		q.Set("rank_by", "tokens")
+		byTokens := app.GetUsageSummary(t, q.Encode())
+		topTok, ok := byTokens["top_sessions"].([]interface{})
+		require.True(t, ok)
+		require.Len(t, topTok, 2)
+		// rank_by=tokens: B (more tokens) before A
+		assert.Equal(t, ids[1], topTok[0].(map[string]interface{})["session_id"])
+		assert.Equal(t, ids[0], topTok[1].(map[string]interface{})["session_id"])
+	})
+
+	t.Run("SystemConfigCostEstimation", func(t *testing.T) {
+		cfg := app.GetSystemConfig(t)
+		system, ok := cfg["system"].(map[string]interface{})
+		require.True(t, ok, "system should be present")
+		ce, ok := system["cost_estimation"].(map[string]interface{})
+		require.True(t, ok, "system.cost_estimation should be present")
+		assert.Equal(t, true, ce["enabled"])
+
+		rates, ok := ce["model_rates"].(map[string]interface{})
+		require.True(t, ok)
+		tm, ok := rates["test-model"].(map[string]interface{})
+		require.True(t, ok)
+		assert.InDelta(t, usageCostInputPerMillion, toFloat(tm["input_per_million"]), 1e-12)
+		assert.InDelta(t, usageCostOutputPerMillion, toFloat(tm["output_per_million"]), 1e-12)
+
+		catalog, ok := ce["catalog"].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, "snapshot", catalog["source"])
+		assert.Greater(t, toInt(catalog["entry_count"]), 0)
+	})
+}
+
+// TestUsageCost_EstimationDisabled verifies tokens still flow while cost fields
+// are omitted and rank_by=cost is rejected.
+func TestUsageCost_EstimationDisabled(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test in short mode")
+	}
+
+	cfg := configs.Load(t, "usage-cost")
+	require.NotNil(t, cfg.CostEstimation)
+	cfg.CostEstimation.Enabled = false
+
+	llm := NewScriptedLLMClient()
+	llm.AddSequential(LLMScriptEntry{
+		Chunks: []agent.Chunk{
+			&agent.TextChunk{Content: "Disabled-cost investigation."},
+			&agent.UsageChunk{InputTokens: 80, OutputTokens: 40, TotalTokens: 120},
+		},
+	})
+	llm.AddSequential(LLMScriptEntry{
+		Chunks: []agent.Chunk{
+			&agent.TextChunk{Content: "Disabled-cost summary."},
+			&agent.UsageChunk{InputTokens: 20, OutputTokens: 10, TotalTokens: 30},
+		},
+	})
+
+	app := NewTestApp(t, WithConfig(cfg), WithLLMClient(llm))
+	result := app.SubmitAlert(t, "test-usage-cost", "disabled cost payload")
+	sessionID := result["session_id"].(string)
+	app.WaitForSessionStatus(t, sessionID, "completed")
+
+	list := app.GetSessionList(t, "")
+	assert.Equal(t, false, list["cost_estimation_enabled"])
+	items := list["sessions"].([]interface{})
+	require.Len(t, items, 1)
+	sess := items[0].(map[string]interface{})
+	assert.Equal(t, 100, toInt(sess["input_tokens"]))
+	assert.Equal(t, 50, toInt(sess["output_tokens"]))
+	assert.Equal(t, 150, toInt(sess["total_tokens"]))
+	_, hasCost := sess["estimated_cost_usd"]
+	assert.False(t, hasCost, "estimated_cost_usd must be omitted when estimation is disabled")
+	_, hasCompleteness := sess["cost_completeness"]
+	assert.False(t, hasCompleteness, "cost_completeness must be omitted when estimation is disabled")
+
+	detail := app.GetSession(t, sessionID)
+	assert.Equal(t, false, detail["cost_estimation_enabled"])
+	_, hasDetailCost := detail["estimated_cost_usd"]
+	assert.False(t, hasDetailCost)
+
+	start := time.Now().UTC().Add(-1 * time.Hour).Format(time.RFC3339)
+	end := time.Now().UTC().Add(1 * time.Hour).Format(time.RFC3339)
+
+	usage := app.GetUsageSummary(t, fmt.Sprintf(
+		"start_date=%s&end_date=%s&rank_by=tokens",
+		url.QueryEscape(start), url.QueryEscape(end),
+	))
+	assert.Equal(t, false, usage["cost_estimation_enabled"])
+	totals := usage["totals"].(map[string]interface{})
+	assert.Equal(t, 150, toInt(totals["total_tokens"]))
+	_, hasUsageCost := totals["estimated_cost_usd"]
+	assert.False(t, hasUsageCost)
+
+	// rank_by=cost is rejected when estimation is disabled.
+	app.getJSON(t, fmt.Sprintf(
+		"/api/v1/usage/summary?start_date=%s&end_date=%s&rank_by=cost",
+		url.QueryEscape(start), url.QueryEscape(end),
+	), 400)
+
+	sysCfg := app.GetSystemConfig(t)
+	system := sysCfg["system"].(map[string]interface{})
+	ce := system["cost_estimation"].(map[string]interface{})
+	assert.Equal(t, false, ce["enabled"])
+}

--- a/web/dashboard/src/App.tsx
+++ b/web/dashboard/src/App.tsx
@@ -12,6 +12,7 @@ import { TracePage } from './pages/TracePage.tsx';
 import { SubmitAlertPage } from './pages/SubmitAlertPage.tsx';
 import { SystemStatusPage } from './pages/SystemStatusPage.tsx';
 import { ScoringPage } from './pages/ScoringPage.tsx';
+import { UsagePage } from './pages/UsagePage.tsx';
 import { NotFoundPage } from './pages/NotFoundPage.tsx';
 
 const router = createBrowserRouter([
@@ -38,6 +39,10 @@ const router = createBrowserRouter([
   {
     path: '/system',
     element: <SystemStatusPage />,
+  },
+  {
+    path: '/usage',
+    element: <UsagePage />,
   },
   {
     path: '*',

--- a/web/dashboard/src/components/dashboard/DashboardView.tsx
+++ b/web/dashboard/src/components/dashboard/DashboardView.tsx
@@ -36,6 +36,7 @@ import {
   Menu as MenuIcon,
   Send as SendIcon,
   Dns as DnsIcon,
+  BarChart as BarChartIcon,
   DarkMode as DarkModeIcon,
   LightMode as LightModeIcon,
 } from '@mui/icons-material';
@@ -160,6 +161,10 @@ export function DashboardView() {
     window.open('/system', '_blank', 'noopener,noreferrer');
     handleMenuClose();
   };
+  const handleUsage = () => {
+    window.open('/usage', '_blank', 'noopener,noreferrer');
+    handleMenuClose();
+  };
 
   // ── Active sessions state ──
   const [activeSessions, setActiveSessions] = useState<ActiveSessionItem[]>([]);
@@ -171,6 +176,7 @@ export function DashboardView() {
   const [historicalSessions, setHistoricalSessions] = useState<DashboardSessionItem[]>([]);
   const [historicalLoading, setHistoricalLoading] = useState(true);
   const [historicalError, setHistoricalError] = useState<string | null>(null);
+  const [costEstimationEnabled, setCostEstimationEnabled] = useState(false);
 
   // ── Progress data from WebSocket ──
   const [progressData, setProgressData] = useState<Record<string, SessionProgressPayload>>({});
@@ -276,6 +282,7 @@ export function DashboardView() {
 
       if (filtersOk && pageOk && sortOk) {
         setHistoricalSessions(data.sessions);
+        setCostEstimationEnabled(data.cost_estimation_enabled === true);
         setPagination((prev) => ({
           ...prev,
           totalItems: data.pagination.total_items,
@@ -1038,6 +1045,12 @@ export function DashboardView() {
           </ListItemIcon>
           <ListItemText>Manual Alert Submission</ListItemText>
         </MenuItem>
+        <MenuItem onClick={handleUsage}>
+          <ListItemIcon>
+            <BarChartIcon fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>Usage</ListItemText>
+        </MenuItem>
         <MenuItem onClick={handleSystemStatus}>
           <ListItemIcon>
             <DnsIcon fontSize="small" />
@@ -1075,6 +1088,7 @@ export function DashboardView() {
               filteredCount={pagination.totalItems}
               sortState={sortState}
               pagination={pagination}
+              costEstimationEnabled={costEstimationEnabled}
               onRefresh={handleRefreshHistorical}
               onSortChange={handleSortChange}
               onPageChange={handlePageChange}

--- a/web/dashboard/src/components/dashboard/HistoricalAlertsList.tsx
+++ b/web/dashboard/src/components/dashboard/HistoricalAlertsList.tsx
@@ -31,10 +31,11 @@ import type { SessionFilter, PaginationState, SortState } from '../../types/dash
 import { QualityGroupHeaders } from './QualityGroupHeaders.tsx';
 
 /**
- * Column order: Status | Indicators | Type | Author | Time | Duration | Tokens | Eval Score | Review | Actions
+ * Column order: Status | Indicators | Type | Author | Time | Duration | Tokens | [Est. Cost] | Eval Score | Review | Actions
  * Indicators column packs: parallel, sub-agents, action, fallback, chat (fixed-slot grid).
+ * Est. Cost column only renders when cost estimation is enabled.
  */
-const TOTAL_COLUMNS = 10;
+const BASE_TOTAL_COLUMNS = 10;
 
 interface HistoricalAlertsListProps {
   sessions: DashboardSessionItem[];
@@ -67,6 +68,7 @@ export function HistoricalAlertsList({
   onPageSizeChange,
   onReviewClick,
 }: HistoricalAlertsListProps) {
+  const totalColumns = BASE_TOTAL_COLUMNS + (costEstimationEnabled ? 1 : 0);
   return (
     <Paper variant="outlined" sx={{ overflow: 'hidden' }}>
       {/* Header */}
@@ -241,6 +243,11 @@ export function HistoricalAlertsList({
                   {/* Tokens — not sortable */}
                   <TableCell sx={{ fontWeight: 600 }}>Tokens</TableCell>
 
+                  {/* Est. Cost — not sortable; only shown when estimation is enabled */}
+                  {costEstimationEnabled && (
+                    <TableCell sx={{ fontWeight: 600 }}>Est. Cost</TableCell>
+                  )}
+
                   <QualityGroupHeaders
                     sortField={sortState.field}
                     sortDirection={sortState.direction}
@@ -255,7 +262,7 @@ export function HistoricalAlertsList({
               <TableBody>
                 {sessions.length === 0 ? (
                   <TableRow>
-                    <TableCell colSpan={TOTAL_COLUMNS} align="center">
+                    <TableCell colSpan={totalColumns} align="center">
                       <Box sx={{ py: 6, textAlign: 'center' }}>
                         {hasActiveFilters(filters) ? (
                           <>

--- a/web/dashboard/src/components/dashboard/HistoricalAlertsList.tsx
+++ b/web/dashboard/src/components/dashboard/HistoricalAlertsList.tsx
@@ -44,6 +44,7 @@ interface HistoricalAlertsListProps {
   filteredCount: number;
   sortState: SortState;
   pagination: PaginationState;
+  costEstimationEnabled?: boolean;
   onRefresh: () => void;
   onSortChange: (field: string) => void;
   onPageChange: (page: number) => void;
@@ -59,6 +60,7 @@ export function HistoricalAlertsList({
   filteredCount,
   sortState,
   pagination,
+  costEstimationEnabled = false,
   onRefresh,
   onSortChange,
   onPageChange,
@@ -284,6 +286,7 @@ export function HistoricalAlertsList({
                       key={session.id}
                       session={session}
                       searchTerm={filters.search}
+                      costEstimationEnabled={costEstimationEnabled}
                       onReviewClick={onReviewClick}
                     />
                   ))

--- a/web/dashboard/src/components/dashboard/SessionListItem.tsx
+++ b/web/dashboard/src/components/dashboard/SessionListItem.tsx
@@ -32,6 +32,7 @@ import { OpenNewTabButton } from './OpenNewTabButton.tsx';
 import { highlightSearchTermNodes } from '../../utils/search.ts';
 import { formatTimestamp, formatDurationMs } from '../../utils/format.ts';
 import TokenUsageDisplay from '../shared/TokenUsageDisplay.tsx';
+import EstimatedCostDisplay from '../shared/EstimatedCostDisplay.tsx';
 import { sessionDetailPath } from '../../constants/routes.ts';
 import type { DashboardSessionItem } from '../../types/session.ts';
 import { actionStageChipStyles } from './sessionActionChipSx.ts';
@@ -39,6 +40,7 @@ import { actionStageChipStyles } from './sessionActionChipSx.ts';
 interface SessionListItemProps {
   session: DashboardSessionItem;
   searchTerm: string;
+  costEstimationEnabled?: boolean;
   onReviewClick?: (session: DashboardSessionItem) => void;
 }
 
@@ -49,7 +51,12 @@ const iconOnlyChipSx = {
   '& .MuiChip-icon': { mx: 0 },
 } as const;
 
-export function SessionListItem({ session, searchTerm, onReviewClick }: SessionListItemProps) {
+export function SessionListItem({
+  session,
+  searchTerm,
+  costEstimationEnabled = false,
+  onReviewClick,
+}: SessionListItemProps) {
   const navigate = useNavigate();
 
   const handleRowClick = () => {
@@ -184,19 +191,27 @@ export function SessionListItem({ session, searchTerm, onReviewClick }: SessionL
         </Typography>
       </TableCell>
 
-      {/* Tokens */}
+      {/* Tokens + Est. cost */}
       <TableCell>
         {(session.total_tokens > 0 || session.input_tokens > 0 || session.output_tokens > 0) ? (
-          <TokenUsageDisplay
-            tokenData={{
-              input_tokens: session.input_tokens,
-              output_tokens: session.output_tokens,
-              total_tokens: session.total_tokens,
-            }}
-            variant="inline"
-            size="small"
-            showBreakdown={false}
-          />
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.25 }}>
+            <TokenUsageDisplay
+              tokenData={{
+                input_tokens: session.input_tokens,
+                output_tokens: session.output_tokens,
+                total_tokens: session.total_tokens,
+              }}
+              variant="inline"
+              size="small"
+              showBreakdown={false}
+            />
+            <EstimatedCostDisplay
+              enabled={costEstimationEnabled}
+              estimatedCostUsd={session.estimated_cost_usd}
+              costCompleteness={session.cost_completeness}
+              size="small"
+            />
+          </Box>
         ) : (
           <Typography variant="body2" color="text.secondary">
             —

--- a/web/dashboard/src/components/dashboard/SessionListItem.tsx
+++ b/web/dashboard/src/components/dashboard/SessionListItem.tsx
@@ -191,33 +191,43 @@ export function SessionListItem({
         </Typography>
       </TableCell>
 
-      {/* Tokens + Est. cost */}
+      {/* Tokens */}
       <TableCell>
         {(session.total_tokens > 0 || session.input_tokens > 0 || session.output_tokens > 0) ? (
-          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.25 }}>
-            <TokenUsageDisplay
-              tokenData={{
-                input_tokens: session.input_tokens,
-                output_tokens: session.output_tokens,
-                total_tokens: session.total_tokens,
-              }}
-              variant="inline"
-              size="small"
-              showBreakdown={false}
-            />
-            <EstimatedCostDisplay
-              enabled={costEstimationEnabled}
-              estimatedCostUsd={session.estimated_cost_usd}
-              costCompleteness={session.cost_completeness}
-              size="small"
-            />
-          </Box>
+          <TokenUsageDisplay
+            tokenData={{
+              input_tokens: session.input_tokens,
+              output_tokens: session.output_tokens,
+              total_tokens: session.total_tokens,
+            }}
+            variant="inline"
+            size="small"
+            showBreakdown={false}
+          />
         ) : (
           <Typography variant="body2" color="text.secondary">
             —
           </Typography>
         )}
       </TableCell>
+
+      {/* Est. Cost — only rendered when cost estimation is enabled */}
+      {costEstimationEnabled && (
+        <TableCell>
+          {session.estimated_cost_usd != null && session.cost_completeness != null && session.cost_completeness !== 'none' ? (
+            <EstimatedCostDisplay
+              enabled
+              estimatedCostUsd={session.estimated_cost_usd}
+              costCompleteness={session.cost_completeness}
+              size="small"
+            />
+          ) : (
+            <Typography variant="body2" color="text.secondary">
+              —
+            </Typography>
+          )}
+        </TableCell>
+      )}
 
       {/* Eval Score */}
       <ScoreCell

--- a/web/dashboard/src/components/dashboard/TimeRangeModal.tsx
+++ b/web/dashboard/src/components/dashboard/TimeRangeModal.tsx
@@ -25,7 +25,22 @@ import { Close, AccessTime, CalendarToday } from '@mui/icons-material';
 import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
-import { format, subMinutes, subHours, subDays, isBefore } from 'date-fns';
+import {
+  format,
+  subMinutes,
+  subHours,
+  subDays,
+  isBefore,
+  startOfMonth,
+  subMonths,
+} from 'date-fns';
+
+export interface TimePreset {
+  label: string;
+  value: string;
+  description: string;
+  getDateRange: () => { start: Date; end: Date };
+}
 
 export interface TimeRangeModalProps {
   open: boolean;
@@ -33,14 +48,111 @@ export interface TimeRangeModalProps {
   startDate?: Date | null;
   endDate?: Date | null;
   onApply: (startDate: Date | null, endDate: Date | null, preset?: string) => void;
+  /** Override presets (defaults to Alert History quick ranges). */
+  presets?: TimePreset[];
 }
 
-interface TimePreset {
-  label: string;
-  value: string;
-  description: string;
-  getDateRange: () => { start: Date; end: Date };
-}
+/** Default Alert History presets (10m … 30d). */
+export const DEFAULT_TIME_PRESETS: TimePreset[] = [
+  {
+    label: 'Last 10 minutes',
+    value: '10m',
+    description: 'Last 10 minutes',
+    getDateRange: () => ({
+      start: subMinutes(new Date(), 10),
+      end: new Date(),
+    }),
+  },
+  {
+    label: 'Last hour',
+    value: '1h',
+    description: 'Last hour',
+    getDateRange: () => ({
+      start: subHours(new Date(), 1),
+      end: new Date(),
+    }),
+  },
+  {
+    label: 'Last 12 hours',
+    value: '12h',
+    description: 'Last 12 hours',
+    getDateRange: () => ({
+      start: subHours(new Date(), 12),
+      end: new Date(),
+    }),
+  },
+  {
+    label: 'Last day',
+    value: '1d',
+    description: 'Last 24 hours',
+    getDateRange: () => ({
+      start: subDays(new Date(), 1),
+      end: new Date(),
+    }),
+  },
+  {
+    label: 'Last 7 days',
+    value: '7d',
+    description: 'Last week',
+    getDateRange: () => ({
+      start: subDays(new Date(), 7),
+      end: new Date(),
+    }),
+  },
+  {
+    label: 'Last 30 days',
+    value: '30d',
+    description: 'Last month',
+    getDateRange: () => ({
+      start: subDays(new Date(), 30),
+      end: new Date(),
+    }),
+  },
+];
+
+/** Usage page presets (7d / 30d / MTD / last calendar month). */
+export const USAGE_TIME_PRESETS: TimePreset[] = [
+  {
+    label: 'Last 7 days',
+    value: '7d',
+    description: 'Last 7 days',
+    getDateRange: () => ({
+      start: subDays(new Date(), 7),
+      end: new Date(),
+    }),
+  },
+  {
+    label: 'Last 30 days',
+    value: '30d',
+    description: 'Last 30 days',
+    getDateRange: () => ({
+      start: subDays(new Date(), 30),
+      end: new Date(),
+    }),
+  },
+  {
+    label: 'Month to date',
+    value: 'mtd',
+    description: 'From the start of this calendar month',
+    getDateRange: () => ({
+      start: startOfMonth(new Date()),
+      end: new Date(),
+    }),
+  },
+  {
+    label: 'Last calendar month',
+    value: 'last_month',
+    description: 'Previous calendar month',
+    getDateRange: () => {
+      const prev = subMonths(new Date(), 1);
+      return {
+        start: startOfMonth(prev),
+        // Half-open end: first instant of current month
+        end: startOfMonth(new Date()),
+      };
+    },
+  },
+];
 
 /** Compare optional dates by timestamp; null/undefined only match the same sentinel. */
 function sameDate(a?: Date | null, b?: Date | null): boolean {
@@ -57,69 +169,13 @@ export function TimeRangeModal({
   startDate,
   endDate,
   onApply,
+  presets = DEFAULT_TIME_PRESETS,
 }: TimeRangeModalProps) {
   const [selectedPreset, setSelectedPreset] = useState<string | null>(null);
   const [customStartDate, setCustomStartDate] = useState<Date | null>(startDate || null);
   const [customEndDate, setCustomEndDate] = useState<Date | null>(endDate || null);
   const [mode, setMode] = useState<'preset' | 'custom'>('preset');
-
-  // Time presets — matching old dashboard
-  const timePresets: TimePreset[] = [
-    {
-      label: 'Last 10 minutes',
-      value: '10m',
-      description: 'Last 10 minutes',
-      getDateRange: () => ({
-        start: subMinutes(new Date(), 10),
-        end: new Date(),
-      }),
-    },
-    {
-      label: 'Last hour',
-      value: '1h',
-      description: 'Last hour',
-      getDateRange: () => ({
-        start: subHours(new Date(), 1),
-        end: new Date(),
-      }),
-    },
-    {
-      label: 'Last 12 hours',
-      value: '12h',
-      description: 'Last 12 hours',
-      getDateRange: () => ({
-        start: subHours(new Date(), 12),
-        end: new Date(),
-      }),
-    },
-    {
-      label: 'Last day',
-      value: '1d',
-      description: 'Last 24 hours',
-      getDateRange: () => ({
-        start: subDays(new Date(), 1),
-        end: new Date(),
-      }),
-    },
-    {
-      label: 'Last 7 days',
-      value: '7d',
-      description: 'Last week',
-      getDateRange: () => ({
-        start: subDays(new Date(), 7),
-        end: new Date(),
-      }),
-    },
-    {
-      label: 'Last 30 days',
-      value: '30d',
-      description: 'Last month',
-      getDateRange: () => ({
-        start: subDays(new Date(), 30),
-        end: new Date(),
-      }),
-    },
-  ];
+  const timePresets = presets;
 
   // Reset state when modal opens (null = not yet synced).
   // Compare dates by timestamp so new Date instances with the same value don't retrigger.

--- a/web/dashboard/src/components/session/ConversationTimeline.tsx
+++ b/web/dashboard/src/components/session/ConversationTimeline.tsx
@@ -98,6 +98,8 @@ interface ConversationTimelineProps {
   defaultCollapsed?: boolean;
   /** Increment to expand the timeline from outside (e.g. when user sends a chat message) */
   expandCounter?: number;
+  /** Whether cost estimation is enabled for this session (gates EstimatedCostDisplay in sub-agent cards) */
+  costEstimationEnabled?: boolean;
 }
 
 /**
@@ -137,6 +139,7 @@ export default function ConversationTimeline({
   hasExecutiveSummary,
   defaultCollapsed,
   expandCounter = 0,
+  costEstimationEnabled = false,
 }: ConversationTimelineProps) {
   // --- Whole-timeline collapse (for terminal sessions opened directly) ---
   const [timelineCollapsed, setTimelineCollapsed] = useState(defaultCollapsed ?? false);
@@ -644,6 +647,7 @@ export default function ConversationTimeline({
                   onSelectedAgentChange={handleSelectedAgentChange}
                   searchTerm={searchTerm}
                   stageType={group.stageType}
+                  costEstimationEnabled={costEstimationEnabled}
                 />
               </Collapse>
             </Box>

--- a/web/dashboard/src/components/session/SessionHeader.tsx
+++ b/web/dashboard/src/components/session/SessionHeader.tsx
@@ -28,6 +28,7 @@ import { AlertDataContent } from './OriginalAlertCard';
 import { StatusBadge } from '../common/StatusBadge';
 import ProgressIndicator from '../common/ProgressIndicator';
 import { formatTimestamp, formatTokensCompact } from '../../utils/format';
+import EstimatedCostDisplay from '../shared/EstimatedCostDisplay';
 import { cancelSession, triggerScoring, handleAPIError } from '../../services/api';
 import {
   SESSION_STATUS,
@@ -347,7 +348,7 @@ export default function SessionHeader({
                 borderColor: 'divider',
               }}
             >
-              {/* Left: tokens */}
+              {/* Left: tokens + Est. cost */}
               {session.total_tokens > 0 ? (
                 <Box sx={{ display: 'flex', alignItems: 'center', gap: 3 }}>
                   <Typography variant="caption" color="text.secondary" sx={{ fontWeight: 600, textTransform: 'uppercase', letterSpacing: 0.5 }}>
@@ -375,6 +376,13 @@ export default function SessionHeader({
                       <Typography variant="caption" color="text.disabled">out</Typography>
                     </Box>
                   )}
+                  <EstimatedCostDisplay
+                    enabled={session.cost_estimation_enabled === true}
+                    estimatedCostUsd={session.estimated_cost_usd}
+                    costCompleteness={session.cost_completeness}
+                    variant="labeled"
+                    size="small"
+                  />
                 </Box>
               ) : <Box />}
 

--- a/web/dashboard/src/components/session/SessionHeader.tsx
+++ b/web/dashboard/src/components/session/SessionHeader.tsx
@@ -381,7 +381,6 @@ export default function SessionHeader({
                     estimatedCostUsd={session.estimated_cost_usd}
                     costCompleteness={session.cost_completeness}
                     variant="labeled"
-                    size="small"
                   />
                 </Box>
               ) : <Box />}

--- a/web/dashboard/src/components/shared/EstimatedCostDisplay.tsx
+++ b/web/dashboard/src/components/shared/EstimatedCostDisplay.tsx
@@ -1,8 +1,19 @@
 /**
  * EstimatedCostDisplay — sibling of TokenUsageDisplay for estimated USD cost.
  *
- * Soft "Est. $X" with tooltip caveats; warning when completeness is partial.
- * Hidden when estimation is disabled, fields are absent, or completeness is none.
+ * Value-first "$X" (no extra "approximate" glyph — the "$" already reads as
+ * money, the surrounding label/header/caption already says "Cost"/"Est.",
+ * and the tooltip carries the full caveat; a per-value glyph was redundant
+ * and, at small sizes, easy to misread). Matches TokenUsageDisplay's
+ * number-then-muted-label grammar for the 'labeled' variant. Complete
+ * estimates get a dedicated accent color (not plain gray text) so cost holds
+ * its own next to the colorful token figures it's usually paired with.
+ * `size="medium"` (default) matches SessionHeader's bespoke body2 token
+ * sizing; `size="small"` matches TokenUsageDisplay's own small/labeled
+ * sizing used in tables and parallel/sub-agent cards.
+ * Tooltip carries the full estimate caveat; warning color + icon when
+ * completeness is partial. Hidden when estimation is disabled, fields are
+ * absent, or completeness is none.
  */
 
 import { memo } from 'react';
@@ -60,39 +71,37 @@ function EstimatedCostDisplay({
     return null;
   }
 
-  const label = `Est. ${formatEstimatedCostUsd(estimatedCostUsd)}`;
   const isPartial = costCompleteness === 'partial';
   const tooltip = isPartial ? CAVEAT_PARTIAL : CAVEAT_COMPLETE;
-  const fontSize = size === 'small' ? '0.75rem' : '0.875rem';
+  // 'small' matches TokenUsageDisplay's own small/labeled sizing (dense
+  // contexts: tables, parallel/sub-agent cards). 'medium' matches
+  // SessionHeader's bespoke body2/caption token sizing (the hero display).
+  const fs = size === 'small' ? '0.7rem' : '0.875rem';
+  const labelFs = size === 'small' ? '0.65rem' : '0.75rem';
 
   const content = (
     <Box
       component="span"
       sx={{
         display: 'inline-flex',
-        alignItems: 'center',
-        gap: 0.25,
+        alignItems: 'baseline',
+        gap: 0.5,
         cursor: 'help',
       }}
     >
-      {variant === 'labeled' && (
-        <Typography
-          component="span"
-          variant="caption"
-          color="text.secondary"
-          sx={{ fontWeight: 600, textTransform: 'uppercase', letterSpacing: 0.5, mr: 0.5 }}
-        >
-          Cost
-        </Typography>
-      )}
       <Typography
         component="span"
-        variant="body2"
-        color={isPartial ? 'warning.main' : 'text.secondary'}
-        sx={{ fontWeight: 600, fontSize, whiteSpace: 'nowrap' }}
+        variant="caption"
+        color={isPartial ? 'warning.main' : 'secondary.main'}
+        sx={{ fontWeight: 700, fontSize: fs, whiteSpace: 'nowrap' }}
       >
-        {label}
+        {formatEstimatedCostUsd(estimatedCostUsd)}
       </Typography>
+      {variant === 'labeled' && (
+        <Typography component="span" variant="caption" color="text.disabled" sx={{ fontSize: labelFs }}>
+          cost
+        </Typography>
+      )}
       {isPartial && (
         <WarningAmberRounded
           sx={{ fontSize: size === 'small' ? '0.9rem' : '1rem', color: 'warning.main' }}

--- a/web/dashboard/src/components/shared/EstimatedCostDisplay.tsx
+++ b/web/dashboard/src/components/shared/EstimatedCostDisplay.tsx
@@ -1,0 +1,112 @@
+/**
+ * EstimatedCostDisplay — sibling of TokenUsageDisplay for estimated USD cost.
+ *
+ * Soft "Est. $X" with tooltip caveats; warning when completeness is partial.
+ * Hidden when estimation is disabled, fields are absent, or completeness is none.
+ */
+
+import { memo } from 'react';
+import { Box, Typography, Tooltip } from '@mui/material';
+import WarningAmberRounded from '@mui/icons-material/WarningAmberRounded';
+import { formatEstimatedCostUsd } from '../../utils/format';
+import type { CostCompleteness, ExecutionOverview } from '../../types/session';
+
+/** Client-side cost rollup for parallel / sub-agent aggregate summaries. */
+export function rollupExecutionCost(overviews: ExecutionOverview[]): {
+  estimatedCostUsd?: number;
+  costCompleteness?: CostCompleteness;
+} {
+  const withCost = overviews.filter((eo) => eo.cost_completeness != null);
+  if (withCost.length === 0) return {};
+
+  const estimatedCostUsd = withCost.reduce((sum, eo) => sum + (eo.estimated_cost_usd ?? 0), 0);
+  const statuses = new Set(withCost.map((eo) => eo.cost_completeness));
+  let costCompleteness: CostCompleteness = 'complete';
+  if (statuses.has('partial') || (statuses.has('complete') && statuses.has('none'))) {
+    costCompleteness = 'partial';
+  } else if (statuses.has('none') && !statuses.has('complete')) {
+    costCompleteness = 'none';
+  }
+  return { estimatedCostUsd, costCompleteness };
+}
+
+export interface EstimatedCostDisplayProps {
+  estimatedCostUsd?: number | null;
+  costCompleteness?: CostCompleteness | null;
+  /** When false, render nothing. Defaults to true when cost fields are passed. */
+  enabled?: boolean;
+  size?: 'small' | 'medium';
+  variant?: 'inline' | 'labeled';
+}
+
+const CAVEAT_COMPLETE =
+  'Estimated list-price cost — not invoice truth. Rates are resolved at write time.';
+const CAVEAT_PARTIAL =
+  'Partial estimate: some token-bearing interactions were unpriced. Total may undercount.';
+
+function EstimatedCostDisplay({
+  estimatedCostUsd,
+  costCompleteness,
+  enabled = true,
+  size = 'medium',
+  variant = 'inline',
+}: EstimatedCostDisplayProps) {
+  if (
+    !enabled ||
+    estimatedCostUsd == null ||
+    costCompleteness == null ||
+    costCompleteness === 'none'
+  ) {
+    return null;
+  }
+
+  const label = `Est. ${formatEstimatedCostUsd(estimatedCostUsd)}`;
+  const isPartial = costCompleteness === 'partial';
+  const tooltip = isPartial ? CAVEAT_PARTIAL : CAVEAT_COMPLETE;
+  const fontSize = size === 'small' ? '0.75rem' : '0.875rem';
+
+  const content = (
+    <Box
+      component="span"
+      sx={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 0.25,
+        cursor: 'help',
+      }}
+    >
+      {variant === 'labeled' && (
+        <Typography
+          component="span"
+          variant="caption"
+          color="text.secondary"
+          sx={{ fontWeight: 600, textTransform: 'uppercase', letterSpacing: 0.5, mr: 0.5 }}
+        >
+          Cost
+        </Typography>
+      )}
+      <Typography
+        component="span"
+        variant="body2"
+        color={isPartial ? 'warning.main' : 'text.secondary'}
+        sx={{ fontWeight: 600, fontSize, whiteSpace: 'nowrap' }}
+      >
+        {label}
+      </Typography>
+      {isPartial && (
+        <WarningAmberRounded
+          sx={{ fontSize: size === 'small' ? '0.9rem' : '1rem', color: 'warning.main' }}
+          aria-label="Incomplete cost estimate"
+        />
+      )}
+    </Box>
+  );
+
+  return (
+    <Tooltip title={tooltip} arrow>
+      {content}
+    </Tooltip>
+  );
+}
+
+export default memo(EstimatedCostDisplay);

--- a/web/dashboard/src/components/system/ConfigViewer.tsx
+++ b/web/dashboard/src/components/system/ConfigViewer.tsx
@@ -33,6 +33,7 @@ import { highlightYaml } from '../shared/JsonDisplay/utils';
 import { getSystemConfig, getSystemConfigSkill, handleAPIError } from '../../services/api.ts';
 import type {
   SystemConfigResponse,
+  SystemSettingsView,
   SkillMetaView,
   MCPServerConfigView,
   AgentConfigView,
@@ -221,7 +222,7 @@ function StructuredConfig({ config }: { config: SystemConfigResponse }) {
       </ConfigSection>
 
       <ConfigSection title="System" count={1}>
-        <KeyValueBlock data={config.system} />
+        <SystemDetails system={config.system} />
       </ConfigSection>
 
       <ConfigSection title="Agents" count={Object.keys(config.agents).length}>
@@ -359,6 +360,60 @@ function KeyValueBlock({ data }: { data: unknown }) {
     <Typography variant="body2" sx={{ fontFamily: 'monospace', fontSize: '0.85rem' }}>
       {String(data)}
     </Typography>
+  );
+}
+
+function SystemDetails({ system }: { system: SystemSettingsView }) {
+  const { cost_estimation: costEstimation, ...rest } = system;
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+      <KeyValueBlock data={rest} />
+      {costEstimation && <CostEstimationDetails costEstimation={costEstimation} />}
+    </Box>
+  );
+}
+
+function CostEstimationDetails({
+  costEstimation,
+}: {
+  costEstimation: NonNullable<SystemSettingsView['cost_estimation']>;
+}) {
+  const rates = costEstimation.model_rates
+    ? Object.entries(costEstimation.model_rates)
+    : [];
+  return (
+    <Paper variant="outlined" sx={{ p: 1.5 }}>
+      <Typography variant="subtitle2" sx={{ mb: 1 }}>
+        Cost estimation
+      </Typography>
+      <Field label="enabled" value={String(costEstimation.enabled)} />
+      <Field
+        label="model_rates"
+        value={
+          rates.length === 0 ? (
+            <Typography variant="body2" color="text.secondary">
+              (none)
+            </Typography>
+          ) : (
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+              {rates.map(([model, rate]) => (
+                <Typography
+                  key={model}
+                  variant="body2"
+                  sx={{ fontFamily: 'monospace', fontSize: '0.85rem' }}
+                >
+                  {model}: in {rate.input_per_million}/M · out {rate.output_per_million}/M
+                </Typography>
+              ))}
+            </Box>
+          )
+        }
+      />
+      <Field label="catalog.source" value={costEstimation.catalog.source} />
+      <Field label="catalog.entry_count" value={costEstimation.catalog.entry_count} />
+      <Field label="catalog.last_fetch" value={costEstimation.catalog.last_fetch} />
+      <Field label="catalog.last_error" value={costEstimation.catalog.last_error} />
+    </Paper>
   );
 }
 

--- a/web/dashboard/src/components/timeline/StageContent.tsx
+++ b/web/dashboard/src/components/timeline/StageContent.tsx
@@ -13,6 +13,7 @@ import type { ExecutionOverview } from '../../types/session';
 import type { StreamingItem } from '../streaming/StreamingContentRenderer';
 import StreamingContentRenderer from '../streaming/StreamingContentRenderer';
 import TokenUsageDisplay from '../shared/TokenUsageDisplay';
+import EstimatedCostDisplay from '../shared/EstimatedCostDisplay';
 import TimelineItem from './TimelineItem';
 import SubAgentCard from './SubAgentCard';
 import ErrorCard from './ErrorCard';
@@ -755,8 +756,13 @@ const StageContent: React.FC<StageContentProps> = ({
                   )}
                 </Box>
                 {hasTokens && tokenData ? (
-                  <Box display="flex" alignItems="center" gap={0.5} flexShrink={0}>
+                  <Box display="flex" alignItems="center" gap={1} flexShrink={0}>
                     <TokenUsageDisplay tokenData={tokenData} variant="labeled" size="small" />
+                    <EstimatedCostDisplay
+                      estimatedCostUsd={eo?.estimated_cost_usd}
+                      costCompleteness={eo?.cost_completeness}
+                      size="small"
+                    />
                   </Box>
                 ) : !eo && (() => {
                   const streamCount = (streamingByExecution.get(execution.executionId) || []).length;

--- a/web/dashboard/src/components/timeline/StageContent.tsx
+++ b/web/dashboard/src/components/timeline/StageContent.tsx
@@ -55,6 +55,8 @@ interface StageContentProps {
   searchTerm?: string;
   /** Parent stage type (investigation, chat, action, etc.) for context-aware labels */
   stageType?: string;
+  /** Whether cost estimation is enabled for this session (gates EstimatedCostDisplay) */
+  costEstimationEnabled?: boolean;
 }
 
 interface TabPanelProps {
@@ -268,6 +270,7 @@ const StageContent: React.FC<StageContentProps> = ({
   onSelectedAgentChange,
   searchTerm,
   stageType,
+  costEstimationEnabled = false,
 }) => {
   const [selectedTab, setSelectedTab] = useState(0);
 
@@ -516,6 +519,7 @@ const StageContent: React.FC<StageContentProps> = ({
         expandAllToolCalls={expandAllToolCalls}
         isItemCollapsible={isItemCollapsible}
         searchTerm={searchTerm}
+        costEstimationEnabled={costEstimationEnabled}
       />
     );
   };
@@ -759,6 +763,7 @@ const StageContent: React.FC<StageContentProps> = ({
                   <Box display="flex" alignItems="center" gap={1} flexShrink={0}>
                     <TokenUsageDisplay tokenData={tokenData} variant="labeled" size="small" />
                     <EstimatedCostDisplay
+                      enabled={costEstimationEnabled === true}
                       estimatedCostUsd={eo?.estimated_cost_usd}
                       costCompleteness={eo?.cost_completeness}
                       size="small"

--- a/web/dashboard/src/components/timeline/SubAgentCard.tsx
+++ b/web/dashboard/src/components/timeline/SubAgentCard.tsx
@@ -13,6 +13,7 @@ import type { StreamingItem } from '../streaming/StreamingContentRenderer';
 import StreamingContentRenderer from '../streaming/StreamingContentRenderer';
 import ProcessingIndicator from '../streaming/ProcessingIndicator';
 import TokenUsageDisplay from '../shared/TokenUsageDisplay';
+import EstimatedCostDisplay from '../shared/EstimatedCostDisplay';
 import TimelineItem from './TimelineItem';
 import CopyButton from '../shared/CopyButton';
 import ErrorCard from './ErrorCard';
@@ -186,9 +187,14 @@ const SubAgentCard: React.FC<SubAgentCardProps> = ({
             <Box sx={{
               px: 1.5, py: 0.75,
               bgcolor: alpha(accentColor, 0.04),
-              display: 'flex', alignItems: 'center', gap: 1,
+              display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap',
             }}>
               <TokenUsageDisplay tokenData={tokenData} variant="inline" size="small" />
+              <EstimatedCostDisplay
+                estimatedCostUsd={eo?.estimated_cost_usd}
+                costCompleteness={eo?.cost_completeness}
+                size="small"
+              />
             </Box>
           )}
 

--- a/web/dashboard/src/components/timeline/SubAgentCard.tsx
+++ b/web/dashboard/src/components/timeline/SubAgentCard.tsx
@@ -43,6 +43,8 @@ interface SubAgentCardProps {
   expandAllToolCalls?: boolean;
   isItemCollapsible?: (item: FlowItem) => boolean;
   searchTerm?: string;
+  /** Whether cost estimation is enabled for this session (gates EstimatedCostDisplay) */
+  costEstimationEnabled?: boolean;
 }
 
 const SubAgentCard: React.FC<SubAgentCardProps> = ({
@@ -58,6 +60,7 @@ const SubAgentCard: React.FC<SubAgentCardProps> = ({
   expandAllToolCalls = false,
   isItemCollapsible,
   searchTerm,
+  costEstimationEnabled = false,
 }) => {
   const [expanded, setExpanded] = useState(false);
   const [prevExpandAllToolCalls, setPrevExpandAllToolCalls] = useState(expandAllToolCalls);
@@ -191,6 +194,7 @@ const SubAgentCard: React.FC<SubAgentCardProps> = ({
             }}>
               <TokenUsageDisplay tokenData={tokenData} variant="inline" size="small" />
               <EstimatedCostDisplay
+                enabled={costEstimationEnabled === true}
                 estimatedCostUsd={eo?.estimated_cost_usd}
                 costCompleteness={eo?.cost_completeness}
                 size="small"

--- a/web/dashboard/src/components/trace/ParallelExecutionTabs.tsx
+++ b/web/dashboard/src/components/trace/ParallelExecutionTabs.tsx
@@ -23,6 +23,7 @@ import {
 import type { TraceStageGroup } from '../../types/trace';
 import type { SessionDetailResponse, ExecutionOverview } from '../../types/session';
 import TokenUsageDisplay from '../shared/TokenUsageDisplay';
+import EstimatedCostDisplay, { rollupExecutionCost } from '../shared/EstimatedCostDisplay';
 import { formatDurationMs, formatTimestamp } from '../../utils/format';
 import {
   findExecutionOverview,
@@ -54,6 +55,7 @@ export default function ParallelExecutionTabs({ stage, session }: ParallelExecut
   const statusCounts = getExecutionStatusCounts(executionOverviews);
   const aggregateTokens = getAggregateTotalTokens(executionOverviews);
   const aggregateDuration = getAggregateDuration(executionOverviews);
+  const aggregateCost = rollupExecutionCost(executionOverviews);
 
   const currentExecution = stage.executions[activeTab];
   const currentOverview = currentExecution
@@ -142,11 +144,19 @@ export default function ParallelExecutionTabs({ stage, session }: ParallelExecut
 
           {/* Tokens */}
           {aggregateTokens.total_tokens > 0 && (
-            <TokenUsageDisplay
-              tokenData={aggregateTokens}
-              variant="inline"
-              size="small"
-            />
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+              <TokenUsageDisplay
+                tokenData={aggregateTokens}
+                variant="inline"
+                size="small"
+              />
+              <EstimatedCostDisplay
+                enabled={session.cost_estimation_enabled === true}
+                estimatedCostUsd={aggregateCost.estimatedCostUsd}
+                costCompleteness={aggregateCost.costCompleteness}
+                size="small"
+              />
+            </Box>
           )}
         </Box>
       </Box>
@@ -246,18 +256,26 @@ export default function ParallelExecutionTabs({ stage, session }: ParallelExecut
               </Box>
 
               {currentOverview.total_tokens > 0 && (
-                <TokenUsageDisplay
-                  tokenData={{
-                    input_tokens: currentOverview.input_tokens,
-                    output_tokens: currentOverview.output_tokens,
-                    total_tokens: currentOverview.total_tokens,
-                  }}
-                  variant="compact"
-                  size="small"
-                  showBreakdown
-                  label="Tokens"
-                  color="info"
-                />
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
+                  <TokenUsageDisplay
+                    tokenData={{
+                      input_tokens: currentOverview.input_tokens,
+                      output_tokens: currentOverview.output_tokens,
+                      total_tokens: currentOverview.total_tokens,
+                    }}
+                    variant="compact"
+                    size="small"
+                    showBreakdown
+                    label="Tokens"
+                    color="info"
+                  />
+                  <EstimatedCostDisplay
+                    enabled={session.cost_estimation_enabled === true}
+                    estimatedCostUsd={currentOverview.estimated_cost_usd}
+                    costCompleteness={currentOverview.cost_completeness}
+                    size="small"
+                  />
+                </Box>
               )}
             </Stack>
           </Box>

--- a/web/dashboard/src/components/trace/StageAccordion.tsx
+++ b/web/dashboard/src/components/trace/StageAccordion.tsx
@@ -27,6 +27,7 @@ import type { TraceStageGroup } from '../../types/trace';
 import type { SessionDetailResponse, ExecutionOverview } from '../../types/session';
 import { STAGE_TYPE } from '../../constants/eventTypes';
 import TokenUsageDisplay from '../shared/TokenUsageDisplay';
+import EstimatedCostDisplay from '../shared/EstimatedCostDisplay';
 import { formatDurationMs, formatTimestamp } from '../../utils/format';
 import {
   findStageOverview,
@@ -253,18 +254,26 @@ export default function StageAccordion({
                   </Box>
 
                   {singleOverview.total_tokens > 0 && (
-                    <TokenUsageDisplay
-                      tokenData={{
-                        input_tokens: singleOverview.input_tokens,
-                        output_tokens: singleOverview.output_tokens,
-                        total_tokens: singleOverview.total_tokens,
-                      }}
-                      variant="compact"
-                      size="small"
-                      showBreakdown
-                      label="Tokens"
-                      color="info"
-                    />
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
+                      <TokenUsageDisplay
+                        tokenData={{
+                          input_tokens: singleOverview.input_tokens,
+                          output_tokens: singleOverview.output_tokens,
+                          total_tokens: singleOverview.total_tokens,
+                        }}
+                        variant="compact"
+                        size="small"
+                        showBreakdown
+                        label="Tokens"
+                        color="info"
+                      />
+                      <EstimatedCostDisplay
+                        enabled={session.cost_estimation_enabled === true}
+                        estimatedCostUsd={singleOverview.estimated_cost_usd}
+                        costCompleteness={singleOverview.cost_completeness}
+                        size="small"
+                      />
+                    </Box>
                   )}
                 </Stack>
               </Box>

--- a/web/dashboard/src/components/trace/SubAgentTabs.tsx
+++ b/web/dashboard/src/components/trace/SubAgentTabs.tsx
@@ -21,6 +21,7 @@ import { AccountTree } from '@mui/icons-material';
 import type { TraceExecutionGroup } from '../../types/trace';
 import type { SessionDetailResponse, ExecutionOverview } from '../../types/session';
 import TokenUsageDisplay from '../shared/TokenUsageDisplay';
+import EstimatedCostDisplay, { rollupExecutionCost } from '../shared/EstimatedCostDisplay';
 import { formatDurationMs, formatTimestamp } from '../../utils/format';
 import {
   findExecutionOverview,
@@ -50,6 +51,7 @@ export default function SubAgentTabs({ subAgents, session }: SubAgentTabsProps) 
   const statusCounts = getExecutionStatusCounts(executionOverviews);
   const aggregateTokens = getAggregateTotalTokens(executionOverviews);
   const aggregateDuration = getAggregateDuration(executionOverviews);
+  const aggregateCost = rollupExecutionCost(executionOverviews);
 
   const currentSub = subAgents[activeTab];
   const currentOverview = currentSub
@@ -102,7 +104,15 @@ export default function SubAgentTabs({ subAgents, session }: SubAgentTabsProps) 
             </Typography>
           )}
           {aggregateTokens.total_tokens > 0 && (
-            <TokenUsageDisplay tokenData={aggregateTokens} variant="inline" size="small" />
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+              <TokenUsageDisplay tokenData={aggregateTokens} variant="inline" size="small" />
+              <EstimatedCostDisplay
+                enabled={session.cost_estimation_enabled === true}
+                estimatedCostUsd={aggregateCost.estimatedCostUsd}
+                costCompleteness={aggregateCost.costCompleteness}
+                size="small"
+              />
+            </Box>
           )}
         </Box>
       </Box>
@@ -194,18 +204,26 @@ export default function SubAgentTabs({ subAgents, session }: SubAgentTabsProps) 
                 )}
               </Box>
               {currentOverview.total_tokens > 0 && (
-                <TokenUsageDisplay
-                  tokenData={{
-                    input_tokens: currentOverview.input_tokens,
-                    output_tokens: currentOverview.output_tokens,
-                    total_tokens: currentOverview.total_tokens,
-                  }}
-                  variant="compact"
-                  size="small"
-                  showBreakdown
-                  label="Tokens"
-                  color="info"
-                />
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
+                  <TokenUsageDisplay
+                    tokenData={{
+                      input_tokens: currentOverview.input_tokens,
+                      output_tokens: currentOverview.output_tokens,
+                      total_tokens: currentOverview.total_tokens,
+                    }}
+                    variant="compact"
+                    size="small"
+                    showBreakdown
+                    label="Tokens"
+                    color="info"
+                  />
+                  <EstimatedCostDisplay
+                    enabled={session.cost_estimation_enabled === true}
+                    estimatedCostUsd={currentOverview.estimated_cost_usd}
+                    costCompleteness={currentOverview.cost_completeness}
+                    size="small"
+                  />
+                </Box>
               )}
             </Stack>
           </Box>

--- a/web/dashboard/src/constants/routes.ts
+++ b/web/dashboard/src/constants/routes.ts
@@ -9,6 +9,7 @@ export const ROUTES = {
   SESSION_SCORING: '/sessions/:id/scoring',
   SUBMIT_ALERT: '/submit-alert',
   SYSTEM_STATUS: '/system',
+  USAGE: '/usage',
 } as const;
 
 /** Build a session detail path. */

--- a/web/dashboard/src/pages/SessionDetailPage.tsx
+++ b/web/dashboard/src/pages/SessionDetailPage.tsx
@@ -1660,6 +1660,7 @@ export function SessionDetailPage() {
                   searchTerm={debouncedSearchTerm}
                   defaultCollapsed={wasTerminalOnMount && session.status === SESSION_STATUS.COMPLETED}
                   expandCounter={timelineExpandCounter}
+                  costEstimationEnabled={session.cost_estimation_enabled === true}
                   {...(hasFinalContent ? {
                     onJumpToSummary: handleJumpToSummary,
                     hasExecutiveSummary: !!session.executive_summary,

--- a/web/dashboard/src/pages/UsagePage.tsx
+++ b/web/dashboard/src/pages/UsagePage.tsx
@@ -1,0 +1,429 @@
+/**
+ * Usage page — fleet dig-in over a date window.
+ *
+ * Fetches GET /api/v1/usage/summary for server aggregates (totals, breakdowns, top-20).
+ * Date presets are Usage-oriented (7d / 30d / MTD / last calendar month); default 30d.
+ */
+
+import { useCallback, useEffect, useState, type ReactNode } from 'react';
+import { Link as RouterLink } from 'react-router-dom';
+import {
+  Alert,
+  Autocomplete,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Container,
+  FormControl,
+  InputLabel,
+  Link,
+  MenuItem,
+  Paper,
+  Select,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  TextField,
+  Typography,
+} from '@mui/material';
+import AccessTime from '@mui/icons-material/AccessTime';
+import WarningAmberRounded from '@mui/icons-material/WarningAmberRounded';
+
+import { SharedHeader } from '../components/layout/SharedHeader.tsx';
+import { VersionFooter } from '../components/layout/VersionFooter.tsx';
+import { FloatingSubmitAlertFab } from '../components/common/FloatingSubmitAlertFab.tsx';
+import {
+  TimeRangeModal,
+  USAGE_TIME_PRESETS,
+} from '../components/dashboard/TimeRangeModal.tsx';
+import EstimatedCostDisplay from '../components/shared/EstimatedCostDisplay.tsx';
+import { getFilterOptions, getUsageSummary, handleAPIError } from '../services/api.ts';
+import { formatEstimatedCostUsd, formatTimestamp, formatTokens } from '../utils/format.ts';
+import { sessionDetailPath } from '../constants/routes.ts';
+import type { UsageRankBy, UsageSummaryResponse } from '../types/api.ts';
+
+function defaultThirtyDayRange(): { start: Date; end: Date; preset: string } {
+  const range = USAGE_TIME_PRESETS.find((p) => p.value === '30d')!.getDateRange();
+  return { start: range.start, end: range.end, preset: '30d' };
+}
+
+export function UsagePage() {
+  const initial = defaultThirtyDayRange();
+  const [startDate, setStartDate] = useState<Date>(initial.start);
+  const [endDate, setEndDate] = useState<Date>(initial.end);
+  const [datePreset, setDatePreset] = useState<string | null>(initial.preset);
+  const [timeRangeOpen, setTimeRangeOpen] = useState(false);
+
+  const [alertType, setAlertType] = useState<string | null>(null);
+  const [chainId, setChainId] = useState<string | null>(null);
+  /** Undefined = let the server pick the default (cost when enabled, else tokens). */
+  const [rankBy, setRankBy] = useState<UsageRankBy | undefined>(undefined);
+
+  const [alertTypeOptions, setAlertTypeOptions] = useState<string[]>([]);
+  const [chainIdOptions, setChainIdOptions] = useState<string[]>([]);
+
+  const [summary, setSummary] = useState<UsageSummaryResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const opts = await getFilterOptions();
+        if (!cancelled) {
+          setAlertTypeOptions(opts.alert_types ?? []);
+          setChainIdOptions(opts.chain_ids ?? []);
+        }
+      } catch {
+        // Filters remain optional; ignore option load failures.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const fetchSummary = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await getUsageSummary({
+        start_date: startDate.toISOString(),
+        end_date: endDate.toISOString(),
+        alert_type: alertType || undefined,
+        chain_id: chainId || undefined,
+        rank_by: rankBy,
+      });
+      setSummary(data);
+    } catch (err) {
+      setError(handleAPIError(err));
+      setSummary(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [startDate, endDate, alertType, chainId, rankBy]);
+
+  useEffect(() => {
+    void fetchSummary();
+  }, [fetchSummary]);
+
+  const handleTimeRangeApply = (start: Date | null, end: Date | null, preset?: string) => {
+    if (start && end) {
+      setStartDate(start);
+      setEndDate(end);
+      setDatePreset(preset ?? null);
+    } else {
+      const fallback = defaultThirtyDayRange();
+      setStartDate(fallback.start);
+      setEndDate(fallback.end);
+      setDatePreset(fallback.preset);
+    }
+    setTimeRangeOpen(false);
+  };
+
+  const costEnabled = summary?.cost_estimation_enabled === true;
+  const timeRangeLabel = datePreset
+    ? USAGE_TIME_PRESETS.find((p) => p.value === datePreset)?.label ?? `Range: ${datePreset}`
+    : 'Custom range';
+
+  return (
+    <Box sx={{ minHeight: '100vh', backgroundColor: 'background.default', px: 2, py: 2 }}>
+      <SharedHeader title="Usage" showBackButton />
+
+      <Container maxWidth={false} sx={{ py: 4, px: { xs: 1, sm: 2 } }}>
+        <Stack spacing={3}>
+          {/* Filters */}
+          <Paper variant="outlined" sx={{ p: 2 }}>
+            <Stack
+              direction={{ xs: 'column', md: 'row' }}
+              spacing={2}
+              alignItems={{ md: 'center' }}
+              flexWrap="wrap"
+              useFlexGap
+            >
+              <Button
+                variant="outlined"
+                startIcon={<AccessTime />}
+                onClick={() => setTimeRangeOpen(true)}
+                aria-label="Select time range"
+              >
+                {timeRangeLabel}
+              </Button>
+
+              <Autocomplete
+                size="small"
+                sx={{ minWidth: 200 }}
+                options={alertTypeOptions}
+                value={alertType}
+                onChange={(_, value) => setAlertType(value)}
+                renderInput={(params) => <TextField {...params} label="Alert type" />}
+              />
+
+              <Autocomplete
+                size="small"
+                sx={{ minWidth: 200 }}
+                options={chainIdOptions}
+                value={chainId}
+                onChange={(_, value) => setChainId(value)}
+                renderInput={(params) => <TextField {...params} label="Chain" />}
+              />
+
+              {costEnabled && (
+                <FormControl size="small" sx={{ minWidth: 160 }}>
+                  <InputLabel id="usage-rank-by-label">Rank top sessions</InputLabel>
+                  <Select
+                    labelId="usage-rank-by-label"
+                    label="Rank top sessions"
+                    value={rankBy ?? summary?.rank_by ?? 'cost'}
+                    onChange={(e) => setRankBy(e.target.value as UsageRankBy)}
+                  >
+                    <MenuItem value="cost">By cost</MenuItem>
+                    <MenuItem value="tokens">By tokens</MenuItem>
+                  </Select>
+                </FormControl>
+              )}
+            </Stack>
+          </Paper>
+
+          {error && (
+            <Alert severity="error" action={
+              <Button color="inherit" size="small" onClick={() => void fetchSummary()}>
+                Retry
+              </Button>
+            }>
+              {error}
+            </Alert>
+          )}
+
+          {loading && !summary && (
+            <Box sx={{ display: 'flex', justifyContent: 'center', py: 6 }}>
+              <CircularProgress />
+            </Box>
+          )}
+
+          {summary && (
+            <>
+              {/* Totals */}
+              <Paper variant="outlined" sx={{ p: 2 }}>
+                <Typography variant="h6" gutterBottom>
+                  Totals
+                </Typography>
+                <Stack direction="row" spacing={3} flexWrap="wrap" useFlexGap alignItems="center">
+                  <Typography variant="body1">
+                    <strong>{formatTokens(summary.totals.total_tokens)}</strong>{' '}
+                    <Typography component="span" color="text.secondary" variant="body2">
+                      tokens
+                    </Typography>
+                  </Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    {formatTokens(summary.totals.input_tokens)} in ·{' '}
+                    {formatTokens(summary.totals.output_tokens)} out
+                  </Typography>
+                  {costEnabled && (
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                      <EstimatedCostDisplay
+                        enabled
+                        estimatedCostUsd={summary.totals.estimated_cost_usd}
+                        costCompleteness={summary.totals.cost_completeness}
+                        variant="labeled"
+                      />
+                      {summary.totals.cost_completeness === 'partial' &&
+                        summary.totals.unpriced_interaction_count != null &&
+                        summary.totals.unpriced_interaction_count > 0 && (
+                          <Typography variant="caption" color="warning.main">
+                            ({summary.totals.unpriced_interaction_count} unpriced)
+                          </Typography>
+                        )}
+                    </Box>
+                  )}
+                  {loading && <CircularProgress size={18} />}
+                </Stack>
+              </Paper>
+
+              {/* By model */}
+              <BreakdownTable
+                title="By model"
+                columns={
+                  costEnabled
+                    ? ['Model', 'Tokens', 'In', 'Out', 'Est. cost', 'Priced']
+                    : ['Model', 'Tokens', 'In', 'Out']
+                }
+                empty={summary.by_model.length === 0}
+              >
+                {summary.by_model.map((row) => (
+                  <TableRow key={row.model_name}>
+                    <TableCell>{row.model_name}</TableCell>
+                    <TableCell>{formatTokens(row.total_tokens)}</TableCell>
+                    <TableCell>{formatTokens(row.input_tokens)}</TableCell>
+                    <TableCell>{formatTokens(row.output_tokens)}</TableCell>
+                    {costEnabled && (
+                      <>
+                        <TableCell>
+                          {row.estimated_cost_usd != null
+                            ? formatEstimatedCostUsd(row.estimated_cost_usd)
+                            : '—'}
+                        </TableCell>
+                        <TableCell>
+                          {row.priced === false ? (
+                            <Chip
+                              size="small"
+                              icon={<WarningAmberRounded />}
+                              label="Incomplete"
+                              color="warning"
+                              variant="outlined"
+                            />
+                          ) : (
+                            <Chip size="small" label="Priced" color="success" variant="outlined" />
+                          )}
+                        </TableCell>
+                      </>
+                    )}
+                  </TableRow>
+                ))}
+              </BreakdownTable>
+
+              {/* By alert type */}
+              <BreakdownTable
+                title="By alert type"
+                columns={costEnabled ? ['Alert type', 'Tokens', 'Est. cost'] : ['Alert type', 'Tokens']}
+                empty={summary.by_alert_type.length === 0}
+              >
+                {summary.by_alert_type.map((row) => (
+                  <TableRow key={row.alert_type || '(none)'}>
+                    <TableCell>{row.alert_type || '—'}</TableCell>
+                    <TableCell>{formatTokens(row.total_tokens)}</TableCell>
+                    {costEnabled && (
+                      <TableCell>
+                        {row.estimated_cost_usd != null
+                          ? formatEstimatedCostUsd(row.estimated_cost_usd)
+                          : '—'}
+                      </TableCell>
+                    )}
+                  </TableRow>
+                ))}
+              </BreakdownTable>
+
+              {/* By chain */}
+              <BreakdownTable
+                title="By chain"
+                columns={costEnabled ? ['Chain', 'Tokens', 'Est. cost'] : ['Chain', 'Tokens']}
+                empty={summary.by_chain.length === 0}
+              >
+                {summary.by_chain.map((row) => (
+                  <TableRow key={row.chain_id}>
+                    <TableCell>{row.chain_id}</TableCell>
+                    <TableCell>{formatTokens(row.total_tokens)}</TableCell>
+                    {costEnabled && (
+                      <TableCell>
+                        {row.estimated_cost_usd != null
+                          ? formatEstimatedCostUsd(row.estimated_cost_usd)
+                          : '—'}
+                      </TableCell>
+                    )}
+                  </TableRow>
+                ))}
+              </BreakdownTable>
+
+              {/* Top sessions */}
+              <BreakdownTable
+                title={`Top sessions (${summary.top_sessions.length})`}
+                columns={
+                  costEnabled
+                    ? ['Session', 'Alert type', 'Chain', 'Tokens', 'Est. cost', 'Created']
+                    : ['Session', 'Alert type', 'Chain', 'Tokens', 'Created']
+                }
+                empty={summary.top_sessions.length === 0}
+              >
+                {summary.top_sessions.map((row) => (
+                  <TableRow key={row.session_id}>
+                    <TableCell>
+                      <Link
+                        component={RouterLink}
+                        to={sessionDetailPath(row.session_id)}
+                        underline="hover"
+                        sx={{ fontFamily: 'monospace', fontSize: '0.85em' }}
+                      >
+                        {row.session_id.slice(0, 8)}…
+                      </Link>
+                    </TableCell>
+                    <TableCell>{row.alert_type || '—'}</TableCell>
+                    <TableCell>{row.chain_id}</TableCell>
+                    <TableCell>{formatTokens(row.total_tokens)}</TableCell>
+                    {costEnabled && (
+                      <TableCell>
+                        <EstimatedCostDisplay
+                          enabled
+                          estimatedCostUsd={row.estimated_cost_usd}
+                          costCompleteness={row.cost_completeness}
+                          size="small"
+                        />
+                      </TableCell>
+                    )}
+                    <TableCell>{formatTimestamp(row.created_at, 'short')}</TableCell>
+                  </TableRow>
+                ))}
+              </BreakdownTable>
+            </>
+          )}
+        </Stack>
+
+        <VersionFooter />
+      </Container>
+
+      <TimeRangeModal
+        open={timeRangeOpen}
+        onClose={() => setTimeRangeOpen(false)}
+        startDate={startDate}
+        endDate={endDate}
+        onApply={handleTimeRangeApply}
+        presets={USAGE_TIME_PRESETS}
+      />
+
+      <FloatingSubmitAlertFab />
+    </Box>
+  );
+}
+
+function BreakdownTable({
+  title,
+  columns,
+  empty,
+  children,
+}: {
+  title: string;
+  columns: string[];
+  empty: boolean;
+  children: ReactNode;
+}) {
+  return (
+    <Paper variant="outlined" sx={{ p: 2 }}>
+      <Typography variant="h6" gutterBottom>
+        {title}
+      </Typography>
+      {empty ? (
+        <Typography variant="body2" color="text.secondary">
+          No data in this window.
+        </Typography>
+      ) : (
+        <TableContainer>
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                {columns.map((col) => (
+                  <TableCell key={col}>{col}</TableCell>
+                ))}
+              </TableRow>
+            </TableHead>
+            <TableBody>{children}</TableBody>
+          </Table>
+        </TableContainer>
+      )}
+    </Paper>
+  );
+}

--- a/web/dashboard/src/pages/UsagePage.tsx
+++ b/web/dashboard/src/pages/UsagePage.tsx
@@ -206,21 +206,6 @@ export function UsagePage() {
                 onChange={(_, value) => setChainId(value)}
                 renderInput={(params) => <TextField {...params} label="Chain" />}
               />
-
-              {costEnabled && (
-                <FormControl size="small" sx={{ minWidth: 160 }}>
-                  <InputLabel id="usage-rank-by-label">Rank top sessions</InputLabel>
-                  <Select
-                    labelId="usage-rank-by-label"
-                    label="Rank top sessions"
-                    value={rankBy ?? summary?.rank_by ?? 'cost'}
-                    onChange={(e) => setRankBy(e.target.value as UsageRankBy)}
-                  >
-                    <MenuItem value="cost">By cost</MenuItem>
-                    <MenuItem value="tokens">By tokens</MenuItem>
-                  </Select>
-                </FormControl>
-              )}
             </Stack>
           </Paper>
 
@@ -379,6 +364,22 @@ export function UsagePage() {
               {/* Top sessions */}
               <BreakdownTable
                 title={`Top sessions (${summary.top_sessions.length})`}
+                action={
+                  costEnabled && (
+                    <FormControl size="small" sx={{ minWidth: 160 }}>
+                      <InputLabel id="usage-rank-by-label">Rank top sessions</InputLabel>
+                      <Select
+                        labelId="usage-rank-by-label"
+                        label="Rank top sessions"
+                        value={rankBy ?? summary?.rank_by ?? 'cost'}
+                        onChange={(e) => setRankBy(e.target.value as UsageRankBy)}
+                      >
+                        <MenuItem value="cost">By cost</MenuItem>
+                        <MenuItem value="tokens">By tokens</MenuItem>
+                      </Select>
+                    </FormControl>
+                  )
+                }
                 columns={
                   costEnabled
                     ? [
@@ -456,20 +457,24 @@ interface BreakdownColumn {
 
 function BreakdownTable({
   title,
+  action,
   columns,
   empty,
   children,
 }: {
   title: string;
+  /** Optional control affecting only this table's rows (e.g. a sort order), rendered next to the title. */
+  action?: ReactNode;
   columns: BreakdownColumn[];
   empty: boolean;
   children: ReactNode;
 }) {
   return (
     <Paper variant="outlined" sx={{ p: 2, height: '100%' }}>
-      <Typography variant="h6" gutterBottom>
-        {title}
-      </Typography>
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2, flexWrap: 'wrap', gap: 1 }}>
+        <Typography variant="h6">{title}</Typography>
+        {action}
+      </Box>
       {empty ? (
         <Typography variant="body2" color="text.secondary">
           No data in this window.

--- a/web/dashboard/src/pages/UsagePage.tsx
+++ b/web/dashboard/src/pages/UsagePage.tsx
@@ -5,7 +5,7 @@
  * Date presets are Usage-oriented (7d / 30d / MTD / last calendar month); default 30d.
  */
 
-import { useCallback, useEffect, useState, type ReactNode } from 'react';
+import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react';
 import { Link as RouterLink } from 'react-router-dom';
 import {
   Alert,
@@ -21,6 +21,7 @@ import {
   MenuItem,
   Paper,
   Select,
+  Snackbar,
   Stack,
   Table,
   TableBody,
@@ -35,6 +36,7 @@ import {
 import AccessTime from '@mui/icons-material/AccessTime';
 import WarningAmberRounded from '@mui/icons-material/WarningAmberRounded';
 import FilterList from '@mui/icons-material/FilterList';
+import AutorenewRounded from '@mui/icons-material/AutorenewRounded';
 
 import { SharedHeader } from '../components/layout/SharedHeader.tsx';
 import { VersionFooter } from '../components/layout/VersionFooter.tsx';
@@ -45,9 +47,17 @@ import {
 } from '../components/dashboard/TimeRangeModal.tsx';
 import EstimatedCostDisplay from '../components/shared/EstimatedCostDisplay.tsx';
 import { getFilterOptions, getUsageSummary, handleAPIError } from '../services/api.ts';
+import { websocketService } from '../services/websocket.ts';
+import { EVENT_SESSION_STATUS } from '../constants/eventTypes.ts';
+import { isTerminalStatus, type SessionStatus } from '../constants/sessionStatus.ts';
 import { formatEstimatedCostUsd, formatTimestamp, formatTokens } from '../utils/format.ts';
 import { sessionDetailPath } from '../constants/routes.ts';
 import type { UsageRankBy, UsageSummaryResponse } from '../types/api.ts';
+import type { SessionStatusPayload } from '../types/events.ts';
+
+/** Throttle for re-fetching the summary in response to WebSocket session events —
+ * batches bursts of completions (e.g. a whole chain finishing) into one refetch. */
+const WS_REFRESH_THROTTLE_MS = 2000;
 
 function defaultThirtyDayRange(): { start: Date; end: Date; preset: string } {
   const range = USAGE_TIME_PRESETS.find((p) => p.value === '30d')!.getDateRange();
@@ -105,7 +115,7 @@ export function UsagePage() {
     };
   }, []);
 
-  const fetchSummary = useCallback(async () => {
+  const fetchSummary = useCallback(async (): Promise<boolean> => {
     setLoading(true);
     setError(null);
     try {
@@ -117,9 +127,11 @@ export function UsagePage() {
         rank_by: rankBy,
       });
       setSummary(data);
+      return true;
     } catch (err) {
       setError(handleAPIError(err));
       setSummary(null);
+      return false;
     } finally {
       setLoading(false);
     }
@@ -128,6 +140,44 @@ export function UsagePage() {
   useEffect(() => {
     void fetchSummary();
   }, [fetchSummary]);
+
+  // Ref so the WebSocket handler (subscribed once, below) always calls the
+  // latest fetchSummary — without re-subscribing every time filters change.
+  const fetchSummaryRef = useRef(fetchSummary);
+  useEffect(() => {
+    fetchSummaryRef.current = fetchSummary;
+  }, [fetchSummary]);
+
+  const [liveUpdateNotice, setLiveUpdateNotice] = useState(false);
+
+  // Live updates: a session reaching a terminal state can change fleet
+  // totals/breakdowns, so refetch (throttled) and surface a brief, dismissible
+  // notice — the page doesn't otherwise indicate it refreshed itself.
+  useEffect(() => {
+    let refreshTimeout: ReturnType<typeof setTimeout> | null = null;
+
+    const handleSessionEvent = (data: Record<string, unknown>) => {
+      if (data.type !== EVENT_SESSION_STATUS) return;
+      const { status } = data as unknown as SessionStatusPayload;
+      if (!isTerminalStatus(status as SessionStatus)) return;
+
+      if (refreshTimeout) clearTimeout(refreshTimeout);
+      refreshTimeout = setTimeout(() => {
+        refreshTimeout = null;
+        void fetchSummaryRef.current().then((success) => {
+          if (success) setLiveUpdateNotice(true);
+        });
+      }, WS_REFRESH_THROTTLE_MS);
+    };
+
+    const unsubChannel = websocketService.subscribeToChannel('sessions', handleSessionEvent);
+    websocketService.connect();
+
+    return () => {
+      unsubChannel();
+      if (refreshTimeout) clearTimeout(refreshTimeout);
+    };
+  }, []);
 
   const handleTimeRangeApply = (start: Date | null, end: Date | null, preset?: string) => {
     if (start && end) {
@@ -444,6 +494,23 @@ export function UsagePage() {
         onApply={handleTimeRangeApply}
         presets={USAGE_TIME_PRESETS}
       />
+
+      <Snackbar
+        open={liveUpdateNotice}
+        autoHideDuration={3000}
+        onClose={() => setLiveUpdateNotice(false)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert
+          onClose={() => setLiveUpdateNotice(false)}
+          severity="info"
+          variant="filled"
+          icon={<AutorenewRounded fontSize="inherit" />}
+          sx={{ width: '100%' }}
+        >
+          Updated — new session data available
+        </Alert>
+      </Snackbar>
 
       <FloatingSubmitAlertFab />
     </Box>

--- a/web/dashboard/src/pages/UsagePage.tsx
+++ b/web/dashboard/src/pages/UsagePage.tsx
@@ -33,6 +33,7 @@ import {
 } from '@mui/material';
 import AccessTime from '@mui/icons-material/AccessTime';
 import WarningAmberRounded from '@mui/icons-material/WarningAmberRounded';
+import FilterList from '@mui/icons-material/FilterList';
 
 import { SharedHeader } from '../components/layout/SharedHeader.tsx';
 import { VersionFooter } from '../components/layout/VersionFooter.tsx';
@@ -131,6 +132,11 @@ export function UsagePage() {
   const timeRangeLabel = datePreset
     ? USAGE_TIME_PRESETS.find((p) => p.value === datePreset)?.label ?? `Range: ${datePreset}`
     : 'Custom range';
+  const hasActiveFilters = !!alertType || !!chainId;
+  const handleClearFilters = () => {
+    setAlertType(null);
+    setChainId(null);
+  };
 
   return (
     <Box sx={{ minHeight: '100vh', backgroundColor: 'background.default', px: 2, py: 2 }}>
@@ -140,10 +146,21 @@ export function UsagePage() {
         <Stack spacing={3}>
           {/* Filters */}
           <Paper variant="outlined" sx={{ p: 2 }}>
+            <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
+              <Typography variant="h6" sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                <FilterList fontSize="small" />
+                Filters
+              </Typography>
+              {hasActiveFilters && (
+                <Button size="small" onClick={handleClearFilters}>
+                  Clear filters
+                </Button>
+              )}
+            </Box>
             <Stack
               direction={{ xs: 'column', md: 'row' }}
               spacing={2}
-              alignItems={{ md: 'center' }}
+              alignItems={{ md: 'flex-end' }}
               flexWrap="wrap"
               useFlexGap
             >
@@ -152,6 +169,7 @@ export function UsagePage() {
                 startIcon={<AccessTime />}
                 onClick={() => setTimeRangeOpen(true)}
                 aria-label="Select time range"
+                sx={{ height: 40 }}
               >
                 {timeRangeLabel}
               </Button>
@@ -211,39 +229,35 @@ export function UsagePage() {
             <>
               {/* Totals */}
               <Paper variant="outlined" sx={{ p: 2 }}>
-                <Typography variant="h6" gutterBottom>
-                  Totals
-                </Typography>
-                <Stack direction="row" spacing={3} flexWrap="wrap" useFlexGap alignItems="center">
-                  <Typography variant="body1">
-                    <strong>{formatTokens(summary.totals.total_tokens)}</strong>{' '}
-                    <Typography component="span" color="text.secondary" variant="body2">
-                      tokens
-                    </Typography>
-                  </Typography>
-                  <Typography variant="body2" color="text.secondary">
-                    {formatTokens(summary.totals.input_tokens)} in ·{' '}
-                    {formatTokens(summary.totals.output_tokens)} out
-                  </Typography>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
+                  <Typography variant="h6">Totals</Typography>
+                  {loading && <CircularProgress size={16} />}
+                </Box>
+                <Box
+                  sx={{
+                    display: 'grid',
+                    gridTemplateColumns: 'repeat(auto-fit, minmax(160px, 1fr))',
+                    gap: 2,
+                  }}
+                >
+                  <StatCard label="Total tokens" value={formatTokens(summary.totals.total_tokens)} />
+                  <StatCard label="Input tokens" value={formatTokens(summary.totals.input_tokens)} />
+                  <StatCard label="Output tokens" value={formatTokens(summary.totals.output_tokens)} />
                   {costEnabled && (
-                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-                      <EstimatedCostDisplay
-                        enabled
-                        estimatedCostUsd={summary.totals.estimated_cost_usd}
-                        costCompleteness={summary.totals.cost_completeness}
-                        variant="labeled"
-                      />
-                      {summary.totals.cost_completeness === 'partial' &&
+                    <StatCard
+                      label="Est. cost"
+                      value={formatEstimatedCostUsd(summary.totals.estimated_cost_usd)}
+                      warning={summary.totals.cost_completeness === 'partial'}
+                      caption={
+                        summary.totals.cost_completeness === 'partial' &&
                         summary.totals.unpriced_interaction_count != null &&
-                        summary.totals.unpriced_interaction_count > 0 && (
-                          <Typography variant="caption" color="warning.main">
-                            ({summary.totals.unpriced_interaction_count} unpriced)
-                          </Typography>
-                        )}
-                    </Box>
+                        summary.totals.unpriced_interaction_count > 0
+                          ? `${summary.totals.unpriced_interaction_count} unpriced`
+                          : undefined
+                      }
+                    />
                   )}
-                  {loading && <CircularProgress size={18} />}
-                </Stack>
+                </Box>
               </Paper>
 
               {/* By model */}
@@ -251,25 +265,37 @@ export function UsagePage() {
                 title="By model"
                 columns={
                   costEnabled
-                    ? ['Model', 'Tokens', 'In', 'Out', 'Est. cost', 'Priced']
-                    : ['Model', 'Tokens', 'In', 'Out']
+                    ? [
+                        { label: 'Model' },
+                        { label: 'Tokens', align: 'right' },
+                        { label: 'In', align: 'right' },
+                        { label: 'Out', align: 'right' },
+                        { label: 'Est. cost', align: 'right' },
+                        { label: 'Priced', align: 'center' },
+                      ]
+                    : [
+                        { label: 'Model' },
+                        { label: 'Tokens', align: 'right' },
+                        { label: 'In', align: 'right' },
+                        { label: 'Out', align: 'right' },
+                      ]
                 }
                 empty={summary.by_model.length === 0}
               >
                 {summary.by_model.map((row) => (
-                  <TableRow key={row.model_name}>
+                  <TableRow key={row.model_name} hover>
                     <TableCell>{row.model_name}</TableCell>
-                    <TableCell>{formatTokens(row.total_tokens)}</TableCell>
-                    <TableCell>{formatTokens(row.input_tokens)}</TableCell>
-                    <TableCell>{formatTokens(row.output_tokens)}</TableCell>
+                    <TableCell align="right">{formatTokens(row.total_tokens)}</TableCell>
+                    <TableCell align="right">{formatTokens(row.input_tokens)}</TableCell>
+                    <TableCell align="right">{formatTokens(row.output_tokens)}</TableCell>
                     {costEnabled && (
                       <>
-                        <TableCell>
+                        <TableCell align="right">
                           {row.estimated_cost_usd != null
                             ? formatEstimatedCostUsd(row.estimated_cost_usd)
                             : '—'}
                         </TableCell>
-                        <TableCell>
+                        <TableCell align="center">
                           {row.priced === false ? (
                             <Chip
                               size="small"
@@ -288,60 +314,88 @@ export function UsagePage() {
                 ))}
               </BreakdownTable>
 
-              {/* By alert type */}
-              <BreakdownTable
-                title="By alert type"
-                columns={costEnabled ? ['Alert type', 'Tokens', 'Est. cost'] : ['Alert type', 'Tokens']}
-                empty={summary.by_alert_type.length === 0}
+              {/* By alert type + By chain — side by side, both are narrow */}
+              <Box
+                sx={{
+                  display: 'grid',
+                  gridTemplateColumns: { xs: '1fr', md: '1fr 1fr' },
+                  gap: 3,
+                }}
               >
-                {summary.by_alert_type.map((row) => (
-                  <TableRow key={row.alert_type || '(none)'}>
-                    <TableCell>{row.alert_type || '—'}</TableCell>
-                    <TableCell>{formatTokens(row.total_tokens)}</TableCell>
-                    {costEnabled && (
-                      <TableCell>
-                        {row.estimated_cost_usd != null
-                          ? formatEstimatedCostUsd(row.estimated_cost_usd)
-                          : '—'}
-                      </TableCell>
-                    )}
-                  </TableRow>
-                ))}
-              </BreakdownTable>
+                <BreakdownTable
+                  title="By alert type"
+                  columns={
+                    costEnabled
+                      ? [{ label: 'Alert type' }, { label: 'Tokens', align: 'right' }, { label: 'Est. cost', align: 'right' }]
+                      : [{ label: 'Alert type' }, { label: 'Tokens', align: 'right' }]
+                  }
+                  empty={summary.by_alert_type.length === 0}
+                >
+                  {summary.by_alert_type.map((row) => (
+                    <TableRow key={row.alert_type || '(none)'} hover>
+                      <TableCell>{row.alert_type || '—'}</TableCell>
+                      <TableCell align="right">{formatTokens(row.total_tokens)}</TableCell>
+                      {costEnabled && (
+                        <TableCell align="right">
+                          {row.estimated_cost_usd != null
+                            ? formatEstimatedCostUsd(row.estimated_cost_usd)
+                            : '—'}
+                        </TableCell>
+                      )}
+                    </TableRow>
+                  ))}
+                </BreakdownTable>
 
-              {/* By chain */}
-              <BreakdownTable
-                title="By chain"
-                columns={costEnabled ? ['Chain', 'Tokens', 'Est. cost'] : ['Chain', 'Tokens']}
-                empty={summary.by_chain.length === 0}
-              >
-                {summary.by_chain.map((row) => (
-                  <TableRow key={row.chain_id}>
-                    <TableCell>{row.chain_id}</TableCell>
-                    <TableCell>{formatTokens(row.total_tokens)}</TableCell>
-                    {costEnabled && (
-                      <TableCell>
-                        {row.estimated_cost_usd != null
-                          ? formatEstimatedCostUsd(row.estimated_cost_usd)
-                          : '—'}
-                      </TableCell>
-                    )}
-                  </TableRow>
-                ))}
-              </BreakdownTable>
+                <BreakdownTable
+                  title="By chain"
+                  columns={
+                    costEnabled
+                      ? [{ label: 'Chain' }, { label: 'Tokens', align: 'right' }, { label: 'Est. cost', align: 'right' }]
+                      : [{ label: 'Chain' }, { label: 'Tokens', align: 'right' }]
+                  }
+                  empty={summary.by_chain.length === 0}
+                >
+                  {summary.by_chain.map((row) => (
+                    <TableRow key={row.chain_id} hover>
+                      <TableCell>{row.chain_id}</TableCell>
+                      <TableCell align="right">{formatTokens(row.total_tokens)}</TableCell>
+                      {costEnabled && (
+                        <TableCell align="right">
+                          {row.estimated_cost_usd != null
+                            ? formatEstimatedCostUsd(row.estimated_cost_usd)
+                            : '—'}
+                        </TableCell>
+                      )}
+                    </TableRow>
+                  ))}
+                </BreakdownTable>
+              </Box>
 
               {/* Top sessions */}
               <BreakdownTable
                 title={`Top sessions (${summary.top_sessions.length})`}
                 columns={
                   costEnabled
-                    ? ['Session', 'Alert type', 'Chain', 'Tokens', 'Est. cost', 'Created']
-                    : ['Session', 'Alert type', 'Chain', 'Tokens', 'Created']
+                    ? [
+                        { label: 'Session' },
+                        { label: 'Alert type' },
+                        { label: 'Chain' },
+                        { label: 'Tokens', align: 'right' },
+                        { label: 'Est. cost', align: 'right' },
+                        { label: 'Created', align: 'right' },
+                      ]
+                    : [
+                        { label: 'Session' },
+                        { label: 'Alert type' },
+                        { label: 'Chain' },
+                        { label: 'Tokens', align: 'right' },
+                        { label: 'Created', align: 'right' },
+                      ]
                 }
                 empty={summary.top_sessions.length === 0}
               >
                 {summary.top_sessions.map((row) => (
-                  <TableRow key={row.session_id}>
+                  <TableRow key={row.session_id} hover>
                     <TableCell>
                       <Link
                         component={RouterLink}
@@ -354,9 +408,9 @@ export function UsagePage() {
                     </TableCell>
                     <TableCell>{row.alert_type || '—'}</TableCell>
                     <TableCell>{row.chain_id}</TableCell>
-                    <TableCell>{formatTokens(row.total_tokens)}</TableCell>
+                    <TableCell align="right">{formatTokens(row.total_tokens)}</TableCell>
                     {costEnabled && (
-                      <TableCell>
+                      <TableCell align="right">
                         <EstimatedCostDisplay
                           enabled
                           estimatedCostUsd={row.estimated_cost_usd}
@@ -365,7 +419,7 @@ export function UsagePage() {
                         />
                       </TableCell>
                     )}
-                    <TableCell>{formatTimestamp(row.created_at, 'short')}</TableCell>
+                    <TableCell align="right">{formatTimestamp(row.created_at, 'short')}</TableCell>
                   </TableRow>
                 ))}
               </BreakdownTable>
@@ -390,6 +444,11 @@ export function UsagePage() {
   );
 }
 
+interface BreakdownColumn {
+  label: string;
+  align?: 'left' | 'right' | 'center';
+}
+
 function BreakdownTable({
   title,
   columns,
@@ -397,12 +456,12 @@ function BreakdownTable({
   children,
 }: {
   title: string;
-  columns: string[];
+  columns: BreakdownColumn[];
   empty: boolean;
   children: ReactNode;
 }) {
   return (
-    <Paper variant="outlined" sx={{ p: 2 }}>
+    <Paper variant="outlined" sx={{ p: 2, height: '100%' }}>
       <Typography variant="h6" gutterBottom>
         {title}
       </Typography>
@@ -412,11 +471,27 @@ function BreakdownTable({
         </Typography>
       ) : (
         <TableContainer>
-          <Table size="small">
+          <Table
+            size="small"
+            sx={{
+              '& thead th': {
+                fontWeight: 700,
+                fontSize: '0.7rem',
+                textTransform: 'uppercase',
+                letterSpacing: 0.4,
+                color: 'text.secondary',
+                borderBottomWidth: 2,
+              },
+              '& tbody td': { fontVariantNumeric: 'tabular-nums' },
+              '& tbody tr:last-child td': { borderBottom: 0 },
+            }}
+          >
             <TableHead>
               <TableRow>
                 {columns.map((col) => (
-                  <TableCell key={col}>{col}</TableCell>
+                  <TableCell key={col.label} align={col.align ?? 'left'}>
+                    {col.label}
+                  </TableCell>
                 ))}
               </TableRow>
             </TableHead>
@@ -425,5 +500,47 @@ function BreakdownTable({
         </TableContainer>
       )}
     </Paper>
+  );
+}
+
+function StatCard({
+  label,
+  value,
+  warning,
+  caption,
+}: {
+  label: string;
+  value: string;
+  warning?: boolean;
+  caption?: string;
+}) {
+  return (
+    <Box sx={{ p: 1.5, borderRadius: 1, bgcolor: 'action.hover' }}>
+      <Typography
+        variant="caption"
+        color="text.secondary"
+        sx={{ textTransform: 'uppercase', letterSpacing: 0.5, fontWeight: 600, display: 'block' }}
+      >
+        {label}
+      </Typography>
+      <Typography
+        variant="h5"
+        fontWeight={700}
+        color={warning ? 'warning.main' : 'text.primary'}
+        sx={{ mt: 0.25, lineHeight: 1.2 }}
+      >
+        {value}
+      </Typography>
+      {caption && (
+        <Typography
+          variant="caption"
+          color="warning.main"
+          sx={{ display: 'flex', alignItems: 'center', gap: 0.25, mt: 0.25 }}
+        >
+          <WarningAmberRounded sx={{ fontSize: '0.9rem' }} />
+          {caption}
+        </Typography>
+      )}
+    </Box>
   );
 }

--- a/web/dashboard/src/pages/UsagePage.tsx
+++ b/web/dashboard/src/pages/UsagePage.tsx
@@ -29,6 +29,7 @@ import {
   TableHead,
   TableRow,
   TextField,
+  Tooltip,
   Typography,
 } from '@mui/material';
 import AccessTime from '@mui/icons-material/AccessTime';
@@ -51,6 +52,20 @@ import type { UsageRankBy, UsageSummaryResponse } from '../types/api.ts';
 function defaultThirtyDayRange(): { start: Date; end: Date; preset: string } {
   const range = USAGE_TIME_PRESETS.find((p) => p.value === '30d')!.getDateRange();
   return { start: range.start, end: range.end, preset: '30d' };
+}
+
+/** "~$X" for the Usage page's large, colored cost displays — tilde reads clearly at this size/weight. */
+function approxCostUsd(usd: number | null | undefined): string {
+  const formatted = formatEstimatedCostUsd(usd);
+  return formatted === '—' ? formatted : `~${formatted}`;
+}
+
+/** Explains exactly what "Incomplete" means for a model's priced status. */
+function incompletePricingTooltip(unpricedCount: number | undefined): string {
+  const suffix = 'so its total cost likely undercounts.';
+  return unpricedCount != null && unpricedCount > 0
+    ? `${unpricedCount} token-bearing interaction${unpricedCount === 1 ? '' : 's'} for this model had no resolved rate (missing from the price catalog/overrides), ${suffix}`
+    : `Some token-bearing interactions for this model had no resolved rate (missing from the price catalog/overrides), ${suffix}`;
 }
 
 export function UsagePage() {
@@ -246,7 +261,7 @@ export function UsagePage() {
                   {costEnabled && (
                     <StatCard
                       label="Est. cost"
-                      value={formatEstimatedCostUsd(summary.totals.estimated_cost_usd)}
+                      value={approxCostUsd(summary.totals.estimated_cost_usd)}
                       warning={summary.totals.cost_completeness === 'partial'}
                       caption={
                         summary.totals.cost_completeness === 'partial' &&
@@ -290,20 +305,18 @@ export function UsagePage() {
                     <TableCell align="right">{formatTokens(row.output_tokens)}</TableCell>
                     {costEnabled && (
                       <>
-                        <TableCell align="right">
-                          {row.estimated_cost_usd != null
-                            ? formatEstimatedCostUsd(row.estimated_cost_usd)
-                            : '—'}
-                        </TableCell>
+                        <TableCell align="right">{approxCostUsd(row.estimated_cost_usd)}</TableCell>
                         <TableCell align="center">
                           {row.priced === false ? (
-                            <Chip
-                              size="small"
-                              icon={<WarningAmberRounded />}
-                              label="Incomplete"
-                              color="warning"
-                              variant="outlined"
-                            />
+                            <Tooltip title={incompletePricingTooltip(row.unpriced_interaction_count)} arrow>
+                              <Chip
+                                size="small"
+                                icon={<WarningAmberRounded />}
+                                label="Incomplete"
+                                color="warning"
+                                variant="outlined"
+                              />
+                            </Tooltip>
                           ) : (
                             <Chip size="small" label="Priced" color="success" variant="outlined" />
                           )}
@@ -336,11 +349,7 @@ export function UsagePage() {
                       <TableCell>{row.alert_type || '—'}</TableCell>
                       <TableCell align="right">{formatTokens(row.total_tokens)}</TableCell>
                       {costEnabled && (
-                        <TableCell align="right">
-                          {row.estimated_cost_usd != null
-                            ? formatEstimatedCostUsd(row.estimated_cost_usd)
-                            : '—'}
-                        </TableCell>
+                        <TableCell align="right">{approxCostUsd(row.estimated_cost_usd)}</TableCell>
                       )}
                     </TableRow>
                   ))}
@@ -360,11 +369,7 @@ export function UsagePage() {
                       <TableCell>{row.chain_id}</TableCell>
                       <TableCell align="right">{formatTokens(row.total_tokens)}</TableCell>
                       {costEnabled && (
-                        <TableCell align="right">
-                          {row.estimated_cost_usd != null
-                            ? formatEstimatedCostUsd(row.estimated_cost_usd)
-                            : '—'}
-                        </TableCell>
+                        <TableCell align="right">{approxCostUsd(row.estimated_cost_usd)}</TableCell>
                       )}
                     </TableRow>
                   ))}

--- a/web/dashboard/src/services/api.ts
+++ b/web/dashboard/src/services/api.ts
@@ -26,6 +26,8 @@ import type {
   UpdateReviewRequest,
   UpdateReviewResponse,
   ReviewActivityResponse,
+  UsageSummaryParams,
+  UsageSummaryResponse,
 } from '../types/api.ts';
 import type {
   SessionDetailResponse,
@@ -136,6 +138,13 @@ export function handleAPIError(error: unknown): string {
 export async function getSessions(params: DashboardListParams): Promise<DashboardListResponse> {
   const response = await retryOnTemporaryError(() =>
     client.get<DashboardListResponse>('/api/v1/sessions', { params }),
+  );
+  return response.data;
+}
+
+export async function getUsageSummary(params: UsageSummaryParams): Promise<UsageSummaryResponse> {
+  const response = await retryOnTemporaryError(() =>
+    client.get<UsageSummaryResponse>('/api/v1/usage/summary', { params }),
   );
   return response.data;
 }

--- a/web/dashboard/src/test/components/EstimatedCostDisplay.test.tsx
+++ b/web/dashboard/src/test/components/EstimatedCostDisplay.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from '@testing-library/react';
+import EstimatedCostDisplay from '../../components/shared/EstimatedCostDisplay';
+
+describe('EstimatedCostDisplay', () => {
+  it('renders nothing when disabled', () => {
+    const { container } = render(
+      <EstimatedCostDisplay
+        enabled={false}
+        estimatedCostUsd={1.23}
+        costCompleteness="complete"
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing when cost fields are absent', () => {
+    const { container } = render(<EstimatedCostDisplay enabled />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing when completeness is none', () => {
+    const { container } = render(
+      <EstimatedCostDisplay
+        enabled
+        estimatedCostUsd={0}
+        costCompleteness="none"
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders Est. label for complete estimates', () => {
+    render(
+      <EstimatedCostDisplay
+        enabled
+        estimatedCostUsd={1.23}
+        costCompleteness="complete"
+      />,
+    );
+    expect(screen.getByText('Est. $1.23')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Incomplete cost estimate')).not.toBeInTheDocument();
+  });
+
+  it('renders warning affordance for partial estimates', () => {
+    render(
+      <EstimatedCostDisplay
+        enabled
+        estimatedCostUsd={0.0042}
+        costCompleteness="partial"
+      />,
+    );
+    expect(screen.getByText('Est. $0.0042')).toBeInTheDocument();
+    expect(screen.getByLabelText('Incomplete cost estimate')).toBeInTheDocument();
+  });
+});

--- a/web/dashboard/src/test/components/EstimatedCostDisplay.test.tsx
+++ b/web/dashboard/src/test/components/EstimatedCostDisplay.test.tsx
@@ -29,7 +29,7 @@ describe('EstimatedCostDisplay', () => {
     expect(container).toBeEmptyDOMElement();
   });
 
-  it('renders Est. label for complete estimates', () => {
+  it('renders plain dollar value for complete estimates', () => {
     render(
       <EstimatedCostDisplay
         enabled
@@ -37,7 +37,7 @@ describe('EstimatedCostDisplay', () => {
         costCompleteness="complete"
       />,
     );
-    expect(screen.getByText('Est. $1.23')).toBeInTheDocument();
+    expect(screen.getByText('$1.23')).toBeInTheDocument();
     expect(screen.queryByLabelText('Incomplete cost estimate')).not.toBeInTheDocument();
   });
 
@@ -49,7 +49,20 @@ describe('EstimatedCostDisplay', () => {
         costCompleteness="partial"
       />,
     );
-    expect(screen.getByText('Est. $0.0042')).toBeInTheDocument();
+    expect(screen.getByText('$0.0042')).toBeInTheDocument();
     expect(screen.getByLabelText('Incomplete cost estimate')).toBeInTheDocument();
+  });
+
+  it('renders trailing "cost" label for the labeled variant', () => {
+    render(
+      <EstimatedCostDisplay
+        enabled
+        estimatedCostUsd={1.23}
+        costCompleteness="complete"
+        variant="labeled"
+      />,
+    );
+    expect(screen.getByText('$1.23')).toBeInTheDocument();
+    expect(screen.getByText('cost')).toBeInTheDocument();
   });
 });

--- a/web/dashboard/src/test/pages/UsagePage.test.tsx
+++ b/web/dashboard/src/test/pages/UsagePage.test.tsx
@@ -35,6 +35,21 @@ vi.mock('../../contexts/VersionContext.tsx', () => ({
   }),
 }));
 
+/** Captures the handler UsagePage registers on the 'sessions' channel so tests
+ * can simulate incoming WebSocket events without a real socket connection. */
+let capturedSessionHandler: ((data: Record<string, unknown>) => void) | null = null;
+vi.mock('../../services/websocket.ts', () => ({
+  websocketService: {
+    subscribeToChannel: (_channel: string, handler: (data: Record<string, unknown>) => void) => {
+      capturedSessionHandler = handler;
+      return () => {
+        capturedSessionHandler = null;
+      };
+    },
+    connect: () => {},
+  },
+}));
+
 import { getFilterOptions, getUsageSummary } from '../../services/api';
 import { UsagePage } from '../../pages/UsagePage';
 
@@ -144,6 +159,51 @@ describe('UsagePage', () => {
       expect(mockGetUsageSummary).toHaveBeenCalledTimes(2);
     });
     expect(mockGetUsageSummary.mock.calls[1][0].rank_by).toBe('tokens');
+  });
+
+  it('refetches and shows a brief notice when a session completes via WebSocket', async () => {
+    mockGetUsageSummary.mockResolvedValue(makeSummary());
+
+    renderUsagePage();
+    await screen.findByText('Totals');
+    expect(mockGetUsageSummary).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText('Updated — new session data available')).not.toBeInTheDocument();
+
+    expect(capturedSessionHandler).not.toBeNull();
+    capturedSessionHandler?.({
+      type: 'session.status',
+      session_id: 'abcdef12-3456-7890-abcd-ef1234567890',
+      status: 'completed',
+      timestamp: '2026-07-23T12:00:00Z',
+    });
+
+    await waitFor(
+      () => {
+        expect(mockGetUsageSummary).toHaveBeenCalledTimes(2);
+      },
+      { timeout: 4000 },
+    );
+    expect(await screen.findByText('Updated — new session data available')).toBeInTheDocument();
+  });
+
+  it('ignores non-terminal session status events (no refetch, no notice)', async () => {
+    mockGetUsageSummary.mockResolvedValue(makeSummary());
+
+    renderUsagePage();
+    await screen.findByText('Totals');
+    expect(mockGetUsageSummary).toHaveBeenCalledTimes(1);
+
+    capturedSessionHandler?.({
+      type: 'session.status',
+      session_id: 'abcdef12-3456-7890-abcd-ef1234567890',
+      status: 'in_progress',
+      timestamp: '2026-07-23T12:00:00Z',
+    });
+
+    // Give the (unused) throttle window time to elapse; the call count should stay at 1.
+    await new Promise((resolve) => setTimeout(resolve, 2200));
+    expect(mockGetUsageSummary).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText('Updated — new session data available')).not.toBeInTheDocument();
   });
 
   it('shows a tooltip on the Incomplete chip explaining exactly what is unpriced', async () => {

--- a/web/dashboard/src/test/pages/UsagePage.test.tsx
+++ b/web/dashboard/src/test/pages/UsagePage.test.tsx
@@ -123,7 +123,7 @@ describe('UsagePage', () => {
     expect(end - start).toBeLessThan(31 * dayMs);
 
     expect(await screen.findByText('Totals')).toBeInTheDocument();
-    expect(screen.getAllByText('Est. $1.23').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('~$1.23').length).toBeGreaterThan(0);
     expect(screen.getByRole('button', { name: 'Select time range' })).toHaveTextContent(
       'Last 30 days',
     );
@@ -144,6 +144,34 @@ describe('UsagePage', () => {
       expect(mockGetUsageSummary).toHaveBeenCalledTimes(2);
     });
     expect(mockGetUsageSummary.mock.calls[1][0].rank_by).toBe('tokens');
+  });
+
+  it('shows a tooltip on the Incomplete chip explaining exactly what is unpriced', async () => {
+    const user = userEvent.setup();
+    mockGetUsageSummary.mockResolvedValue(
+      makeSummary({
+        by_model: [
+          {
+            model_name: 'gemini-flash',
+            input_tokens: 100,
+            output_tokens: 50,
+            total_tokens: 150,
+            estimated_cost_usd: 1.23,
+            priced: false,
+            unpriced_interaction_count: 3,
+          },
+        ],
+      }),
+    );
+
+    renderUsagePage();
+    await screen.findByText('Totals');
+
+    await user.hover(await screen.findByText('Incomplete'));
+
+    expect(
+      await screen.findByText(/3 token-bearing interactions for this model had no resolved rate/),
+    ).toBeInTheDocument();
   });
 
   it('hides cost columns when estimation is disabled', async () => {
@@ -181,7 +209,7 @@ describe('UsagePage', () => {
     renderUsagePage();
     await screen.findByText('Totals');
 
-    expect(screen.queryByText(/Est\./)).not.toBeInTheDocument();
+    expect(screen.queryByText(/[~≈]\$/)).not.toBeInTheDocument();
     expect(screen.queryByLabelText('Rank top sessions')).not.toBeInTheDocument();
 
     const modelSection = screen.getByText('By model').closest('.MuiPaper-root');

--- a/web/dashboard/src/test/pages/UsagePage.test.tsx
+++ b/web/dashboard/src/test/pages/UsagePage.test.tsx
@@ -1,0 +1,192 @@
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import type { UsageSummaryResponse } from '../../types/api';
+
+vi.mock('../../services/api.ts', () => ({
+  getUsageSummary: vi.fn(),
+  getFilterOptions: vi.fn(),
+  handleAPIError: (err: unknown) =>
+    err instanceof Error ? err.message : 'An unexpected error occurred',
+}));
+
+vi.mock('../../config/env.ts', () => ({
+  config: { isDevelopment: false, isProduction: true },
+  DASHBOARD_VERSION: 'test',
+  urls: {
+    api: { base: '', health: '/health' },
+    websocket: { base: 'ws://localhost:8080', path: '/api/v1/ws' },
+    oauth: { signIn: '/oauth2/sign_in', signOut: '/oauth2/sign_out', userInfo: '/oauth2/userinfo' },
+  },
+}));
+
+vi.mock('../../contexts/AuthContext.tsx', () => ({
+  useAuth: () => ({
+    authAvailable: false,
+    isAuthenticated: false,
+    user: null,
+  }),
+}));
+
+vi.mock('../../contexts/VersionContext.tsx', () => ({
+  useVersion: () => ({
+    currentVersion: 'test',
+    updateAvailable: false,
+  }),
+}));
+
+import { getFilterOptions, getUsageSummary } from '../../services/api';
+import { UsagePage } from '../../pages/UsagePage';
+
+const mockGetUsageSummary = vi.mocked(getUsageSummary);
+const mockGetFilterOptions = vi.mocked(getFilterOptions);
+
+function makeSummary(overrides: Partial<UsageSummaryResponse> = {}): UsageSummaryResponse {
+  return {
+    cost_estimation_enabled: true,
+    window: {
+      start: '2026-06-23T00:00:00.000Z',
+      end: '2026-07-23T00:00:00.000Z',
+    },
+    rank_by: 'cost',
+    totals: {
+      input_tokens: 100,
+      output_tokens: 50,
+      total_tokens: 150,
+      estimated_cost_usd: 1.23,
+      cost_completeness: 'complete',
+      unpriced_interaction_count: 0,
+    },
+    by_model: [
+      {
+        model_name: 'gemini-flash',
+        input_tokens: 100,
+        output_tokens: 50,
+        total_tokens: 150,
+        estimated_cost_usd: 1.23,
+        priced: true,
+      },
+    ],
+    by_alert_type: [{ alert_type: 'kubernetes', total_tokens: 150, estimated_cost_usd: 1.23 }],
+    by_chain: [{ chain_id: 'default', total_tokens: 150, estimated_cost_usd: 1.23 }],
+    top_sessions: [
+      {
+        session_id: 'abcdef12-3456-7890-abcd-ef1234567890',
+        alert_type: 'kubernetes',
+        chain_id: 'default',
+        total_tokens: 150,
+        estimated_cost_usd: 1.23,
+        cost_completeness: 'complete',
+        created_at: '2026-07-01T12:00:00Z',
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function renderUsagePage() {
+  return render(
+    <MemoryRouter>
+      <UsagePage />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetFilterOptions.mockResolvedValue({
+    alert_types: ['kubernetes'],
+    chain_ids: ['default'],
+    statuses: [],
+  });
+});
+
+describe('UsagePage', () => {
+  it('fetches summary with default 30d window on load', async () => {
+    mockGetUsageSummary.mockResolvedValue(makeSummary());
+
+    renderUsagePage();
+
+    await waitFor(() => {
+      expect(mockGetUsageSummary).toHaveBeenCalled();
+    });
+
+    const params = mockGetUsageSummary.mock.calls[0][0];
+    expect(params.start_date).toBeTruthy();
+    expect(params.end_date).toBeTruthy();
+    expect(params.rank_by).toBeUndefined();
+
+    const start = new Date(params.start_date).getTime();
+    const end = new Date(params.end_date).getTime();
+    const dayMs = 24 * 60 * 60 * 1000;
+    expect(end - start).toBeGreaterThan(29 * dayMs);
+    expect(end - start).toBeLessThan(31 * dayMs);
+
+    expect(await screen.findByText('Totals')).toBeInTheDocument();
+    expect(screen.getAllByText('Est. $1.23').length).toBeGreaterThan(0);
+    expect(screen.getByRole('button', { name: 'Select time range' })).toHaveTextContent(
+      'Last 30 days',
+    );
+  });
+
+  it('re-fetches when rank_by changes', async () => {
+    const user = userEvent.setup();
+    mockGetUsageSummary.mockResolvedValue(makeSummary());
+
+    renderUsagePage();
+    await screen.findByText('Totals');
+
+    const select = screen.getByLabelText('Rank top sessions');
+    await user.click(select);
+    await user.click(await screen.findByRole('option', { name: 'By tokens' }));
+
+    await waitFor(() => {
+      expect(mockGetUsageSummary).toHaveBeenCalledTimes(2);
+    });
+    expect(mockGetUsageSummary.mock.calls[1][0].rank_by).toBe('tokens');
+  });
+
+  it('hides cost columns when estimation is disabled', async () => {
+    mockGetUsageSummary.mockResolvedValue(
+      makeSummary({
+        cost_estimation_enabled: false,
+        rank_by: 'tokens',
+        totals: {
+          input_tokens: 100,
+          output_tokens: 50,
+          total_tokens: 150,
+        },
+        by_model: [
+          {
+            model_name: 'gemini-flash',
+            input_tokens: 100,
+            output_tokens: 50,
+            total_tokens: 150,
+          },
+        ],
+        by_alert_type: [{ alert_type: 'kubernetes', total_tokens: 150 }],
+        by_chain: [{ chain_id: 'default', total_tokens: 150 }],
+        top_sessions: [
+          {
+            session_id: 'abcdef12-3456-7890-abcd-ef1234567890',
+            alert_type: 'kubernetes',
+            chain_id: 'default',
+            total_tokens: 150,
+            created_at: '2026-07-01T12:00:00Z',
+          },
+        ],
+      }),
+    );
+
+    renderUsagePage();
+    await screen.findByText('Totals');
+
+    expect(screen.queryByText(/Est\./)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Rank top sessions')).not.toBeInTheDocument();
+
+    const modelSection = screen.getByText('By model').closest('.MuiPaper-root');
+    expect(modelSection).toBeInstanceOf(HTMLElement);
+    expect(within(modelSection as HTMLElement).queryByText('Est. cost')).not.toBeInTheDocument();
+    expect(within(modelSection as HTMLElement).getByText('Tokens')).toBeInTheDocument();
+  });
+});

--- a/web/dashboard/src/test/services/api.test.ts
+++ b/web/dashboard/src/test/services/api.test.ts
@@ -53,6 +53,7 @@ import {
   getDefaultTools,
   getSystemConfig,
   getSystemConfigSkill,
+  getUsageSummary,
 } from '../../services/api';
 
 function getMockClient() {
@@ -211,6 +212,31 @@ describe('API methods', () => {
       client.get.mockResolvedValue({ data: { name: 'my skill', body: '...' } });
       await getSystemConfigSkill('my skill');
       expect(client.get).toHaveBeenCalledWith('/api/v1/system/config/skills/my%20skill');
+    });
+  });
+
+  describe('getUsageSummary', () => {
+    it('calls usage summary endpoint with params', async () => {
+      const data = {
+        cost_estimation_enabled: true,
+        window: { start: '2026-01-01T00:00:00Z', end: '2026-01-31T00:00:00Z' },
+        rank_by: 'cost',
+        totals: { input_tokens: 1, output_tokens: 2, total_tokens: 3 },
+        by_model: [],
+        by_alert_type: [],
+        by_chain: [],
+        top_sessions: [],
+      };
+      client.get.mockResolvedValue({ data });
+      const params = {
+        start_date: '2026-01-01T00:00:00Z',
+        end_date: '2026-01-31T00:00:00Z',
+        alert_type: 'kubernetes',
+        rank_by: 'tokens' as const,
+      };
+      const result = await getUsageSummary(params);
+      expect(client.get).toHaveBeenCalledWith('/api/v1/usage/summary', { params });
+      expect(result).toEqual(data);
     });
   });
 });

--- a/web/dashboard/src/test/utils/format.test.ts
+++ b/web/dashboard/src/test/utils/format.test.ts
@@ -9,6 +9,7 @@ import {
   formatDurationMs,
   formatTokens,
   formatTokensCompact,
+  formatEstimatedCostUsd,
   compactTimeAgo,
   timeAgo,
   liveDuration,
@@ -283,5 +284,29 @@ describe('formatTokensCompact', () => {
     expect(formatTokensCompact(1_000_000)).toBe('1.0M');
     expect(formatTokensCompact(1_500_000)).toBe('1.5M');
     expect(formatTokensCompact(10_500_000)).toBe('10.5M');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatEstimatedCostUsd
+// ---------------------------------------------------------------------------
+
+describe('formatEstimatedCostUsd', () => {
+  it('returns "—" for null/undefined', () => {
+    expect(formatEstimatedCostUsd(null)).toBe('—');
+    expect(formatEstimatedCostUsd(undefined)).toBe('—');
+  });
+
+  it('formats zero with two decimals', () => {
+    expect(formatEstimatedCostUsd(0)).toBe('$0.00');
+  });
+
+  it('keeps extra precision for sub-cent amounts', () => {
+    expect(formatEstimatedCostUsd(0.0042)).toBe('$0.0042');
+  });
+
+  it('formats mid-range and dollar amounts', () => {
+    expect(formatEstimatedCostUsd(0.123)).toBe('$0.123');
+    expect(formatEstimatedCostUsd(1.234)).toBe('$1.23');
   });
 });

--- a/web/dashboard/src/types/api.ts
+++ b/web/dashboard/src/types/api.ts
@@ -2,7 +2,7 @@
  * API request/response wrapper types.
  */
 
-import type { DashboardSessionItem } from './session.ts';
+import type { CostCompleteness, DashboardSessionItem } from './session.ts';
 import type { MCPSelectionConfig } from './system.ts';
 
 /** Pagination info in list responses. */
@@ -17,6 +17,82 @@ export interface PaginationInfo {
 export interface DashboardListResponse {
   sessions: DashboardSessionItem[];
   pagination: PaginationInfo;
+  cost_estimation_enabled?: boolean;
+}
+
+/** Ranking for Usage summary top sessions. */
+export type UsageRankBy = 'cost' | 'tokens';
+
+/** Query parameters for GET /api/v1/usage/summary. */
+export interface UsageSummaryParams {
+  start_date: string;
+  end_date: string;
+  alert_type?: string;
+  chain_id?: string;
+  rank_by?: UsageRankBy;
+}
+
+/** Window echoed by the usage summary endpoint. */
+export interface UsageWindow {
+  start: string;
+  end: string;
+}
+
+/** Fleet-wide token/cost rollup for a usage window. */
+export interface UsageTotals {
+  input_tokens: number;
+  output_tokens: number;
+  total_tokens: number;
+  estimated_cost_usd?: number | null;
+  cost_completeness?: CostCompleteness;
+  unpriced_interaction_count?: number;
+}
+
+/** Per-model rollup within a usage window. */
+export interface UsageModelBreakdown {
+  model_name: string;
+  input_tokens: number;
+  output_tokens: number;
+  total_tokens: number;
+  estimated_cost_usd?: number | null;
+  priced?: boolean;
+}
+
+/** Per-alert-type rollup within a usage window. */
+export interface UsageAlertBreakdown {
+  alert_type: string;
+  total_tokens: number;
+  estimated_cost_usd?: number | null;
+}
+
+/** Per-chain rollup within a usage window. */
+export interface UsageChainBreakdown {
+  chain_id: string;
+  total_tokens: number;
+  estimated_cost_usd?: number | null;
+}
+
+/** One of the capped top sessions in a usage window. */
+export interface UsageTopSession {
+  session_id: string;
+  alert_type: string | null;
+  chain_id: string;
+  total_tokens: number;
+  estimated_cost_usd?: number | null;
+  cost_completeness?: CostCompleteness;
+  created_at: string;
+}
+
+/** Response from GET /api/v1/usage/summary. */
+export interface UsageSummaryResponse {
+  cost_estimation_enabled: boolean;
+  window: UsageWindow;
+  rank_by: UsageRankBy;
+  totals: UsageTotals;
+  by_model: UsageModelBreakdown[];
+  by_alert_type: UsageAlertBreakdown[];
+  by_chain: UsageChainBreakdown[];
+  top_sessions: UsageTopSession[];
 }
 
 /** Query parameters for the dashboard session list. */

--- a/web/dashboard/src/types/api.ts
+++ b/web/dashboard/src/types/api.ts
@@ -56,6 +56,7 @@ export interface UsageModelBreakdown {
   total_tokens: number;
   estimated_cost_usd?: number | null;
   priced?: boolean;
+  unpriced_interaction_count?: number;
 }
 
 /** Per-alert-type rollup within a usage window. */

--- a/web/dashboard/src/types/session.ts
+++ b/web/dashboard/src/types/session.ts
@@ -2,6 +2,9 @@
  * Session-related types derived from Go models (pkg/models/session.go).
  */
 
+/** Cost completeness for session / execution aggregates. */
+export type CostCompleteness = 'complete' | 'partial' | 'none';
+
 /** Single session in the dashboard list with pre-computed stats. */
 export interface DashboardSessionItem {
   id: string;
@@ -20,6 +23,8 @@ export interface DashboardSessionItem {
   input_tokens: number;
   output_tokens: number;
   total_tokens: number;
+  estimated_cost_usd?: number | null;
+  cost_completeness?: CostCompleteness;
   total_stages: number;
   completed_stages: number;
   has_parallel_stages: boolean;
@@ -103,6 +108,10 @@ export interface SessionDetailResponse {
   input_tokens: number;
   output_tokens: number;
   total_tokens: number;
+  cost_estimation_enabled?: boolean;
+  estimated_cost_usd?: number | null;
+  cost_completeness?: CostCompleteness;
+  unpriced_interaction_count?: number;
   llm_interaction_count: number;
   mcp_interaction_count: number;
   current_stage_index: number | null;
@@ -157,6 +166,9 @@ export interface ExecutionOverview {
   input_tokens: number;
   output_tokens: number;
   total_tokens: number;
+  estimated_cost_usd?: number | null;
+  cost_completeness?: CostCompleteness;
+  unpriced_interaction_count?: number;
   parent_execution_id?: string | null;
   task?: string | null;
   original_llm_provider?: string | null;
@@ -176,6 +188,10 @@ export interface SessionSummaryResponse {
   input_tokens: number;
   output_tokens: number;
   total_tokens: number;
+  cost_estimation_enabled?: boolean;
+  estimated_cost_usd?: number | null;
+  cost_completeness?: CostCompleteness;
+  unpriced_interaction_count?: number;
   total_duration_ms: number | null;
   chain_statistics: ChainStatistics;
   total_score?: number | null;

--- a/web/dashboard/src/utils/format.ts
+++ b/web/dashboard/src/utils/format.ts
@@ -167,6 +167,9 @@ export function formatTokensCompact(tokens: number | null | undefined): string {
 /**
  * Compact USD format for estimated cost surfaces.
  * Small amounts keep extra precision so sub-cent estimates remain readable.
+ * Plain "$X" — callers that want an "approximate" glyph prefix it themselves,
+ * since the right glyph/weight/color depends on how prominently it's displayed
+ * (see EstimatedCostDisplay for the small/inline case).
  */
 export function formatEstimatedCostUsd(usd: number | null | undefined): string {
   if (usd == null || !Number.isFinite(usd)) return '—';

--- a/web/dashboard/src/utils/format.ts
+++ b/web/dashboard/src/utils/format.ts
@@ -159,3 +159,27 @@ export function formatTokensCompact(tokens: number | null | undefined): string {
   }
   return String(tokens);
 }
+
+// ────────────────────────────────────────────────────────────
+// Estimated cost (USD)
+// ────────────────────────────────────────────────────────────
+
+/**
+ * Compact USD format for estimated cost surfaces.
+ * Small amounts keep extra precision so sub-cent estimates remain readable.
+ */
+export function formatEstimatedCostUsd(usd: number | null | undefined): string {
+  if (usd == null || !Number.isFinite(usd)) return '—';
+  const abs = Math.abs(usd);
+  let fractionDigits: number;
+  if (abs === 0) {
+    fractionDigits = 2;
+  } else if (abs < 0.01) {
+    fractionDigits = 4;
+  } else if (abs < 1) {
+    fractionDigits = 3;
+  } else {
+    fractionDigits = 2;
+  }
+  return `$${usd.toFixed(fractionDigits)}`;
+}


### PR DESCRIPTION
Add dashboard Est. $ surfaces and Usage page
- Show EstimatedCostDisplay beside tokens on history, session header, and execution surfaces
- Add /usage page with Usage date presets, filters, aggregates, and top-20 rank_by
- Surface cost-estimation settings in Config Viewer System section
- Wire getUsageSummary client types/tests and operator docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Usage dashboard with date-range filtering, totals, model/alert/chain breakdowns, and top-session rankings by tokens or estimated cost.
  * Added estimated cost displays across session views, traces, timelines, and execution/execution details, including “Est. Cost” columns where enabled.
  * Added incomplete-pricing indicators/tooltips and surfaced unpriced interaction counts in usage breakdowns.
  * Enhanced the system configuration viewer with dedicated cost-estimation details.
* **Documentation**
  * Updated session usage-cost documentation to reflect persisted estimation, the usage summary API behavior, ranking, and pricing-completeness semantics.
* **Tests**
  * Added end-to-end and UI/unit test coverage for usage-cost estimation, incomplete estimates/unpriced interactions, API access, and dashboard behavior (including disabled-state handling).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->