### PR TITLE
Open system menu pages in the same tab

### DIFF
--- a/web/dashboard/src/components/common/FloatingSubmitAlertFab.tsx
+++ b/web/dashboard/src/components/common/FloatingSubmitAlertFab.tsx
@@ -1,18 +1,17 @@
 import { Fab, Tooltip } from '@mui/material';
 import { NotificationAdd } from '@mui/icons-material';
+import { Link as RouterLink } from 'react-router-dom';
+import { ROUTES } from '../../constants/routes.ts';
 
 /**
  * Reusable floating action button for quick alert submission access.
- * Uses proper anchor-based navigation to prevent tabnabbing security issues.
  */
 export function FloatingSubmitAlertFab() {
   return (
     <Tooltip title="Submit Manual Alert" placement="left">
       <Fab
-        component="a"
-        href="/submit-alert"
-        target="_blank"
-        rel="noopener noreferrer"
+        component={RouterLink}
+        to={ROUTES.SUBMIT_ALERT}
         color="primary"
         aria-label="submit alert"
         sx={{

--- a/web/dashboard/src/components/dashboard/DashboardView.tsx
+++ b/web/dashboard/src/components/dashboard/DashboardView.tsx
@@ -15,6 +15,7 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import type { MouseEvent } from 'react';
 import { Link as RouterLink } from 'react-router-dom';
+import { ROUTES } from '../../constants/routes.ts';
 import {
   Container,
   AppBar,
@@ -152,18 +153,6 @@ export function DashboardView() {
   };
   const handleMenuClose = () => {
     setMenuAnchorEl(null);
-  };
-  const handleManualAlertSubmission = () => {
-    window.open('/submit-alert', '_blank', 'noopener,noreferrer');
-    handleMenuClose();
-  };
-  const handleSystemStatus = () => {
-    window.open('/system', '_blank', 'noopener,noreferrer');
-    handleMenuClose();
-  };
-  const handleUsage = () => {
-    window.open('/usage', '_blank', 'noopener,noreferrer');
-    handleMenuClose();
   };
 
   // ── Active sessions state ──
@@ -1035,23 +1024,25 @@ export function DashboardView() {
         anchorEl={menuAnchorEl}
         open={Boolean(menuAnchorEl)}
         onClose={handleMenuClose}
-        MenuListProps={{
-          'aria-labelledby': 'navigation-menu-button',
+        slotProps={{
+          list: {
+            'aria-labelledby': 'navigation-menu-button',
+          },
         }}
       >
-        <MenuItem onClick={handleManualAlertSubmission}>
+        <MenuItem component={RouterLink} to={ROUTES.SUBMIT_ALERT} onClick={handleMenuClose}>
           <ListItemIcon>
             <SendIcon fontSize="small" />
           </ListItemIcon>
           <ListItemText>Manual Alert Submission</ListItemText>
         </MenuItem>
-        <MenuItem onClick={handleUsage}>
+        <MenuItem component={RouterLink} to={ROUTES.USAGE} onClick={handleMenuClose}>
           <ListItemIcon>
             <BarChartIcon fontSize="small" />
           </ListItemIcon>
           <ListItemText>Usage</ListItemText>
         </MenuItem>
-        <MenuItem onClick={handleSystemStatus}>
+        <MenuItem component={RouterLink} to={ROUTES.SYSTEM_STATUS} onClick={handleMenuClose}>
           <ListItemIcon>
             <DnsIcon fontSize="small" />
           </ListItemIcon>


### PR DESCRIPTION
- Use React Router links for Usage, System Status, and Manual Alert
- Navigate the submit-alert FAB in-tab instead of target=_blank

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Navigation Improvements**
  * Updated dashboard navigation to use in-app routing instead of opening destinations in new browser tabs.
  * Submit Alert, Usage, and System Status links now provide a smoother internal navigation experience while preserving existing styling and menu behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->