### PR TITLE
Show currently-applied time range in usage filters

### DIFF
--- a/web/dashboard/src/components/dashboard/FilterPanel.tsx
+++ b/web/dashboard/src/components/dashboard/FilterPanel.tsx
@@ -24,9 +24,9 @@ import {
 } from '@mui/material';
 import type { SelectChangeEvent } from '@mui/material';
 import { Search, Clear, FilterList } from '@mui/icons-material';
-import { format, parseISO } from 'date-fns';
+import { parseISO } from 'date-fns';
 import { StatusFilter } from './StatusFilter.tsx';
-import { TimeRangeModal } from './TimeRangeModal.tsx';
+import { TimeRangeModal, formatAppliedRange } from './TimeRangeModal.tsx';
 import type { SessionFilter } from '../../types/dashboard.ts';
 import type { FilterOptionsResponse } from '../../types/system.ts';
 import { hasActiveFilters } from '../../utils/search.ts';
@@ -112,12 +112,15 @@ export function FilterPanel({
     onFiltersChange({ ...filters, start_date: null, end_date: null, date_preset: null });
   };
 
-  // ── Time range button label (matches old dashboard) ──
-  const timeRangeLabel = filters.date_preset
-    ? `Range: ${filters.date_preset}`
-    : filters.start_date || filters.end_date
-      ? 'Custom Range'
-      : 'Time Range';
+  // ── Time range button label — always reflects what's actually applied
+  // (preset label, or real dates for a custom range) instead of a generic
+  // "Custom Range" placeholder that hides the selection. ──
+  const appliedRangeLabel = formatAppliedRange(
+    filters.start_date ? parseISO(filters.start_date) : null,
+    filters.end_date ? parseISO(filters.end_date) : null,
+    filters.date_preset,
+  );
+  const timeRangeLabel = appliedRangeLabel ?? 'Time Range';
 
   return (
     <>
@@ -286,17 +289,9 @@ export function FilterPanel({
                   variant="outlined"
                 />
               )}
-              {(filters.start_date || filters.end_date || filters.date_preset) && (
+              {appliedRangeLabel && (
                 <Chip
-                  label={
-                    filters.date_preset
-                      ? `Range: ${filters.date_preset}`
-                      : filters.start_date && filters.end_date
-                        ? `${format(parseISO(filters.start_date), 'MMM d')} - ${format(parseISO(filters.end_date), 'MMM d')}`
-                        : filters.start_date
-                          ? `From: ${format(parseISO(filters.start_date), 'MMM d, yyyy')}`
-                          : `Until: ${format(parseISO(filters.end_date!), 'MMM d, yyyy')}`
-                  }
+                  label={`Range: ${appliedRangeLabel}`}
                   onDelete={handleClearDateRange}
                   size="small"
                   color="secondary"
@@ -314,6 +309,7 @@ export function FilterPanel({
         onClose={() => setTimeRangeModalOpen(false)}
         startDate={filters.start_date ? parseISO(filters.start_date) : null}
         endDate={filters.end_date ? parseISO(filters.end_date) : null}
+        activePreset={filters.date_preset}
         onApply={handleTimeRangeApply}
       />
     </>

--- a/web/dashboard/src/components/dashboard/TimeRangeModal.tsx
+++ b/web/dashboard/src/components/dashboard/TimeRangeModal.tsx
@@ -189,7 +189,8 @@ export function formatAppliedRange(
   }
   if (!startDate && !endDate) return null;
 
-  const isMidnight = (d: Date) => d.getHours() === 0 && d.getMinutes() === 0;
+  const isMidnight = (d: Date) =>
+    d.getHours() === 0 && d.getMinutes() === 0 && d.getSeconds() === 0 && d.getMilliseconds() === 0;
   const showTime = [startDate, endDate].some((d) => d != null && !isMidnight(d));
   const fmt = showTime ? 'MMM d, yyyy HH:mm' : 'MMM d, yyyy';
 

--- a/web/dashboard/src/components/dashboard/TimeRangeModal.tsx
+++ b/web/dashboard/src/components/dashboard/TimeRangeModal.tsx
@@ -47,6 +47,8 @@ export interface TimeRangeModalProps {
   onClose: () => void;
   startDate?: Date | null;
   endDate?: Date | null;
+  /** Preset value currently applied, if the applied range came from a preset (vs. custom dates). */
+  activePreset?: string | null;
   onApply: (startDate: Date | null, endDate: Date | null, preset?: string) => void;
   /** Override presets (defaults to Alert History quick ranges). */
   presets?: TimePreset[];
@@ -110,8 +112,17 @@ export const DEFAULT_TIME_PRESETS: TimePreset[] = [
   },
 ];
 
-/** Usage page presets (7d / 30d / MTD / last calendar month). */
+/** Usage page presets (1d / 7d / 30d / MTD / last calendar month). */
 export const USAGE_TIME_PRESETS: TimePreset[] = [
+  {
+    label: 'Last day',
+    value: '1d',
+    description: 'Last 24 hours',
+    getDateRange: () => ({
+      start: subDays(new Date(), 1),
+      end: new Date(),
+    }),
+  },
   {
     label: 'Last 7 days',
     value: '7d',
@@ -160,6 +171,34 @@ function sameDate(a?: Date | null, b?: Date | null): boolean {
 }
 
 /**
+ * Human-readable description of the currently-applied range, for display
+ * outside the modal (filter buttons/chips) and inside it (the "currently
+ * applied" banner). Presets are shown by their friendly label; custom
+ * ranges are formatted as dates (with times included only when a boundary
+ * isn't at midnight, so plain day ranges stay compact).
+ */
+export function formatAppliedRange(
+  startDate: Date | null | undefined,
+  endDate: Date | null | undefined,
+  presetValue: string | null | undefined,
+  presets: TimePreset[] = DEFAULT_TIME_PRESETS,
+): string | null {
+  if (presetValue) {
+    const preset = presets.find((p) => p.value === presetValue);
+    if (preset) return preset.label;
+  }
+  if (!startDate && !endDate) return null;
+
+  const isMidnight = (d: Date) => d.getHours() === 0 && d.getMinutes() === 0;
+  const showTime = [startDate, endDate].some((d) => d != null && !isMidnight(d));
+  const fmt = showTime ? 'MMM d, yyyy HH:mm' : 'MMM d, yyyy';
+
+  if (startDate && endDate) return `${format(startDate, fmt)} \u2013 ${format(endDate, fmt)}`;
+  if (startDate) return `From ${format(startDate, fmt)}`;
+  return `Until ${format(endDate!, fmt)}`;
+}
+
+/**
  * TimeRangeModal — Advanced Time Range Selection
  * Provides both preset time ranges and custom date/time selection in a modal dialog.
  */
@@ -168,6 +207,7 @@ export function TimeRangeModal({
   onClose,
   startDate,
   endDate,
+  activePreset = null,
   onApply,
   presets = DEFAULT_TIME_PRESETS,
 }: TimeRangeModalProps) {
@@ -177,27 +217,42 @@ export function TimeRangeModal({
   const [mode, setMode] = useState<'preset' | 'custom'>('preset');
   const timePresets = presets;
 
-  // Reset state when modal opens (null = not yet synced).
+  // Reset state when modal opens (null = not yet synced), restoring whichever
+  // tab/selection matches what's actually applied — so reopening the dialog
+  // shows the currently-in-effect range instead of always defaulting to
+  // "Quick Select" with nothing highlighted.
   // Compare dates by timestamp so new Date instances with the same value don't retrigger.
   const [resetSnapshot, setResetSnapshot] = useState<{
     open: boolean;
     startDate?: Date | null;
     endDate?: Date | null;
+    activePreset?: string | null;
   } | null>(null);
   if (
     resetSnapshot === null ||
     open !== resetSnapshot.open ||
     !sameDate(startDate, resetSnapshot.startDate) ||
-    !sameDate(endDate, resetSnapshot.endDate)
+    !sameDate(endDate, resetSnapshot.endDate) ||
+    activePreset !== resetSnapshot.activePreset
   ) {
-    setResetSnapshot({ open, startDate, endDate });
+    setResetSnapshot({ open, startDate, endDate, activePreset });
     if (open) {
       setCustomStartDate(startDate || null);
       setCustomEndDate(endDate || null);
-      setSelectedPreset(null);
-      setMode('preset');
+      if (activePreset && timePresets.some((p) => p.value === activePreset)) {
+        setSelectedPreset(activePreset);
+        setMode('preset');
+      } else if (startDate || endDate) {
+        setSelectedPreset(null);
+        setMode('custom');
+      } else {
+        setSelectedPreset(null);
+        setMode('preset');
+      }
     }
   }
+
+  const appliedRangeLabel = formatAppliedRange(startDate, endDate, activePreset, timePresets);
 
   // Handle preset selection
   const handlePresetSelect = (preset: TimePreset) => {
@@ -268,6 +323,27 @@ export function TimeRangeModal({
         </DialogTitle>
 
         <DialogContent sx={{ pb: 1 }}>
+          {/* Currently applied — always visible, independent of which tab is open */}
+          <Box
+            sx={{
+              mb: 3,
+              p: 1.5,
+              borderRadius: 1,
+              bgcolor: 'action.hover',
+              display: 'flex',
+              alignItems: 'baseline',
+              gap: 1,
+              flexWrap: 'wrap',
+            }}
+          >
+            <Typography variant="caption" color="text.secondary" sx={{ textTransform: 'uppercase', letterSpacing: 0.5 }}>
+              Currently applied
+            </Typography>
+            <Typography variant="body2" fontWeight={600}>
+              {appliedRangeLabel ?? 'All time'}
+            </Typography>
+          </Box>
+
           {/* Mode Selection */}
           <Box sx={{ mb: 3 }}>
             <Stack direction="row" spacing={1}>
@@ -326,7 +402,7 @@ export function TimeRangeModal({
 
               {selectedPreset && (
                 <Alert severity="info" sx={{ mt: 2 }}>
-                  <strong>Selected:</strong>{' '}
+                  <strong>Will apply:</strong>{' '}
                   {timePresets.find((p) => p.value === selectedPreset)?.description}
                   <br />
                   <strong>From:</strong>{' '}
@@ -396,7 +472,7 @@ export function TimeRangeModal({
 
               {customStartDate && customEndDate && isValidCustomRange() && (
                 <Alert severity="success" sx={{ mt: 2 }}>
-                  <strong>Custom Range:</strong>
+                  <strong>Will apply:</strong>
                   <br />
                   <strong>From:</strong> {format(customStartDate, 'MMM dd, yyyy HH:mm')}
                   <br />

--- a/web/dashboard/src/pages/UsagePage.tsx
+++ b/web/dashboard/src/pages/UsagePage.tsx
@@ -44,6 +44,7 @@ import { FloatingSubmitAlertFab } from '../components/common/FloatingSubmitAlert
 import {
   TimeRangeModal,
   USAGE_TIME_PRESETS,
+  formatAppliedRange,
 } from '../components/dashboard/TimeRangeModal.tsx';
 import EstimatedCostDisplay from '../components/shared/EstimatedCostDisplay.tsx';
 import { getFilterOptions, getUsageSummary, handleAPIError } from '../services/api.ts';
@@ -194,9 +195,11 @@ export function UsagePage() {
   };
 
   const costEnabled = summary?.cost_estimation_enabled === true;
-  const timeRangeLabel = datePreset
-    ? USAGE_TIME_PRESETS.find((p) => p.value === datePreset)?.label ?? `Range: ${datePreset}`
-    : 'Custom range';
+  // Always reflects the actual applied range — the preset label, or the
+  // real dates when a custom range is in effect — never a generic "Custom
+  // range" placeholder that hides what's actually being shown.
+  const timeRangeLabel =
+    formatAppliedRange(startDate, endDate, datePreset, USAGE_TIME_PRESETS) ?? 'Select time range';
   const hasActiveFilters = !!alertType || !!chainId;
   const handleClearFilters = () => {
     setAlertType(null);
@@ -491,6 +494,7 @@ export function UsagePage() {
         onClose={() => setTimeRangeOpen(false)}
         startDate={startDate}
         endDate={endDate}
+        activePreset={datePreset}
         onApply={handleTimeRangeApply}
         presets={USAGE_TIME_PRESETS}
       />


### PR DESCRIPTION
- TimeRangeModal: show a persistent "Currently applied" banner and restore the correct tab/selection on reopen (previously always reset to Quick Select with nothing highlighted, even for an active custom range or preset)
- Add formatAppliedRange() to render the real applied range (preset label, or actual custom dates) instead of a generic "Custom range" placeholder that hid the selection
- UsagePage and FilterPanel time-range buttons/chips now use it
- Add a "Last day" quick-select preset to the Usage page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Last day” quick-select option for time ranges (“Last 24 hours”).
  * Added a “Currently applied” summary banner to the time range modal.
  * Time range controls now consistently show the exact applied preset or start/end dates (including time when relevant).

* **Bug Fixes**
  * Improved synchronization between selected choices and the currently applied time range when opening the modal.
  * Updated range chips and button labels to always match the active filter state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->