### PR TITLE
SANDBOX-1819: MCP custom_headers + SESSION_ID and cli-mcp session cleanup

### DIFF
--- a/cmd/tarsy/main.go
+++ b/cmd/tarsy/main.go
@@ -212,6 +212,7 @@ func main() {
 	// on the dashboard. The HealthMonitor handles recovery and warning cleanup.
 	mcpServerIDs := cfg.AllMCPServerIDs()
 	if len(mcpServerIDs) > 0 {
+		// Empty mcpSessionID omits X-Session-ID (no sandbox allocation/cleanup).
 		validationClient, err := mcpFactory.CreateClient(ctx, mcpServerIDs, "")
 		if err != nil {
 			slog.Warn("MCP client creation failed — starting degraded", "error", err)

--- a/cmd/tarsy/main.go
+++ b/cmd/tarsy/main.go
@@ -212,7 +212,7 @@ func main() {
 	// on the dashboard. The HealthMonitor handles recovery and warning cleanup.
 	mcpServerIDs := cfg.AllMCPServerIDs()
 	if len(mcpServerIDs) > 0 {
-		validationClient, err := mcpFactory.CreateClient(ctx, mcpServerIDs)
+		validationClient, err := mcpFactory.CreateClient(ctx, mcpServerIDs, "")
 		if err != nil {
 			slog.Warn("MCP client creation failed — starting degraded", "error", err)
 		} else {

--- a/deploy/config/tarsy.yaml.example
+++ b/deploy/config/tarsy.yaml.example
@@ -280,8 +280,10 @@ mcp_servers:
       verify_ssl: false
       custom_headers:
         # SESSION_ID is the agent execution ID (not the investigation session ID).
+        # Health/startup MCP probes omit this header; cli-mcp only requires it for bash tools.
         X-Session-ID: "{{.SESSION_ID}}"
       # Optional: DELETE when the agent/sub-agent MCP client closes (best-effort).
+      # Only runs for servers this execution actually requested.
       session_cleanup_url: "https://cli-mcp-server:8443/sessions/{{.SESSION_ID}}"
     instructions: |
       This server provides a sandboxed shell environment for cluster investigation.

--- a/deploy/config/tarsy.yaml.example
+++ b/deploy/config/tarsy.yaml.example
@@ -266,7 +266,7 @@ mcp_servers:
     summarization:
       size_threshold_tokens: 3000     # Summarize above 3000 tokens (default: 5000)
 
-  # Example: CLI sandbox MCP server (per-investigation bash pod)
+  # Example: CLI sandbox MCP server (one bash pod per agent/sub-agent execution)
   # Requires TARSy custom_headers support and CLI_MCP_BEARER_TOKEN (SA token).
   cli-mcp-server:
     transport:
@@ -279,8 +279,9 @@ mcp_servers:
       # instead of disabling verification (MITM can steal bearer + X-Session-ID).
       verify_ssl: false
       custom_headers:
-        X-Session-ID: "{{.SESSION_ID}}"  # Resolved per investigation; not an env var
-      # Optional: DELETE this URL after each investigation/chat (best-effort).
+        # SESSION_ID is the agent execution ID (not the investigation session ID).
+        X-Session-ID: "{{.SESSION_ID}}"
+      # Optional: DELETE when the agent/sub-agent MCP client closes (best-effort).
       session_cleanup_url: "https://cli-mcp-server:8443/sessions/{{.SESSION_ID}}"
     instructions: |
       This server provides a sandboxed shell environment for cluster investigation.

--- a/deploy/config/tarsy.yaml.example
+++ b/deploy/config/tarsy.yaml.example
@@ -266,6 +266,31 @@ mcp_servers:
     summarization:
       size_threshold_tokens: 3000     # Summarize above 3000 tokens (default: 5000)
 
+  # Example: CLI sandbox MCP server (per-investigation bash pod)
+  # Requires TARSy custom_headers support and CLI_MCP_BEARER_TOKEN (SA token).
+  cli-mcp-server:
+    transport:
+      type: "http"
+      url: "https://cli-mcp-server:8443/mcp"
+      bearer_token: "{{.CLI_MCP_BEARER_TOKEN}}"
+      timeout: 90
+      verify_ssl: false
+      custom_headers:
+        X-Session-ID: "{{.SESSION_ID}}"  # Resolved per investigation; not an env var
+    instructions: |
+      This server provides a sandboxed shell environment for cluster investigation.
+      You have full bash access: pipes, redirects, chaining, and standard Unix tools (jq, grep, awk).
+      Available CLIs: oc, kubectl.
+      Your workspace at /workspace is ephemeral — use it for intermediate files during investigation.
+      All cluster access is read-only via RBAC.
+    data_masking:
+      enabled: true
+      pattern_groups: ["kubernetes", "security"]
+      patterns: ["certificate", "token", "email"]
+    summarization:
+      enabled: true
+      summary_max_token_limit: 1200
+
   # Example: HTTP-based MCP server
   monitoring-server:
     transport:

--- a/deploy/config/tarsy.yaml.example
+++ b/deploy/config/tarsy.yaml.example
@@ -280,6 +280,8 @@ mcp_servers:
       verify_ssl: false
       custom_headers:
         X-Session-ID: "{{.SESSION_ID}}"  # Resolved per investigation; not an env var
+      # Optional: DELETE this URL after each investigation/chat (best-effort).
+      session_cleanup_url: "https://cli-mcp-server:8443/sessions/{{.SESSION_ID}}"
     instructions: |
       This server provides a sandboxed shell environment for cluster investigation.
       You have full bash access: pipes, redirects, chaining, and standard Unix tools (jq, grep, awk).

--- a/deploy/config/tarsy.yaml.example
+++ b/deploy/config/tarsy.yaml.example
@@ -274,6 +274,9 @@ mcp_servers:
       url: "https://cli-mcp-server:8443/mcp"
       bearer_token: "{{.CLI_MCP_BEARER_TOKEN}}"
       timeout: 90
+      # Prefer verify_ssl: true. false is shown for typical in-cluster self-signed
+      # service certs; for production, trust the service CA in TARSy's trust store
+      # instead of disabling verification (MITM can steal bearer + X-Session-ID).
       verify_ssl: false
       custom_headers:
         X-Session-ID: "{{.SESSION_ID}}"  # Resolved per investigation; not an env var

--- a/docs/functional-areas-design.md
+++ b/docs/functional-areas-design.md
@@ -716,7 +716,7 @@ When an alert provides `mcp_selection`, it **replaces** the chain/agent's MCP se
 **Key Implementation Files**:
 - `pkg/mcp/client.go` -- MCP Client wrapping Go SDK
 - `pkg/mcp/executor.go` -- ToolExecutor implementing `agent.ToolExecutor`
-- `pkg/mcp/client_factory.go` -- Per-session client creation
+- `pkg/mcp/client_factory.go` -- Per agent-execution client creation
 - `pkg/mcp/health.go` -- Background health monitoring
 - `pkg/mcp/transport.go` -- Transport creation (stdio/HTTP/SSE)
 - `pkg/mcp/params.go` -- Multi-format ActionInput parsing

--- a/docs/functional-areas-design.md
+++ b/docs/functional-areas-design.md
@@ -648,7 +648,7 @@ graph TB
 | File | Purpose |
 |------|---------|
 | `client.go` | Client -- MCP SDK session manager, per-server mutex |
-| `client_factory.go` | ClientFactory -- per-session client creation |
+| `client_factory.go` | ClientFactory -- per agent-execution client creation |
 | `executor.go` | ToolExecutor -- implements `agent.ToolExecutor` |
 | `params.go` | ActionInput parameter parsing (JSON/YAML/key-value/raw cascade) |
 | `router.go` | Tool name normalization (`server__tool` to `server.tool`), splitting, validation |

--- a/pkg/agent/orchestrator/runner.go
+++ b/pkg/agent/orchestrator/runner.go
@@ -392,7 +392,7 @@ func (r *SubAgentRunner) createSubAgentToolExecutor(
 	var executor agent.ToolExecutor
 	if r.deps.MCPFactory != nil && len(resolvedConfig.MCPServers) > 0 {
 		mcpExecutor, _, mcpErr := r.deps.MCPFactory.CreateToolExecutor(
-			ctx, resolvedConfig.MCPServers, nil,
+			ctx, resolvedConfig.MCPServers, nil, r.sessionID,
 		)
 		if mcpErr != nil {
 			logger.Warn("Failed to create MCP tool executor for sub-agent, using stub",

--- a/pkg/agent/orchestrator/runner.go
+++ b/pkg/agent/orchestrator/runner.go
@@ -254,7 +254,7 @@ func (r *SubAgentRunner) runSubAgent(
 		"sub_agent", exec.agentName,
 	)
 
-	toolExecutor := r.createSubAgentToolExecutor(ctx, resolvedConfig, logger)
+	toolExecutor := r.createSubAgentToolExecutor(ctx, resolvedConfig, exec.executionID, logger)
 	defer func() { _ = toolExecutor.Close() }()
 
 	// MemoryBriefing is intentionally omitted: Tier 4 memories are matched
@@ -384,15 +384,17 @@ func (r *SubAgentRunner) publishSubAgentStatus(ctx context.Context, executionID 
 
 // createSubAgentToolExecutor builds a ToolExecutor for the sub-agent's MCP servers,
 // optionally wrapped with a SkillToolExecutor for on-demand skills.
+// mcpSessionID is the sub-agent execution ID used for sandbox isolation (X-Session-ID).
 func (r *SubAgentRunner) createSubAgentToolExecutor(
 	ctx context.Context,
 	resolvedConfig *agent.ResolvedAgentConfig,
+	mcpSessionID string,
 	logger *slog.Logger,
 ) agent.ToolExecutor {
 	var executor agent.ToolExecutor
 	if r.deps.MCPFactory != nil && len(resolvedConfig.MCPServers) > 0 {
 		mcpExecutor, _, mcpErr := r.deps.MCPFactory.CreateToolExecutor(
-			ctx, resolvedConfig.MCPServers, nil, r.sessionID,
+			ctx, resolvedConfig.MCPServers, nil, mcpSessionID,
 		)
 		if mcpErr != nil {
 			logger.Warn("Failed to create MCP tool executor for sub-agent, using stub",

--- a/pkg/agent/orchestrator/runner_test.go
+++ b/pkg/agent/orchestrator/runner_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/codeready-toolchain/tarsy/pkg/agent"
 	"github.com/codeready-toolchain/tarsy/pkg/config"
 	"github.com/codeready-toolchain/tarsy/pkg/events"
+	"github.com/codeready-toolchain/tarsy/pkg/mcp"
 	"github.com/codeready-toolchain/tarsy/pkg/models"
 	"github.com/codeready-toolchain/tarsy/pkg/services"
 	testdb "github.com/codeready-toolchain/tarsy/test/database"
@@ -621,7 +622,29 @@ func TestSubAgentRunner_CancelAll_Idempotent(t *testing.T) {
 	r.CancelAll()
 }
 
-// ─── createSubAgentToolExecutor: memory wrapping ────────────────────────────
+// ─── createSubAgentToolExecutor: MCP session ID + memory wrapping ───────────
+
+func TestCreateSubAgentToolExecutor_ForwardsExecutionID(t *testing.T) {
+	var gotSessionID string
+	factory := mcp.NewTestClientFactory(config.NewMCPServerRegistry(nil), func(_ *mcp.Client, mcpSessionID string) {
+		gotSessionID = mcpSessionID
+	})
+
+	r := newMinimalRunner(1)
+	r.deps.MCPFactory = factory
+	r.sessionID = "investigation-must-not-be-used"
+
+	cfg := &agent.ResolvedAgentConfig{
+		AgentName:  "SessionWorker",
+		MCPServers: []string{"cli-mcp-server"},
+	}
+	exec := r.createSubAgentToolExecutor(t.Context(), cfg, "sub-exec-42", slog.Default())
+	require.NotNil(t, exec)
+	t.Cleanup(func() { _ = exec.Close() })
+	assert.Equal(t, "sub-exec-42", gotSessionID,
+		"sub-agent MCP client must use sub-agent execution ID as sandbox session key")
+	assert.NotEqual(t, r.sessionID, gotSessionID)
+}
 
 func TestCreateSubAgentToolExecutor_SkipsMemoryForNativeOnly(t *testing.T) {
 	wrapped := false

--- a/pkg/agent/orchestrator/runner_test.go
+++ b/pkg/agent/orchestrator/runner_test.go
@@ -642,7 +642,7 @@ func TestCreateSubAgentToolExecutor_SkipsMemoryForNativeOnly(t *testing.T) {
 				},
 			},
 		}
-		r.createSubAgentToolExecutor(t.Context(), cfg, slog.Default())
+		r.createSubAgentToolExecutor(t.Context(), cfg, "exec-native", slog.Default())
 		assert.False(t, wrapped, "memory wrapping should be skipped for native-only agents")
 	})
 
@@ -652,7 +652,7 @@ func TestCreateSubAgentToolExecutor_SkipsMemoryForNativeOnly(t *testing.T) {
 			AgentName:   "GeneralWorker",
 			LLMProvider: &config.LLMProviderConfig{},
 		}
-		r.createSubAgentToolExecutor(t.Context(), cfg, slog.Default())
+		r.createSubAgentToolExecutor(t.Context(), cfg, "exec-general", slog.Default())
 		assert.True(t, wrapped, "memory wrapping should apply for non-native agents")
 	})
 
@@ -667,7 +667,7 @@ func TestCreateSubAgentToolExecutor_SkipsMemoryForNativeOnly(t *testing.T) {
 				},
 			},
 		}
-		r.createSubAgentToolExecutor(t.Context(), cfg, slog.Default())
+		r.createSubAgentToolExecutor(t.Context(), cfg, "exec-hybrid", slog.Default())
 		assert.True(t, wrapped, "memory wrapping should apply when MCP servers are present")
 	})
 }

--- a/pkg/api/system_config.go
+++ b/pkg/api/system_config.go
@@ -35,15 +35,16 @@ type SystemConfigSkillResponse struct {
 
 // SanitizedTransport is the fail-closed MCP transport allowlist.
 type SanitizedTransport struct {
-	Type             string   `json:"type"`
-	Command          string   `json:"command,omitempty"`
-	Args             []string `json:"args,omitempty"`
-	URL              string   `json:"url,omitempty"`
-	VerifySSL        *bool    `json:"verify_ssl,omitempty"`
-	Timeout          int      `json:"timeout,omitempty"`
-	EnvKeys          []string `json:"env_keys,omitempty"`
-	CustomHeaderKeys []string `json:"custom_header_keys,omitempty"`
-	BearerTokenSet   bool     `json:"bearer_token_set"`
+	Type              string   `json:"type"`
+	Command           string   `json:"command,omitempty"`
+	Args              []string `json:"args,omitempty"`
+	URL               string   `json:"url,omitempty"`
+	VerifySSL         *bool    `json:"verify_ssl,omitempty"`
+	Timeout           int      `json:"timeout,omitempty"`
+	EnvKeys           []string `json:"env_keys,omitempty"`
+	CustomHeaderKeys  []string `json:"custom_header_keys,omitempty"`
+	SessionCleanupURL string   `json:"session_cleanup_url,omitempty"`
+	BearerTokenSet    bool     `json:"bearer_token_set"`
 }
 
 // MCPServerView is a sanitized MCP server config entry.
@@ -721,6 +722,15 @@ func sanitizeTransport(t config.TransportConfig) SanitizedTransport {
 		keys := slices.Collect(maps.Keys(t.CustomHeaders))
 		slices.Sort(keys)
 		out.CustomHeaderKeys = keys
+	}
+
+	if t.SessionCleanupURL != "" {
+		// sanitizeURL percent-encodes path braces; restore {{ }} so session
+		// templates remain readable in the config viewer.
+		cleaned := sanitizeURL(t.SessionCleanupURL)
+		cleaned = strings.ReplaceAll(cleaned, "%7B%7B", "{{")
+		cleaned = strings.ReplaceAll(cleaned, "%7D%7D", "}}")
+		out.SessionCleanupURL = cleaned
 	}
 
 	return out

--- a/pkg/api/system_config.go
+++ b/pkg/api/system_config.go
@@ -35,14 +35,15 @@ type SystemConfigSkillResponse struct {
 
 // SanitizedTransport is the fail-closed MCP transport allowlist.
 type SanitizedTransport struct {
-	Type           string   `json:"type"`
-	Command        string   `json:"command,omitempty"`
-	Args           []string `json:"args,omitempty"`
-	URL            string   `json:"url,omitempty"`
-	VerifySSL      *bool    `json:"verify_ssl,omitempty"`
-	Timeout        int      `json:"timeout,omitempty"`
-	EnvKeys        []string `json:"env_keys,omitempty"`
-	BearerTokenSet bool     `json:"bearer_token_set"`
+	Type             string   `json:"type"`
+	Command          string   `json:"command,omitempty"`
+	Args             []string `json:"args,omitempty"`
+	URL              string   `json:"url,omitempty"`
+	VerifySSL        *bool    `json:"verify_ssl,omitempty"`
+	Timeout          int      `json:"timeout,omitempty"`
+	EnvKeys          []string `json:"env_keys,omitempty"`
+	CustomHeaderKeys []string `json:"custom_header_keys,omitempty"`
+	BearerTokenSet   bool     `json:"bearer_token_set"`
 }
 
 // MCPServerView is a sanitized MCP server config entry.
@@ -714,6 +715,12 @@ func sanitizeTransport(t config.TransportConfig) SanitizedTransport {
 		keys := slices.Collect(maps.Keys(t.Env))
 		slices.Sort(keys)
 		out.EnvKeys = keys
+	}
+
+	if len(t.CustomHeaders) > 0 {
+		keys := slices.Collect(maps.Keys(t.CustomHeaders))
+		slices.Sort(keys)
+		out.CustomHeaderKeys = keys
 	}
 
 	return out

--- a/pkg/api/system_config_test.go
+++ b/pkg/api/system_config_test.go
@@ -49,6 +49,9 @@ func TestSanitizeTransport(t *testing.T) {
 			BearerToken: "live-bearer-token",
 			VerifySSL:   &verify,
 			Timeout:     30,
+			CustomHeaders: map[string]string{
+				"X-Session-ID": "{{.SESSION_ID}}",
+			},
 		})
 
 		assert.Equal(t, "http", got.Type)
@@ -58,13 +61,16 @@ func TestSanitizeTransport(t *testing.T) {
 		assert.Equal(t, 30, got.Timeout)
 		assert.Empty(t, got.Command)
 		assert.Nil(t, got.Args)
+		assert.Equal(t, []string{"X-Session-ID"}, got.CustomHeaderKeys)
 
 		raw, err := json.Marshal(got)
 		require.NoError(t, err)
 		assert.NotContains(t, string(raw), "live-secret")
 		assert.NotContains(t, string(raw), "live-query-secret")
 		assert.NotContains(t, string(raw), "live-bearer-token")
+		assert.NotContains(t, string(raw), "{{.SESSION_ID}}")
 		assert.Contains(t, string(raw), `"bearer_token_set":true`)
+		assert.Contains(t, string(raw), `"custom_header_keys"`)
 	})
 
 	t.Run("empty args and url omitted", func(t *testing.T) {

--- a/pkg/api/system_config_test.go
+++ b/pkg/api/system_config_test.go
@@ -52,6 +52,7 @@ func TestSanitizeTransport(t *testing.T) {
 			CustomHeaders: map[string]string{
 				"X-Session-ID": "{{.SESSION_ID}}",
 			},
+			SessionCleanupURL: "https://user:live-secret@mcp.example.com/sessions/{{.SESSION_ID}}?token=live-query-secret",
 		})
 
 		assert.Equal(t, "http", got.Type)
@@ -62,15 +63,19 @@ func TestSanitizeTransport(t *testing.T) {
 		assert.Empty(t, got.Command)
 		assert.Nil(t, got.Args)
 		assert.Equal(t, []string{"X-Session-ID"}, got.CustomHeaderKeys)
+		assert.Equal(t, "https://mcp.example.com/sessions/{{.SESSION_ID}}", got.SessionCleanupURL)
 
 		raw, err := json.Marshal(got)
 		require.NoError(t, err)
 		assert.NotContains(t, string(raw), "live-secret")
 		assert.NotContains(t, string(raw), "live-query-secret")
 		assert.NotContains(t, string(raw), "live-bearer-token")
-		assert.NotContains(t, string(raw), "{{.SESSION_ID}}")
 		assert.Contains(t, string(raw), `"bearer_token_set":true`)
 		assert.Contains(t, string(raw), `"custom_header_keys"`)
+		assert.Contains(t, string(raw), `"session_cleanup_url"`)
+		assert.Contains(t, string(raw), `/sessions/{{.SESSION_ID}}`)
+		// Custom header *values* must stay out of the sanitized view.
+		assert.NotContains(t, string(raw), `"X-Session-ID":"{{.SESSION_ID}}"`)
 	})
 
 	t.Run("empty args and url omitted", func(t *testing.T) {

--- a/pkg/config/envexpand.go
+++ b/pkg/config/envexpand.go
@@ -7,10 +7,10 @@ import (
 	"text/template"
 )
 
-// PerSessionTemplateVars are config template keys resolved per MCP client
+// PerExecutionTemplateVars are config template keys resolved per MCP client
 // (agent execution ID for SESSION_ID; not from the process environment at
 // config load time).
-var PerSessionTemplateVars = []string{"SESSION_ID"}
+var PerExecutionTemplateVars = []string{"SESSION_ID"}
 
 // ExpandEnv expands environment variables in YAML content using Go templates.
 // Uses {{.VAR_NAME}} syntax to avoid collision with $ in regex patterns.
@@ -54,10 +54,10 @@ func ExpandEnv(data []byte) []byte {
 		}
 	}
 
-	// Preserve per-session template variables so ExpandEnv does not blank them
+	// Preserve per-execution template variables so ExpandEnv does not blank them
 	// (missingkey=zero). These are resolved later when an MCP client is created
-	// for a specific investigation/chat session.
-	for _, key := range PerSessionTemplateVars {
+	// for a specific agent execution (sandbox session key).
+	for _, key := range PerExecutionTemplateVars {
 		envMap[key] = "{{." + key + "}}"
 	}
 

--- a/pkg/config/envexpand.go
+++ b/pkg/config/envexpand.go
@@ -8,7 +8,8 @@ import (
 )
 
 // PerSessionTemplateVars are config template keys resolved per MCP client
-// session (not from the process environment at config load time).
+// (agent execution ID for SESSION_ID; not from the process environment at
+// config load time).
 var PerSessionTemplateVars = []string{"SESSION_ID"}
 
 // ExpandEnv expands environment variables in YAML content using Go templates.

--- a/pkg/config/envexpand.go
+++ b/pkg/config/envexpand.go
@@ -7,6 +7,10 @@ import (
 	"text/template"
 )
 
+// PerSessionTemplateVars are config template keys resolved per MCP client
+// session (not from the process environment at config load time).
+var PerSessionTemplateVars = []string{"SESSION_ID"}
+
 // ExpandEnv expands environment variables in YAML content using Go templates.
 // Uses {{.VAR_NAME}} syntax to avoid collision with $ in regex patterns.
 //
@@ -47,6 +51,13 @@ func ExpandEnv(data []byte) []byte {
 			value := env[idx+1:]
 			envMap[key] = value
 		}
+	}
+
+	// Preserve per-session template variables so ExpandEnv does not blank them
+	// (missingkey=zero). These are resolved later when an MCP client is created
+	// for a specific investigation/chat session.
+	for _, key := range PerSessionTemplateVars {
+		envMap[key] = "{{." + key + "}}"
 	}
 
 	var buf bytes.Buffer

--- a/pkg/config/envexpand_test.go
+++ b/pkg/config/envexpand_test.go
@@ -49,7 +49,7 @@ func TestExpandEnv(t *testing.T) {
 			want:  "endpoint: ",
 		},
 		{
-			name:  "SESSION_ID preserved for per-session resolution",
+			name:  "SESSION_ID preserved for per-execution resolution",
 			input: "X-Session-ID: {{.SESSION_ID}}",
 			env:   map[string]string{},
 			want:  "X-Session-ID: {{.SESSION_ID}}",

--- a/pkg/config/envexpand_test.go
+++ b/pkg/config/envexpand_test.go
@@ -61,6 +61,21 @@ func TestExpandEnv(t *testing.T) {
 			want:  "X-Session-ID: {{.SESSION_ID}}",
 		},
 		{
+			name: "ENV secrets expanded while SESSION_ID preserved in same document",
+			input: `bearer_token: {{.API_TOKEN}}
+custom_headers:
+  X-Session-ID: "{{.SESSION_ID}}"
+session_cleanup_url: "https://cli/sessions/{{.SESSION_ID}}"`,
+			env: map[string]string{
+				"API_TOKEN":  "secret-token",
+				"SESSION_ID": "from-process-env",
+			},
+			want: `bearer_token: secret-token
+custom_headers:
+  X-Session-ID: "{{.SESSION_ID}}"
+session_cleanup_url: "https://cli/sessions/{{.SESSION_ID}}"`,
+		},
+		{
 			name:  "mixed present and missing variables",
 			input: "url: {{.PROTOCOL}}://{{.MISSING}}:{{.PORT}}",
 			env: map[string]string{

--- a/pkg/config/envexpand_test.go
+++ b/pkg/config/envexpand_test.go
@@ -49,6 +49,18 @@ func TestExpandEnv(t *testing.T) {
 			want:  "endpoint: ",
 		},
 		{
+			name:  "SESSION_ID preserved for per-session resolution",
+			input: "X-Session-ID: {{.SESSION_ID}}",
+			env:   map[string]string{},
+			want:  "X-Session-ID: {{.SESSION_ID}}",
+		},
+		{
+			name:  "SESSION_ID not taken from process environment",
+			input: "X-Session-ID: {{.SESSION_ID}}",
+			env:   map[string]string{"SESSION_ID": "should-not-use"},
+			want:  "X-Session-ID: {{.SESSION_ID}}",
+		},
+		{
 			name:  "mixed present and missing variables",
 			input: "url: {{.PROTOCOL}}://{{.MISSING}}:{{.PORT}}",
 			env: map[string]string{

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -18,10 +18,11 @@ type TransportConfig struct {
 	Env     map[string]string `yaml:"env,omitempty"` // Environment overrides for stdio subprocess
 
 	// For http/sse transport
-	URL         string `yaml:"url,omitempty"`
-	BearerToken string `yaml:"bearer_token,omitempty"`
-	VerifySSL   *bool  `yaml:"verify_ssl,omitempty"`
-	Timeout     int    `yaml:"timeout,omitempty"` // In seconds
+	URL           string            `yaml:"url,omitempty"`
+	BearerToken   string            `yaml:"bearer_token,omitempty"`
+	VerifySSL     *bool             `yaml:"verify_ssl,omitempty"`
+	Timeout       int               `yaml:"timeout,omitempty"` // In seconds
+	CustomHeaders map[string]string `yaml:"custom_headers,omitempty"` // Per-request headers; supports {{.SESSION_ID}}
 }
 
 // MaskingConfig defines data masking configuration for MCP servers

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -18,11 +18,12 @@ type TransportConfig struct {
 	Env     map[string]string `yaml:"env,omitempty"` // Environment overrides for stdio subprocess
 
 	// For http/sse transport
-	URL           string            `yaml:"url,omitempty"`
-	BearerToken   string            `yaml:"bearer_token,omitempty"`
-	VerifySSL     *bool             `yaml:"verify_ssl,omitempty"`
-	Timeout       int               `yaml:"timeout,omitempty"`        // In seconds
-	CustomHeaders map[string]string `yaml:"custom_headers,omitempty"` // Per-request headers; supports {{.SESSION_ID}}
+	URL               string            `yaml:"url,omitempty"`
+	BearerToken       string            `yaml:"bearer_token,omitempty"`
+	VerifySSL         *bool             `yaml:"verify_ssl,omitempty"`
+	Timeout           int               `yaml:"timeout,omitempty"`             // In seconds
+	CustomHeaders     map[string]string `yaml:"custom_headers,omitempty"`      // Per-request headers; supports {{.SESSION_ID}}
+	SessionCleanupURL string            `yaml:"session_cleanup_url,omitempty"` // Optional DELETE URL; supports {{.SESSION_ID}}
 }
 
 // MaskingConfig defines data masking configuration for MCP servers

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -22,8 +22,8 @@ type TransportConfig struct {
 	BearerToken       string            `yaml:"bearer_token,omitempty"`
 	VerifySSL         *bool             `yaml:"verify_ssl,omitempty"`
 	Timeout           int               `yaml:"timeout,omitempty"`             // In seconds
-	CustomHeaders     map[string]string `yaml:"custom_headers,omitempty"`      // Per-request headers; supports {{.SESSION_ID}}
-	SessionCleanupURL string            `yaml:"session_cleanup_url,omitempty"` // Optional DELETE URL; supports {{.SESSION_ID}}
+	CustomHeaders     map[string]string `yaml:"custom_headers,omitempty"`      // Per-request headers; {{.SESSION_ID}} = agent execution ID
+	SessionCleanupURL string            `yaml:"session_cleanup_url,omitempty"` // Optional DELETE URL; {{.SESSION_ID}} = agent execution ID
 }
 
 // MaskingConfig defines data masking configuration for MCP servers

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -21,7 +21,7 @@ type TransportConfig struct {
 	URL           string            `yaml:"url,omitempty"`
 	BearerToken   string            `yaml:"bearer_token,omitempty"`
 	VerifySSL     *bool             `yaml:"verify_ssl,omitempty"`
-	Timeout       int               `yaml:"timeout,omitempty"` // In seconds
+	Timeout       int               `yaml:"timeout,omitempty"`        // In seconds
 	CustomHeaders map[string]string `yaml:"custom_headers,omitempty"` // Per-request headers; supports {{.SESSION_ID}}
 }
 

--- a/pkg/mcp/client.go
+++ b/pkg/mcp/client.go
@@ -21,16 +21,17 @@ import (
 // Each Client instance is scoped to a single agent execution (or health check).
 // Thread-safe: sessions may be accessed from multiple goroutines during parallel stages.
 type Client struct {
-	registry  *config.MCPServerRegistry
-	sessionID string // agent execution ID for custom_headers (e.g. X-Session-ID); empty for health/startup
+	registry     *config.MCPServerRegistry
+	mcpSessionID string // agent execution ID for custom_headers (e.g. X-Session-ID); empty for health/startup
 
-	mu            sync.RWMutex
-	sessions      map[string]*mcpsdk.ClientSession // serverID → session
-	clients       map[string]*mcpsdk.Client        // serverID → client (for reconnection)
-	failedServers map[string]string                // serverID → error message
+	mu               sync.RWMutex
+	sessions         map[string]*mcpsdk.ClientSession // serverID → session
+	clients          map[string]*mcpsdk.Client        // serverID → client (for reconnection)
+	failedServers    map[string]string                // serverID → error message
+	requestedServers map[string]struct{}              // servers this client was asked to use
 
 	// Tool cache (populated on first ListTools, never invalidated — each Client
-	// instance is short-lived per session, so the cache is naturally fresh)
+	// instance is short-lived per agent execution, so the cache is naturally fresh)
 	toolCache   map[string][]*mcpsdk.Tool
 	toolCacheMu sync.RWMutex
 
@@ -41,34 +42,50 @@ type Client struct {
 }
 
 // newClient creates a new Client.
-// sessionID is the agent execution ID used to resolve per-execution transport
+// mcpSessionID is the agent execution ID used to resolve per-execution transport
 // templates (custom_headers, e.g. X-Session-ID). Empty for health/startup clients.
-func newClient(registry *config.MCPServerRegistry, sessionID string) *Client {
+func newClient(registry *config.MCPServerRegistry, mcpSessionID string) *Client {
 	return &Client{
-		registry:      registry,
-		sessionID:     sessionID,
-		sessions:      make(map[string]*mcpsdk.ClientSession),
-		clients:       make(map[string]*mcpsdk.Client),
-		failedServers: make(map[string]string),
-		toolCache:     make(map[string][]*mcpsdk.Tool),
-		logger:        slog.Default(),
+		registry:         registry,
+		mcpSessionID:     mcpSessionID,
+		sessions:         make(map[string]*mcpsdk.ClientSession),
+		clients:          make(map[string]*mcpsdk.Client),
+		failedServers:    make(map[string]string),
+		requestedServers: make(map[string]struct{}),
+		toolCache:        make(map[string][]*mcpsdk.Tool),
+		logger:           slog.Default(),
 	}
 }
 
 // sessionVars returns template variables for resolving custom_headers.
 func (c *Client) sessionVars() map[string]string {
-	if c.sessionID == "" {
+	if c.mcpSessionID == "" {
 		return nil
 	}
-	return map[string]string{"SESSION_ID": c.sessionID}
+	return map[string]string{"SESSION_ID": c.mcpSessionID}
+}
+
+// recordRequestedServers remembers server IDs for scoped sandbox cleanup on Close.
+func (c *Client) recordRequestedServers(serverIDs []string) {
+	if len(serverIDs) == 0 {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, id := range serverIDs {
+		if id != "" {
+			c.requestedServers[id] = struct{}{}
+		}
+	}
 }
 
 // Initialize connects to all configured MCP servers.
 // Servers that fail to connect are recorded in failedServers (retrievable via
 // FailedServers()). The caller decides how to handle partial failures:
 //   - Startup: check FailedServers() and log warnings (non-fatal, TARSy starts degraded)
-//   - Per-session: partial initialization is acceptable
+//   - Per agent execution: partial initialization is acceptable
 func (c *Client) Initialize(ctx context.Context, serverIDs []string) {
+	c.recordRequestedServers(serverIDs)
 	for _, serverID := range serverIDs {
 		if err := c.InitializeServer(ctx, serverID); err != nil {
 			c.mu.Lock()
@@ -84,6 +101,8 @@ func (c *Client) Initialize(ctx context.Context, serverIDs []string) {
 // Returns nil if already connected. Used for lazy initialization and recovery.
 // Uses per-server mutex to prevent concurrent initialization of the same server.
 func (c *Client) InitializeServer(ctx context.Context, serverID string) error {
+	c.recordRequestedServers([]string{serverID})
+
 	// Acquire per-server mutex to serialize initialization attempts
 	muI, _ := c.reinitMu.LoadOrStore(serverID, &sync.Mutex{})
 	mu := muI.(*sync.Mutex)
@@ -110,7 +129,7 @@ func (c *Client) initializeServerLocked(ctx context.Context, serverID string) er
 		return fmt.Errorf("server %q not found in registry: %w", serverID, err)
 	}
 
-	// Create transport (resolves custom_headers with per-session vars)
+	// Create transport (resolves custom_headers with per-execution vars)
 	transport, err := createTransport(serverCfg.Transport, c.sessionVars())
 	if err != nil {
 		return fmt.Errorf("failed to create transport for %q: %w", serverID, err)
@@ -322,21 +341,29 @@ func (c *Client) recreateSession(ctx context.Context, serverID string) error {
 }
 
 // Close shuts down all sessions and transports gracefully, then best-effort
-// deletes per-execution MCP sandboxes (e.g. cli-mcp-server) when sessionID is set.
+// deletes per-execution MCP sandboxes (e.g. cli-mcp-server) when mcpSessionID
+// is set. Idempotent: a second Close skips sandbox DELETE.
 func (c *Client) Close() error {
-	firstErr, sessionID, registry, logger := c.closeSessions()
+	firstErr, mcpSessionID, registry, serverIDs, logger := c.closeSessions()
 
 	// Sandbox cleanup outside mu — DELETE uses HTTP and must not hold client locks.
-	if sessionID != "" {
-		CleanupSessions(context.Background(), registry, sessionID, logger)
+	if mcpSessionID != "" {
+		CleanupSessions(context.Background(), registry, mcpSessionID, serverIDs, logger)
 	}
 
 	return firstErr
 }
 
 // closeSessions closes MCP sessions and clears client state under mu.
-// Returns the sandbox session key and registry for cleanup after unlock.
-func (c *Client) closeSessions() (firstErr error, sessionID string, registry *config.MCPServerRegistry, logger *slog.Logger) {
+// Returns the sandbox session key, requested server IDs, and registry for
+// cleanup after unlock. Clears mcpSessionID so a second Close is a no-op for DELETE.
+func (c *Client) closeSessions() (
+	firstErr error,
+	mcpSessionID string,
+	registry *config.MCPServerRegistry,
+	serverIDs []string,
+	logger *slog.Logger,
+) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -356,7 +383,16 @@ func (c *Client) closeSessions() (firstErr error, sessionID string, registry *co
 	c.toolCache = make(map[string][]*mcpsdk.Tool)
 	c.toolCacheMu.Unlock()
 
-	return firstErr, c.sessionID, c.registry, c.logger
+	mcpSessionID = c.mcpSessionID
+	c.mcpSessionID = "" // make Close idempotent for sandbox cleanup
+
+	serverIDs = make([]string, 0, len(c.requestedServers))
+	for id := range c.requestedServers {
+		serverIDs = append(serverIDs, id)
+	}
+	c.requestedServers = make(map[string]struct{})
+
+	return firstErr, mcpSessionID, c.registry, serverIDs, c.logger
 }
 
 // InvalidateToolCache removes the cached tool list for a server,

--- a/pkg/mcp/client.go
+++ b/pkg/mcp/client.go
@@ -25,6 +25,7 @@ type Client struct {
 	mcpSessionID string // agent execution ID for custom_headers (e.g. X-Session-ID); empty for health/startup
 
 	mu               sync.RWMutex
+	closed           bool                             // set by Close; Client is not reusable afterward
 	sessions         map[string]*mcpsdk.ClientSession // serverID → session
 	clients          map[string]*mcpsdk.Client        // serverID → client (for reconnection)
 	failedServers    map[string]string                // serverID → error message
@@ -75,6 +76,9 @@ func (c *Client) recordRequestedServers(serverIDs []string) {
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	if c.closed {
+		return
+	}
 	for _, id := range serverIDs {
 		if id != "" {
 			c.requestedServers[id] = struct{}{}
@@ -118,8 +122,12 @@ func (c *Client) InitializeServer(ctx context.Context, serverID string) error {
 // initializeServerLocked performs the actual server initialization.
 // Caller must hold the per-server reinitMu lock.
 func (c *Client) initializeServerLocked(ctx context.Context, serverID string) error {
-	// Check if already connected (under per-server lock, no TOCTOU race)
+	// Check closed / already connected (under per-server lock, no TOCTOU race)
 	c.mu.RLock()
+	if c.closed {
+		c.mu.RUnlock()
+		return fmt.Errorf("client is closed")
+	}
 	if _, exists := c.sessions[serverID]; exists {
 		c.mu.RUnlock()
 		return nil
@@ -159,8 +167,13 @@ func (c *Client) initializeServerLocked(ctx context.Context, serverID string) er
 		return fmt.Errorf("failed to connect to %q: %w", serverID, err)
 	}
 
-	// Store session and clear failure record
+	// Install only if still open — Close may have run during Connect.
 	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		_ = session.Close()
+		return fmt.Errorf("client is closed")
+	}
 	c.sessions[serverID] = session
 	c.clients[serverID] = client
 	delete(c.failedServers, serverID)
@@ -369,6 +382,8 @@ func (c *Client) closeSessions() (
 ) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+
+	c.closed = true
 
 	for id, session := range c.sessions {
 		if err := session.Close(); err != nil && firstErr == nil {

--- a/pkg/mcp/client.go
+++ b/pkg/mcp/client.go
@@ -344,7 +344,7 @@ func (c *Client) recreateSession(ctx context.Context, serverID string) error {
 // deletes per-execution MCP sandboxes (e.g. cli-mcp-server) when mcpSessionID
 // is set. Idempotent: a second Close skips sandbox DELETE.
 func (c *Client) Close() error {
-	firstErr, mcpSessionID, registry, serverIDs, logger := c.closeSessions()
+	mcpSessionID, registry, serverIDs, logger, firstErr := c.closeSessions()
 
 	// Sandbox cleanup outside mu — DELETE uses HTTP and must not hold client locks.
 	if mcpSessionID != "" {
@@ -358,11 +358,11 @@ func (c *Client) Close() error {
 // Returns the sandbox session key, requested server IDs, and registry for
 // cleanup after unlock. Clears mcpSessionID so a second Close is a no-op for DELETE.
 func (c *Client) closeSessions() (
-	firstErr error,
 	mcpSessionID string,
 	registry *config.MCPServerRegistry,
 	serverIDs []string,
 	logger *slog.Logger,
+	firstErr error,
 ) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -392,7 +392,7 @@ func (c *Client) closeSessions() (
 	}
 	c.requestedServers = make(map[string]struct{})
 
-	return firstErr, mcpSessionID, c.registry, serverIDs, c.logger
+	return mcpSessionID, c.registry, serverIDs, c.logger, firstErr
 }
 
 // InvalidateToolCache removes the cached tool list for a server,

--- a/pkg/mcp/client.go
+++ b/pkg/mcp/client.go
@@ -18,11 +18,11 @@ import (
 )
 
 // Client manages MCP SDK sessions for multiple servers.
-// Each Client instance is scoped to a single session (alert processing or health check).
+// Each Client instance is scoped to a single agent execution (or health check).
 // Thread-safe: sessions may be accessed from multiple goroutines during parallel stages.
 type Client struct {
 	registry  *config.MCPServerRegistry
-	sessionID string // investigation/chat session ID for custom_headers (e.g. X-Session-ID)
+	sessionID string // agent execution ID for custom_headers (e.g. X-Session-ID); empty for health/startup
 
 	mu            sync.RWMutex
 	sessions      map[string]*mcpsdk.ClientSession // serverID → session
@@ -41,8 +41,8 @@ type Client struct {
 }
 
 // newClient creates a new Client.
-// sessionID is the investigation/chat session ID used to resolve per-session
-// transport templates (custom_headers). Empty for health/startup clients.
+// sessionID is the agent execution ID used to resolve per-execution transport
+// templates (custom_headers, e.g. X-Session-ID). Empty for health/startup clients.
 func newClient(registry *config.MCPServerRegistry, sessionID string) *Client {
 	return &Client{
 		registry:      registry,
@@ -321,19 +321,31 @@ func (c *Client) recreateSession(ctx context.Context, serverID string) error {
 	return c.initializeServerLocked(reinitCtx, serverID)
 }
 
-// Close shuts down all sessions and transports gracefully.
+// Close shuts down all sessions and transports gracefully, then best-effort
+// deletes per-execution MCP sandboxes (e.g. cli-mcp-server) when sessionID is set.
 func (c *Client) Close() error {
+	firstErr, sessionID, registry, logger := c.closeSessions()
+
+	// Sandbox cleanup outside mu — DELETE uses HTTP and must not hold client locks.
+	if sessionID != "" {
+		CleanupSessions(context.Background(), registry, sessionID, logger)
+	}
+
+	return firstErr
+}
+
+// closeSessions closes MCP sessions and clears client state under mu.
+// Returns the sandbox session key and registry for cleanup after unlock.
+func (c *Client) closeSessions() (firstErr error, sessionID string, registry *config.MCPServerRegistry, logger *slog.Logger) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	var firstErr error
 	for id, session := range c.sessions {
 		if err := session.Close(); err != nil && firstErr == nil {
 			firstErr = fmt.Errorf("close session %q: %w", id, err)
 		}
 	}
 
-	// Clear all state
 	c.sessions = make(map[string]*mcpsdk.ClientSession)
 	c.clients = make(map[string]*mcpsdk.Client)
 	c.failedServers = make(map[string]string)
@@ -344,7 +356,7 @@ func (c *Client) Close() error {
 	c.toolCache = make(map[string][]*mcpsdk.Tool)
 	c.toolCacheMu.Unlock()
 
-	return firstErr
+	return firstErr, c.sessionID, c.registry, c.logger
 }
 
 // InvalidateToolCache removes the cached tool list for a server,

--- a/pkg/mcp/client.go
+++ b/pkg/mcp/client.go
@@ -21,7 +21,8 @@ import (
 // Each Client instance is scoped to a single session (alert processing or health check).
 // Thread-safe: sessions may be accessed from multiple goroutines during parallel stages.
 type Client struct {
-	registry *config.MCPServerRegistry
+	registry  *config.MCPServerRegistry
+	sessionID string // investigation/chat session ID for custom_headers (e.g. X-Session-ID)
 
 	mu            sync.RWMutex
 	sessions      map[string]*mcpsdk.ClientSession // serverID → session
@@ -40,15 +41,26 @@ type Client struct {
 }
 
 // newClient creates a new Client.
-func newClient(registry *config.MCPServerRegistry) *Client {
+// sessionID is the investigation/chat session ID used to resolve per-session
+// transport templates (custom_headers). Empty for health/startup clients.
+func newClient(registry *config.MCPServerRegistry, sessionID string) *Client {
 	return &Client{
 		registry:      registry,
+		sessionID:     sessionID,
 		sessions:      make(map[string]*mcpsdk.ClientSession),
 		clients:       make(map[string]*mcpsdk.Client),
 		failedServers: make(map[string]string),
 		toolCache:     make(map[string][]*mcpsdk.Tool),
 		logger:        slog.Default(),
 	}
+}
+
+// sessionVars returns template variables for resolving custom_headers.
+func (c *Client) sessionVars() map[string]string {
+	if c.sessionID == "" {
+		return nil
+	}
+	return map[string]string{"SESSION_ID": c.sessionID}
 }
 
 // Initialize connects to all configured MCP servers.
@@ -98,8 +110,8 @@ func (c *Client) initializeServerLocked(ctx context.Context, serverID string) er
 		return fmt.Errorf("server %q not found in registry: %w", serverID, err)
 	}
 
-	// Create transport
-	transport, err := createTransport(serverCfg.Transport)
+	// Create transport (resolves custom_headers with per-session vars)
+	transport, err := createTransport(serverCfg.Transport, c.sessionVars())
 	if err != nil {
 		return fmt.Errorf("failed to create transport for %q: %w", serverID, err)
 	}

--- a/pkg/mcp/client.go
+++ b/pkg/mcp/client.go
@@ -58,7 +58,10 @@ func newClient(registry *config.MCPServerRegistry, mcpSessionID string) *Client 
 }
 
 // sessionVars returns template variables for resolving custom_headers.
+// Synchronizes with Close(), which clears mcpSessionID under mu.
 func (c *Client) sessionVars() map[string]string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 	if c.mcpSessionID == "" {
 		return nil
 	}

--- a/pkg/mcp/client_factory.go
+++ b/pkg/mcp/client_factory.go
@@ -15,7 +15,7 @@ type ClientFactory struct {
 	// createClientFn overrides the default client creation logic.
 	// When non-nil, it is called instead of newClient + Initialize.
 	// Used by test infrastructure (see testing.go).
-	createClientFn func(ctx context.Context, serverIDs []string, sessionID string) (*Client, error)
+	createClientFn func(ctx context.Context, serverIDs []string, mcpSessionID string) (*Client, error)
 }
 
 // NewClientFactory creates a new factory.
@@ -25,28 +25,30 @@ func NewClientFactory(registry *config.MCPServerRegistry, maskingService *maskin
 }
 
 // CreateClient creates a new Client connected to the specified servers.
-// sessionID is the agent execution ID used to resolve per-execution custom_headers
-// (e.g. X-Session-ID). Pass an empty string for health checks and startup validation.
-// The caller is responsible for calling Close() when done (also triggers sandbox cleanup).
-func (f *ClientFactory) CreateClient(ctx context.Context, serverIDs []string, sessionID string) (*Client, error) {
+// mcpSessionID is the agent execution ID used to resolve per-execution custom_headers
+// (e.g. X-Session-ID). Pass an empty string for health checks and startup validation
+// (no sandbox header; cli-mcp only requires X-Session-ID for bash tool calls).
+// The caller is responsible for calling Close() when done (also triggers sandbox cleanup
+// for requested servers that declare session_cleanup_url).
+func (f *ClientFactory) CreateClient(ctx context.Context, serverIDs []string, mcpSessionID string) (*Client, error) {
 	if f.createClientFn != nil {
-		return f.createClientFn(ctx, serverIDs, sessionID)
+		return f.createClientFn(ctx, serverIDs, mcpSessionID)
 	}
-	client := newClient(f.registry, sessionID)
+	client := newClient(f.registry, mcpSessionID)
 	client.Initialize(ctx, serverIDs)
 	return client, nil
 }
 
 // CreateToolExecutor creates a fully-wired ToolExecutor for an agent execution.
 // This is the primary entry point used by the session executor.
-// sessionID is the agent execution ID forwarded for custom_headers resolution.
+// mcpSessionID is the agent execution ID forwarded for custom_headers resolution.
 func (f *ClientFactory) CreateToolExecutor(
 	ctx context.Context,
 	serverIDs []string,
 	toolFilter map[string][]string,
-	sessionID string,
+	mcpSessionID string,
 ) (*ToolExecutor, *Client, error) {
-	client, err := f.CreateClient(ctx, serverIDs, sessionID)
+	client, err := f.CreateClient(ctx, serverIDs, mcpSessionID)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/mcp/client_factory.go
+++ b/pkg/mcp/client_factory.go
@@ -7,7 +7,7 @@ import (
 	"github.com/codeready-toolchain/tarsy/pkg/masking"
 )
 
-// ClientFactory creates Client instances for sessions.
+// ClientFactory creates Client instances for agent executions.
 type ClientFactory struct {
 	registry       *config.MCPServerRegistry
 	maskingService *masking.Service
@@ -25,9 +25,9 @@ func NewClientFactory(registry *config.MCPServerRegistry, maskingService *maskin
 }
 
 // CreateClient creates a new Client connected to the specified servers.
-// sessionID is used to resolve per-session custom_headers (e.g. X-Session-ID).
-// Pass an empty string for health checks and startup validation.
-// The caller is responsible for calling Close() when done.
+// sessionID is the agent execution ID used to resolve per-execution custom_headers
+// (e.g. X-Session-ID). Pass an empty string for health checks and startup validation.
+// The caller is responsible for calling Close() when done (also triggers sandbox cleanup).
 func (f *ClientFactory) CreateClient(ctx context.Context, serverIDs []string, sessionID string) (*Client, error) {
 	if f.createClientFn != nil {
 		return f.createClientFn(ctx, serverIDs, sessionID)
@@ -37,9 +37,9 @@ func (f *ClientFactory) CreateClient(ctx context.Context, serverIDs []string, se
 	return client, nil
 }
 
-// CreateToolExecutor creates a fully-wired ToolExecutor for a session.
+// CreateToolExecutor creates a fully-wired ToolExecutor for an agent execution.
 // This is the primary entry point used by the session executor.
-// sessionID is forwarded to the MCP HTTP client for custom_headers resolution.
+// sessionID is the agent execution ID forwarded for custom_headers resolution.
 func (f *ClientFactory) CreateToolExecutor(
 	ctx context.Context,
 	serverIDs []string,

--- a/pkg/mcp/client_factory.go
+++ b/pkg/mcp/client_factory.go
@@ -14,8 +14,8 @@ type ClientFactory struct {
 
 	// createClientFn overrides the default client creation logic.
 	// When non-nil, it is called instead of newClient + Initialize.
-	// Used by test infrastructure (see export_test.go).
-	createClientFn func(ctx context.Context, serverIDs []string) (*Client, error)
+	// Used by test infrastructure (see testing.go).
+	createClientFn func(ctx context.Context, serverIDs []string, sessionID string) (*Client, error)
 }
 
 // NewClientFactory creates a new factory.
@@ -25,24 +25,28 @@ func NewClientFactory(registry *config.MCPServerRegistry, maskingService *maskin
 }
 
 // CreateClient creates a new Client connected to the specified servers.
+// sessionID is used to resolve per-session custom_headers (e.g. X-Session-ID).
+// Pass an empty string for health checks and startup validation.
 // The caller is responsible for calling Close() when done.
-func (f *ClientFactory) CreateClient(ctx context.Context, serverIDs []string) (*Client, error) {
+func (f *ClientFactory) CreateClient(ctx context.Context, serverIDs []string, sessionID string) (*Client, error) {
 	if f.createClientFn != nil {
-		return f.createClientFn(ctx, serverIDs)
+		return f.createClientFn(ctx, serverIDs, sessionID)
 	}
-	client := newClient(f.registry)
+	client := newClient(f.registry, sessionID)
 	client.Initialize(ctx, serverIDs)
 	return client, nil
 }
 
 // CreateToolExecutor creates a fully-wired ToolExecutor for a session.
 // This is the primary entry point used by the session executor.
+// sessionID is forwarded to the MCP HTTP client for custom_headers resolution.
 func (f *ClientFactory) CreateToolExecutor(
 	ctx context.Context,
 	serverIDs []string,
 	toolFilter map[string][]string,
+	sessionID string,
 ) (*ToolExecutor, *Client, error) {
-	client, err := f.CreateClient(ctx, serverIDs)
+	client, err := f.CreateClient(ctx, serverIDs, sessionID)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/mcp/client_factory_test.go
+++ b/pkg/mcp/client_factory_test.go
@@ -16,9 +16,9 @@ func TestClientFactory_CreateToolExecutor_PropagatesSessionID(t *testing.T) {
 	var gotSessionID string
 	factory := &ClientFactory{
 		registry: registry,
-		createClientFn: func(_ context.Context, _ []string, sessionID string) (*Client, error) {
-			gotSessionID = sessionID
-			return newClient(registry, sessionID), nil
+		createClientFn: func(_ context.Context, _ []string, mcpSessionID string) (*Client, error) {
+			gotSessionID = mcpSessionID
+			return newClient(registry, mcpSessionID), nil
 		},
 	}
 

--- a/pkg/mcp/client_factory_test.go
+++ b/pkg/mcp/client_factory_test.go
@@ -22,12 +22,12 @@ func TestClientFactory_CreateToolExecutor_PropagatesSessionID(t *testing.T) {
 		},
 	}
 
-	exec, client, err := factory.CreateToolExecutor(context.Background(), nil, nil, "inv-factory")
+	exec, client, err := factory.CreateToolExecutor(context.Background(), nil, nil, "exec-factory")
 	require.NoError(t, err)
 	require.NotNil(t, exec)
 	require.NotNil(t, client)
-	assert.Equal(t, "inv-factory", gotSessionID)
-	assert.Equal(t, map[string]string{"SESSION_ID": "inv-factory"}, client.sessionVars())
+	assert.Equal(t, "exec-factory", gotSessionID)
+	assert.Equal(t, map[string]string{"SESSION_ID": "exec-factory"}, client.sessionVars())
 }
 
 func TestClientFactory_CreateToolExecutor_Error(t *testing.T) {
@@ -38,7 +38,7 @@ func TestClientFactory_CreateToolExecutor_Error(t *testing.T) {
 		},
 	}
 
-	exec, client, err := factory.CreateToolExecutor(context.Background(), nil, nil, "inv-x")
+	exec, client, err := factory.CreateToolExecutor(context.Background(), nil, nil, "exec-x")
 	require.Error(t, err)
 	assert.Nil(t, exec)
 	assert.Nil(t, client)

--- a/pkg/mcp/client_factory_test.go
+++ b/pkg/mcp/client_factory_test.go
@@ -1,0 +1,45 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/codeready-toolchain/tarsy/pkg/config"
+)
+
+func TestClientFactory_CreateToolExecutor_PropagatesSessionID(t *testing.T) {
+	registry := config.NewMCPServerRegistry(nil)
+	var gotSessionID string
+	factory := &ClientFactory{
+		registry: registry,
+		createClientFn: func(_ context.Context, _ []string, sessionID string) (*Client, error) {
+			gotSessionID = sessionID
+			return newClient(registry, sessionID), nil
+		},
+	}
+
+	exec, client, err := factory.CreateToolExecutor(context.Background(), nil, nil, "inv-factory")
+	require.NoError(t, err)
+	require.NotNil(t, exec)
+	require.NotNil(t, client)
+	assert.Equal(t, "inv-factory", gotSessionID)
+	assert.Equal(t, map[string]string{"SESSION_ID": "inv-factory"}, client.sessionVars())
+}
+
+func TestClientFactory_CreateToolExecutor_Error(t *testing.T) {
+	factory := &ClientFactory{
+		registry: config.NewMCPServerRegistry(nil),
+		createClientFn: func(_ context.Context, _ []string, _ string) (*Client, error) {
+			return nil, errors.New("boom")
+		},
+	}
+
+	exec, client, err := factory.CreateToolExecutor(context.Background(), nil, nil, "inv-x")
+	require.Error(t, err)
+	assert.Nil(t, exec)
+	assert.Nil(t, client)
+}

--- a/pkg/mcp/client_test.go
+++ b/pkg/mcp/client_test.go
@@ -55,6 +55,14 @@ func startTestServer(t *testing.T, name string, tools map[string]mcpsdk.ToolHand
 	}
 }
 
+func TestClient_SessionVars(t *testing.T) {
+	empty := newClient(config.NewMCPServerRegistry(nil), "")
+	assert.Nil(t, empty.sessionVars())
+
+	withSession := newClient(config.NewMCPServerRegistry(nil), "inv-99")
+	assert.Equal(t, map[string]string{"SESSION_ID": "inv-99"}, withSession.sessionVars())
+}
+
 // connectClientDirect creates an Client with a pre-wired in-memory transport.
 // Bypasses the registry/createTransport path for unit testing the client itself.
 func connectClientDirect(t *testing.T, serverID string, transport *mcpsdk.InMemoryTransport) *Client {

--- a/pkg/mcp/client_test.go
+++ b/pkg/mcp/client_test.go
@@ -61,6 +61,9 @@ func TestClient_SessionVars(t *testing.T) {
 
 	withSession := newClient(config.NewMCPServerRegistry(nil), "exec-99")
 	assert.Equal(t, map[string]string{"SESSION_ID": "exec-99"}, withSession.sessionVars())
+
+	require.NoError(t, withSession.Close())
+	assert.Nil(t, withSession.sessionVars(), "Close clears mcpSessionID")
 }
 
 // connectClientDirect creates an Client with a pre-wired in-memory transport.

--- a/pkg/mcp/client_test.go
+++ b/pkg/mcp/client_test.go
@@ -61,7 +61,7 @@ func connectClientDirect(t *testing.T, serverID string, transport *mcpsdk.InMemo
 	t.Helper()
 	ctx := context.Background()
 
-	client := newClient(config.NewMCPServerRegistry(nil))
+	client := newClient(config.NewMCPServerRegistry(nil), "")
 
 	sdkClient := mcpsdk.NewClient(&mcpsdk.Implementation{
 		Name: "tarsy-test", Version: "test",
@@ -168,7 +168,7 @@ func TestClient_CallTool_ErrorResult(t *testing.T) {
 }
 
 func TestClient_ListTools_NoSession(t *testing.T) {
-	client := newClient(config.NewMCPServerRegistry(nil))
+	client := newClient(config.NewMCPServerRegistry(nil), "")
 
 	_, err := client.ListTools(context.Background(), "nonexistent")
 	assert.Error(t, err)
@@ -176,7 +176,7 @@ func TestClient_ListTools_NoSession(t *testing.T) {
 }
 
 func TestClient_CallTool_NoSession(t *testing.T) {
-	client := newClient(config.NewMCPServerRegistry(nil))
+	client := newClient(config.NewMCPServerRegistry(nil), "")
 
 	_, err := client.CallTool(context.Background(), "nonexistent", "tool", nil)
 	assert.Error(t, err)
@@ -197,7 +197,7 @@ func TestClient_HasSession(t *testing.T) {
 }
 
 func TestClient_FailedServers(t *testing.T) {
-	client := newClient(config.NewMCPServerRegistry(nil))
+	client := newClient(config.NewMCPServerRegistry(nil), "")
 
 	// Initialize with a non-existent server (failures recorded, not returned)
 	client.Initialize(context.Background(), []string{"nonexistent-server"})

--- a/pkg/mcp/client_test.go
+++ b/pkg/mcp/client_test.go
@@ -3,7 +3,11 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
 	"testing"
+	"time"
 
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/assert"
@@ -64,6 +68,99 @@ func TestClient_SessionVars(t *testing.T) {
 
 	require.NoError(t, withSession.Close())
 	assert.Nil(t, withSession.sessionVars(), "Close clears mcpSessionID")
+}
+
+func TestClient_SessionVars_ConcurrentWithClose(t *testing.T) {
+	client := newClient(config.NewMCPServerRegistry(nil), "exec-race")
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for range 100 {
+			vars := client.sessionVars()
+			if vars != nil {
+				assert.Equal(t, "exec-race", vars["SESSION_ID"])
+			}
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		require.NoError(t, client.Close())
+	}()
+	wg.Wait()
+
+	assert.Nil(t, client.sessionVars(), "sessionVars must be nil after Close")
+}
+
+func TestClient_InitializeServer_AfterClose(t *testing.T) {
+	registry := config.NewMCPServerRegistry(map[string]*config.MCPServerConfig{
+		"srv": {
+			Transport: config.TransportConfig{
+				Type:    config.TransportTypeStdio,
+				Command: "true",
+			},
+		},
+	})
+	client := newClient(registry, "exec-closed")
+	require.NoError(t, client.Close())
+
+	err := client.InitializeServer(context.Background(), "srv")
+	require.EqualError(t, err, "client is closed")
+	assert.False(t, client.HasSession("srv"))
+}
+
+// TestClient_Close_DropsInFlightInitialize ensures a session that finishes
+// Connect after Close is discarded instead of being installed.
+func TestClient_Close_DropsInFlightInitialize(t *testing.T) {
+	release := make(chan struct{})
+	started := make(chan struct{})
+
+	server := mcpsdk.NewServer(&mcpsdk.Implementation{Name: "gate-mcp", Version: "test"}, nil)
+	mcpHandler := mcpsdk.NewStreamableHTTPHandler(func(_ *http.Request) *mcpsdk.Server {
+		return server
+	}, &mcpsdk.StreamableHTTPOptions{JSONResponse: true, Stateless: true})
+
+	httpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-started:
+		default:
+			close(started)
+		}
+		<-release
+		mcpHandler.ServeHTTP(w, r)
+	}))
+	t.Cleanup(httpServer.Close)
+
+	verifySSL := false
+	registry := config.NewMCPServerRegistry(map[string]*config.MCPServerConfig{
+		"srv": {
+			Transport: config.TransportConfig{
+				Type:      config.TransportTypeHTTP,
+				URL:       httpServer.URL,
+				VerifySSL: &verifySSL,
+			},
+		},
+	})
+	client := newClient(registry, "exec-inflight")
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- client.InitializeServer(context.Background(), "srv")
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("InitializeServer never reached the MCP server")
+	}
+
+	require.NoError(t, client.Close())
+	close(release)
+
+	initErr := <-errCh
+	require.EqualError(t, initErr, "client is closed")
+	assert.False(t, client.HasSession("srv"), "late Connect must not install a session after Close")
 }
 
 // connectClientDirect creates an Client with a pre-wired in-memory transport.

--- a/pkg/mcp/client_test.go
+++ b/pkg/mcp/client_test.go
@@ -59,8 +59,8 @@ func TestClient_SessionVars(t *testing.T) {
 	empty := newClient(config.NewMCPServerRegistry(nil), "")
 	assert.Nil(t, empty.sessionVars())
 
-	withSession := newClient(config.NewMCPServerRegistry(nil), "inv-99")
-	assert.Equal(t, map[string]string{"SESSION_ID": "inv-99"}, withSession.sessionVars())
+	withSession := newClient(config.NewMCPServerRegistry(nil), "exec-99")
+	assert.Equal(t, map[string]string{"SESSION_ID": "exec-99"}, withSession.sessionVars())
 }
 
 // connectClientDirect creates an Client with a pre-wired in-memory transport.

--- a/pkg/mcp/executor.go
+++ b/pkg/mcp/executor.go
@@ -159,7 +159,8 @@ func (e *ToolExecutor) ListTools(ctx context.Context) ([]agent.ToolDefinition, e
 	return allTools, nil
 }
 
-// Close releases resources (MCP transports, subprocesses).
+// Close releases MCP transports/subprocesses and best-effort deletes
+// per-execution sandboxes for servers with session_cleanup_url.
 func (e *ToolExecutor) Close() error {
 	if e.client != nil {
 		return e.client.Close()

--- a/pkg/mcp/executor.go
+++ b/pkg/mcp/executor.go
@@ -19,7 +19,7 @@ import (
 var _ agent.ToolExecutor = (*ToolExecutor)(nil)
 
 // ToolExecutor implements agent.ToolExecutor backed by real MCP servers.
-// Created per-session by ClientFactory.
+// Created per agent execution by ClientFactory.
 type ToolExecutor struct {
 	client   *Client
 	registry *config.MCPServerRegistry

--- a/pkg/mcp/executor_test.go
+++ b/pkg/mcp/executor_test.go
@@ -18,7 +18,7 @@ func newTestExecutor(t *testing.T, servers map[string]map[string]mcpsdk.ToolHand
 	t.Helper()
 
 	registry := config.NewMCPServerRegistry(nil)
-	client := newClient(registry)
+	client := newClient(registry, "")
 	var serverIDs []string
 
 	for serverID, tools := range servers {
@@ -269,7 +269,7 @@ func TestToolExecutor_ListTools_MultiServer(t *testing.T) {
 
 func TestToolExecutor_ListTools_WithFilter(t *testing.T) {
 	registry := config.NewMCPServerRegistry(nil)
-	client := newClient(registry)
+	client := newClient(registry, "")
 
 	ts := startTestServer(t, "kubernetes", map[string]mcpsdk.ToolHandler{
 		"get_pods": func(_ context.Context, _ *mcpsdk.CallToolRequest) (*mcpsdk.CallToolResult, error) {
@@ -343,7 +343,7 @@ func newTestExecutorWithMasking(
 	maskingService := masking.NewService(registry, masking.AlertMaskingConfig{})
 
 	ts := startTestServer(t, serverID, tools)
-	client := newClient(registry)
+	client := newClient(registry, "")
 
 	sdkClient := mcpsdk.NewClient(&mcpsdk.Implementation{
 		Name: "tarsy-test", Version: "test",

--- a/pkg/mcp/health.go
+++ b/pkg/mcp/health.go
@@ -80,7 +80,7 @@ func (m *HealthMonitor) Start(ctx context.Context) {
 	// Initialize dedicated health client
 	m.clientMu.Lock()
 	serverIDs := m.registry.ServerIDs()
-	client, err := m.factory.CreateClient(ctx, serverIDs)
+	client, err := m.factory.CreateClient(ctx, serverIDs, "")
 	if err != nil {
 		m.logger.Warn("Health monitor: failed to create initial client", "error", err)
 	}
@@ -155,7 +155,7 @@ func (m *HealthMonitor) ensureClient(ctx context.Context) {
 	}
 
 	serverIDs := m.registry.ServerIDs()
-	client, err := m.factory.CreateClient(ctx, serverIDs)
+	client, err := m.factory.CreateClient(ctx, serverIDs, "")
 	if err != nil {
 		m.logger.Warn("Health monitor: failed to recreate client", "error", err)
 		return

--- a/pkg/mcp/health.go
+++ b/pkg/mcp/health.go
@@ -80,6 +80,7 @@ func (m *HealthMonitor) Start(ctx context.Context) {
 	// Initialize dedicated health client
 	m.clientMu.Lock()
 	serverIDs := m.registry.ServerIDs()
+	// Empty mcpSessionID: no X-Session-ID / no sandbox DELETE (health probes only).
 	client, err := m.factory.CreateClient(ctx, serverIDs, "")
 	if err != nil {
 		m.logger.Warn("Health monitor: failed to create initial client", "error", err)

--- a/pkg/mcp/health_test.go
+++ b/pkg/mcp/health_test.go
@@ -171,3 +171,23 @@ func TestHealthMonitor_StartStop(t *testing.T) {
 
 	monitor.Stop()
 }
+
+func TestHealthMonitor_EnsureClientRecovers(t *testing.T) {
+	registry := config.NewMCPServerRegistry(map[string]*config.MCPServerConfig{
+		"test-server": {
+			Transport: config.TransportConfig{
+				Type:    config.TransportTypeStdio,
+				Command: "true",
+			},
+		},
+	})
+	warningsSvc := services.NewSystemWarningsService()
+	factory := NewTestClientFactory(registry, func(c *Client) {})
+
+	monitor := NewHealthMonitor(factory, registry, warningsSvc)
+	require.Nil(t, monitor.client)
+
+	monitor.ensureClient(context.Background())
+	require.NotNil(t, monitor.client)
+	assert.Nil(t, monitor.client.sessionVars(), "health clients use empty session ID")
+}

--- a/pkg/mcp/health_test.go
+++ b/pkg/mcp/health_test.go
@@ -182,7 +182,7 @@ func TestHealthMonitor_EnsureClientRecovers(t *testing.T) {
 		},
 	})
 	warningsSvc := services.NewSystemWarningsService()
-	factory := NewTestClientFactory(registry, func(c *Client) {})
+	factory := NewTestClientFactory(registry, func(_ *Client) {})
 
 	monitor := NewHealthMonitor(factory, registry, warningsSvc)
 	require.Nil(t, monitor.client)

--- a/pkg/mcp/health_test.go
+++ b/pkg/mcp/health_test.go
@@ -182,7 +182,7 @@ func TestHealthMonitor_EnsureClientRecovers(t *testing.T) {
 		},
 	})
 	warningsSvc := services.NewSystemWarningsService()
-	factory := NewTestClientFactory(registry, func(_ *Client) {})
+	factory := NewTestClientFactory(registry, func(_ *Client, _ string) {})
 
 	monitor := NewHealthMonitor(factory, registry, warningsSvc)
 	require.Nil(t, monitor.client)

--- a/pkg/mcp/health_test.go
+++ b/pkg/mcp/health_test.go
@@ -31,7 +31,7 @@ func TestHealthMonitor_HealthyServer(t *testing.T) {
 	monitor.pingTimeout = 5 * time.Second
 
 	// Wire client directly for test
-	client := newClient(registry)
+	client := newClient(registry, "")
 	sdkClient := mcpsdk.NewClient(&mcpsdk.Implementation{Name: "test", Version: "test"}, nil)
 	session, err := sdkClient.Connect(context.Background(), ts.clientTransport, nil)
 	require.NoError(t, err)
@@ -70,7 +70,7 @@ func TestHealthMonitor_UnhealthyServer(t *testing.T) {
 	monitor.pingTimeout = 1 * time.Second
 
 	// Create client with no sessions (simulating connection failure)
-	client := newClient(registry)
+	client := newClient(registry, "")
 	monitor.client = client
 
 	// Check a non-existent server session
@@ -108,7 +108,7 @@ func TestHealthMonitor_WarningClearedOnRecovery(t *testing.T) {
 
 	// Create healthy client
 	monitor := NewHealthMonitor(factory, registry, warningsSvc)
-	client := newClient(registry)
+	client := newClient(registry, "")
 	sdkClient := mcpsdk.NewClient(&mcpsdk.Implementation{Name: "test", Version: "test"}, nil)
 	session, err := sdkClient.Connect(context.Background(), ts.clientTransport, nil)
 	require.NoError(t, err)
@@ -147,7 +147,7 @@ func TestHealthMonitor_StartStop(t *testing.T) {
 	monitor.checkInterval = 50 * time.Millisecond
 
 	// Pre-wire a client so Start doesn't fail
-	client := newClient(registry)
+	client := newClient(registry, "")
 	sdkClient := mcpsdk.NewClient(&mcpsdk.Implementation{Name: "test", Version: "test"}, nil)
 	session, err := sdkClient.Connect(context.Background(), ts.clientTransport, nil)
 	require.NoError(t, err)

--- a/pkg/mcp/integration_test.go
+++ b/pkg/mcp/integration_test.go
@@ -88,7 +88,7 @@ func TestIntegration_MultiServer_Routing(t *testing.T) {
 
 	// Build multi-server executor
 	registry := config.NewMCPServerRegistry(nil)
-	client := newClient(registry)
+	client := newClient(registry, "")
 	wireSession(t, client, "kubernetes", k8sServer.clientTransport)
 	wireSession(t, client, "github", ghServer.clientTransport)
 
@@ -188,12 +188,12 @@ func TestIntegration_PerSessionIsolation(t *testing.T) {
 	// Create two independent executors
 	registry := config.NewMCPServerRegistry(nil)
 
-	client1 := newClient(registry)
+	client1 := newClient(registry, "")
 	wireSession(t, client1, "server1", ts1.clientTransport)
 	exec1 := NewToolExecutor(client1, registry, []string{"server1"}, nil, nil)
 	t.Cleanup(func() { _ = exec1.Close() })
 
-	client2 := newClient(registry)
+	client2 := newClient(registry, "")
 	wireSession(t, client2, "server2", ts2.clientTransport)
 	exec2 := NewToolExecutor(client2, registry, []string{"server2"}, nil, nil)
 	t.Cleanup(func() { _ = exec2.Close() })
@@ -226,7 +226,7 @@ func TestIntegration_HealthMonitor_Lifecycle(t *testing.T) {
 	monitor := NewHealthMonitor(factory, registry, warningsSvc)
 
 	// Wire healthy client
-	client := newClient(registry)
+	client := newClient(registry, "")
 	wireSession(t, client, "test-server", ts.clientTransport)
 	t.Cleanup(func() { _ = client.Close() })
 	monitor.client = client
@@ -286,7 +286,7 @@ func newTestExecutorFromTransport(t *testing.T, serverID string, transport *mcps
 	t.Helper()
 
 	registry := config.NewMCPServerRegistry(nil)
-	client := newClient(registry)
+	client := newClient(registry, "")
 	wireSession(t, client, serverID, transport)
 
 	executor := NewToolExecutor(client, registry, []string{serverID}, nil, nil)
@@ -322,7 +322,7 @@ func TestIntegration_ToolFilter(t *testing.T) {
 	})
 
 	registry := config.NewMCPServerRegistry(nil)
-	client := newClient(registry)
+	client := newClient(registry, "")
 	wireSession(t, client, "kubernetes", ts.clientTransport)
 
 	// Only allow get_pods
@@ -356,7 +356,7 @@ func TestIntegration_ToolFilter(t *testing.T) {
 // TestIntegration_FailedServers tests failed server tracking through the pipeline.
 func TestIntegration_FailedServers(t *testing.T) {
 	registry := config.NewMCPServerRegistry(nil)
-	client := newClient(registry)
+	client := newClient(registry, "")
 
 	// Initialize with a non-existent server (failures recorded, not returned)
 	client.Initialize(context.Background(), []string{"broken-server"})
@@ -386,7 +386,7 @@ func TestIntegration_HealthMonitor_ToolCaching(t *testing.T) {
 	monitor.pingTimeout = 5 * time.Second
 
 	// Wire client
-	client := newClient(registry)
+	client := newClient(registry, "")
 	wireSession(t, client, "test-server", ts.clientTransport)
 	t.Cleanup(func() { _ = client.Close() })
 	monitor.client = client

--- a/pkg/mcp/session_cleanup.go
+++ b/pkg/mcp/session_cleanup.go
@@ -13,8 +13,9 @@ import (
 
 const sessionCleanupTimeout = 15 * time.Second
 
-// CleanupSessions best-effort deletes per-investigation sandbox sessions on
+// CleanupSessions best-effort deletes per-execution sandbox sessions on
 // MCP servers that declare session_cleanup_url (e.g. cli-mcp-server).
+// sessionID is the agent execution ID used as X-Session-ID.
 // Failures are logged and never returned — idle TTL remains the safety net.
 func CleanupSessions(ctx context.Context, registry *config.MCPServerRegistry, sessionID string, logger *slog.Logger) {
 	if registry == nil || sessionID == "" {

--- a/pkg/mcp/session_cleanup.go
+++ b/pkg/mcp/session_cleanup.go
@@ -13,32 +13,46 @@ import (
 
 const sessionCleanupTimeout = 15 * time.Second
 
-// CleanupSessions best-effort deletes per-execution sandbox sessions on
-// MCP servers that declare session_cleanup_url (e.g. cli-mcp-server).
-// sessionID is the agent execution ID used as X-Session-ID.
+// CleanupSessions best-effort deletes per-execution sandbox sessions on the
+// given MCP servers that declare session_cleanup_url (e.g. cli-mcp-server).
+// mcpSessionID is the agent execution ID used as X-Session-ID.
+// Only serverIDs requested by the closing client are considered — other
+// registry servers are left alone.
 // Failures are logged and never returned — idle TTL remains the safety net.
-func CleanupSessions(ctx context.Context, registry *config.MCPServerRegistry, sessionID string, logger *slog.Logger) {
-	if registry == nil || sessionID == "" {
+func CleanupSessions(
+	ctx context.Context,
+	registry *config.MCPServerRegistry,
+	mcpSessionID string,
+	serverIDs []string,
+	logger *slog.Logger,
+) {
+	if registry == nil || mcpSessionID == "" || len(serverIDs) == 0 {
 		return
 	}
 	if logger == nil {
 		logger = slog.Default()
 	}
 
-	for serverID, serverCfg := range registry.GetAll() {
-		if serverCfg == nil || !needsSessionCleanup(serverCfg.Transport) {
+	// Cap total cleanup time so a hung endpoint cannot stall workers for
+	// longer than one cleanup timeout across all servers.
+	cleanupCtx, cancel := context.WithTimeout(ctx, sessionCleanupTimeout)
+	defer cancel()
+
+	for _, serverID := range serverIDs {
+		serverCfg, err := registry.Get(serverID)
+		if err != nil || serverCfg == nil || !needsSessionCleanup(serverCfg.Transport) {
 			continue
 		}
-		if err := deleteSession(ctx, serverCfg.Transport, sessionID); err != nil {
+		if err := deleteSession(cleanupCtx, serverCfg.Transport, mcpSessionID); err != nil {
 			logger.Warn("MCP session cleanup failed",
 				"server", serverID,
-				"session_id", sessionID,
+				"mcp_session_id", mcpSessionID,
 				"error", err)
 			continue
 		}
 		logger.Info("MCP session cleaned up",
 			"server", serverID,
-			"session_id", sessionID)
+			"mcp_session_id", mcpSessionID)
 	}
 }
 
@@ -48,8 +62,8 @@ func needsSessionCleanup(cfg config.TransportConfig) bool {
 	return cfg.SessionCleanupURL != ""
 }
 
-func deleteSession(ctx context.Context, cfg config.TransportConfig, sessionID string) error {
-	endpoint, err := resolveSessionCleanupURL(cfg.SessionCleanupURL, sessionID)
+func deleteSession(ctx context.Context, cfg config.TransportConfig, mcpSessionID string) error {
+	endpoint, err := resolveSessionCleanupURL(cfg.SessionCleanupURL, mcpSessionID)
 	if err != nil {
 		return err
 	}
@@ -59,7 +73,7 @@ func deleteSession(ctx context.Context, cfg config.TransportConfig, sessionID st
 	cleanupCfg := cfg
 	cleanupCfg.URL = endpoint
 
-	client, err := buildHTTPClient(cleanupCfg, map[string]string{"SESSION_ID": sessionID})
+	client, err := buildHTTPClient(cleanupCfg, map[string]string{"SESSION_ID": mcpSessionID})
 	if err != nil {
 		return err
 	}
@@ -87,12 +101,12 @@ func deleteSession(ctx context.Context, cfg config.TransportConfig, sessionID st
 }
 
 // resolveSessionCleanupURL expands {{.SESSION_ID}} in the configured cleanup URL.
-func resolveSessionCleanupURL(rawURL, sessionID string) (string, error) {
+func resolveSessionCleanupURL(rawURL, mcpSessionID string) (string, error) {
 	if rawURL == "" {
 		return "", fmt.Errorf("session_cleanup_url is empty")
 	}
 	resolved, err := resolveHeaderTemplates(map[string]string{"url": rawURL}, map[string]string{
-		"SESSION_ID": sessionID,
+		"SESSION_ID": mcpSessionID,
 	})
 	if err != nil {
 		return "", err

--- a/pkg/mcp/session_cleanup.go
+++ b/pkg/mcp/session_cleanup.go
@@ -1,0 +1,109 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/codeready-toolchain/tarsy/pkg/config"
+)
+
+const sessionCleanupTimeout = 15 * time.Second
+
+// CleanupSessions best-effort deletes per-investigation sandbox sessions on
+// MCP servers that use session-scoped custom_headers (e.g. cli-mcp-server).
+// Failures are logged and never returned — idle TTL remains the safety net.
+func CleanupSessions(ctx context.Context, registry *config.MCPServerRegistry, sessionID string, logger *slog.Logger) {
+	if registry == nil || sessionID == "" {
+		return
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	for serverID, serverCfg := range registry.GetAll() {
+		if serverCfg == nil || !needsSessionCleanup(serverCfg.Transport) {
+			continue
+		}
+		if err := deleteSession(ctx, serverCfg.Transport, sessionID); err != nil {
+			logger.Warn("MCP session cleanup failed",
+				"server", serverID,
+				"session_id", sessionID,
+				"error", err)
+			continue
+		}
+		logger.Info("MCP session cleaned up",
+			"server", serverID,
+			"session_id", sessionID)
+	}
+}
+
+// needsSessionCleanup reports whether the transport is an HTTP(S) MCP server
+// that injects a session-scoped header (cli-mcp-server pattern).
+func needsSessionCleanup(cfg config.TransportConfig) bool {
+	if cfg.Type != config.TransportTypeHTTP && cfg.Type != config.TransportTypeSSE {
+		return false
+	}
+	if cfg.URL == "" {
+		return false
+	}
+	for _, value := range cfg.CustomHeaders {
+		if strings.Contains(value, "{{.SESSION_ID}}") {
+			return true
+		}
+	}
+	return false
+}
+
+func deleteSession(ctx context.Context, cfg config.TransportConfig, sessionID string) error {
+	endpoint, err := sessionCleanupURL(cfg.URL, sessionID)
+	if err != nil {
+		return err
+	}
+
+	client, err := buildHTTPClient(cfg, map[string]string{"SESSION_ID": sessionID})
+	if err != nil {
+		return err
+	}
+	// Prefer a short dedicated timeout for cleanup.
+	client.Timeout = sessionCleanupTimeout
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, endpoint, nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	// 404 means already gone — treat as success.
+	if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusNoContent ||
+		resp.StatusCode == http.StatusOK {
+		return nil
+	}
+	return fmt.Errorf("unexpected status %d", resp.StatusCode)
+}
+
+// sessionCleanupURL derives DELETE /sessions/{id} from the MCP /mcp endpoint URL.
+func sessionCleanupURL(mcpURL, sessionID string) (string, error) {
+	u, err := url.Parse(mcpURL)
+	if err != nil {
+		return "", fmt.Errorf("parse mcp url: %w", err)
+	}
+	// Strip trailing /mcp (with or without trailing slash) to get the service base.
+	path := strings.TrimSuffix(u.Path, "/")
+	path = strings.TrimSuffix(path, "/mcp")
+	u.Path = strings.TrimSuffix(path, "/") + "/sessions/" + url.PathEscape(sessionID)
+	u.RawQuery = ""
+	u.Fragment = ""
+	return u.String(), nil
+}

--- a/pkg/mcp/session_cleanup.go
+++ b/pkg/mcp/session_cleanup.go
@@ -6,8 +6,6 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
-	"net/url"
-	"strings"
 	"time"
 
 	"github.com/codeready-toolchain/tarsy/pkg/config"
@@ -16,7 +14,7 @@ import (
 const sessionCleanupTimeout = 15 * time.Second
 
 // CleanupSessions best-effort deletes per-investigation sandbox sessions on
-// MCP servers that use session-scoped custom_headers (e.g. cli-mcp-server).
+// MCP servers that declare session_cleanup_url (e.g. cli-mcp-server).
 // Failures are logged and never returned — idle TTL remains the safety net.
 func CleanupSessions(ctx context.Context, registry *config.MCPServerRegistry, sessionID string, logger *slog.Logger) {
 	if registry == nil || sessionID == "" {
@@ -43,30 +41,24 @@ func CleanupSessions(ctx context.Context, registry *config.MCPServerRegistry, se
 	}
 }
 
-// needsSessionCleanup reports whether the transport is an HTTP(S) MCP server
-// that injects a session-scoped header (cli-mcp-server pattern).
+// needsSessionCleanup reports whether the transport opts into explicit session
+// cleanup via session_cleanup_url.
 func needsSessionCleanup(cfg config.TransportConfig) bool {
-	if cfg.Type != config.TransportTypeHTTP && cfg.Type != config.TransportTypeSSE {
-		return false
-	}
-	if cfg.URL == "" {
-		return false
-	}
-	for _, value := range cfg.CustomHeaders {
-		if strings.Contains(value, "{{.SESSION_ID}}") {
-			return true
-		}
-	}
-	return false
+	return cfg.SessionCleanupURL != ""
 }
 
 func deleteSession(ctx context.Context, cfg config.TransportConfig, sessionID string) error {
-	endpoint, err := sessionCleanupURL(cfg.URL, sessionID)
+	endpoint, err := resolveSessionCleanupURL(cfg.SessionCleanupURL, sessionID)
 	if err != nil {
 		return err
 	}
 
-	client, err := buildHTTPClient(cfg, map[string]string{"SESSION_ID": sessionID})
+	// Use the cleanup endpoint as the client URL so bearer/custom headers are
+	// host-scoped to the DELETE target (which may differ from the MCP /mcp path).
+	cleanupCfg := cfg
+	cleanupCfg.URL = endpoint
+
+	client, err := buildHTTPClient(cleanupCfg, map[string]string{"SESSION_ID": sessionID})
 	if err != nil {
 		return err
 	}
@@ -93,17 +85,20 @@ func deleteSession(ctx context.Context, cfg config.TransportConfig, sessionID st
 	return fmt.Errorf("unexpected status %d", resp.StatusCode)
 }
 
-// sessionCleanupURL derives DELETE /sessions/{id} from the MCP /mcp endpoint URL.
-func sessionCleanupURL(mcpURL, sessionID string) (string, error) {
-	u, err := url.Parse(mcpURL)
-	if err != nil {
-		return "", fmt.Errorf("parse mcp url: %w", err)
+// resolveSessionCleanupURL expands {{.SESSION_ID}} in the configured cleanup URL.
+func resolveSessionCleanupURL(rawURL, sessionID string) (string, error) {
+	if rawURL == "" {
+		return "", fmt.Errorf("session_cleanup_url is empty")
 	}
-	// Strip trailing /mcp (with or without trailing slash) to get the service base.
-	path := strings.TrimSuffix(u.Path, "/")
-	path = strings.TrimSuffix(path, "/mcp")
-	u.Path = strings.TrimSuffix(path, "/") + "/sessions/" + url.PathEscape(sessionID)
-	u.RawQuery = ""
-	u.Fragment = ""
-	return u.String(), nil
+	resolved, err := resolveHeaderTemplates(map[string]string{"url": rawURL}, map[string]string{
+		"SESSION_ID": sessionID,
+	})
+	if err != nil {
+		return "", err
+	}
+	endpoint := resolved["url"]
+	if endpoint == "" {
+		return "", fmt.Errorf("session_cleanup_url resolved to empty")
+	}
+	return endpoint, nil
 }

--- a/pkg/mcp/session_cleanup_test.go
+++ b/pkg/mcp/session_cleanup_test.go
@@ -15,20 +15,23 @@ import (
 	"github.com/codeready-toolchain/tarsy/pkg/config"
 )
 
-func TestSessionCleanupURL(t *testing.T) {
-	got, err := sessionCleanupURL("https://cli-mcp-server:8443/mcp", "sess-1")
+func TestResolveSessionCleanupURL(t *testing.T) {
+	got, err := resolveSessionCleanupURL("https://cli-mcp-server:8443/sessions/{{.SESSION_ID}}", "sess-1")
 	require.NoError(t, err)
 	assert.Equal(t, "https://cli-mcp-server:8443/sessions/sess-1", got)
 
-	got, err = sessionCleanupURL("https://cli-mcp-server:8443/mcp/", "sess-1")
-	require.NoError(t, err)
-	assert.Equal(t, "https://cli-mcp-server:8443/sessions/sess-1", got)
-
-	got, err = sessionCleanupURL("https://cli-mcp-server:8443/api/mcp?x=1#frag", "sess-2")
+	got, err = resolveSessionCleanupURL("https://cli-mcp-server:8443/api/sessions/{{.SESSION_ID}}", "sess-2")
 	require.NoError(t, err)
 	assert.Equal(t, "https://cli-mcp-server:8443/api/sessions/sess-2", got)
 
-	_, err = sessionCleanupURL("://bad", "sess-1")
+	got, err = resolveSessionCleanupURL("https://cli-mcp-server:8443/sessions/static", "ignored")
+	require.NoError(t, err)
+	assert.Equal(t, "https://cli-mcp-server:8443/sessions/static", got)
+
+	_, err = resolveSessionCleanupURL("", "sess-1")
+	require.Error(t, err)
+
+	_, err = resolveSessionCleanupURL("https://x/{{.SESSION_ID}}{{", "sess-1")
 	require.Error(t, err)
 }
 
@@ -39,39 +42,28 @@ func TestNeedsSessionCleanup(t *testing.T) {
 		want bool
 	}{
 		{
-			name: "http with SESSION_ID header",
+			name: "http with session_cleanup_url",
 			cfg: config.TransportConfig{
-				Type: config.TransportTypeHTTP,
-				URL:  "https://cli-mcp-server:8443/mcp",
-				CustomHeaders: map[string]string{
-					"X-Session-ID": "{{.SESSION_ID}}",
-				},
+				Type:              config.TransportTypeHTTP,
+				URL:               "https://cli-mcp-server:8443/mcp",
+				SessionCleanupURL: "https://cli-mcp-server:8443/sessions/{{.SESSION_ID}}",
 			},
 			want: true,
 		},
 		{
-			name: "sse with SESSION_ID header",
+			name: "sse with session_cleanup_url",
 			cfg: config.TransportConfig{
-				Type: config.TransportTypeSSE,
-				URL:  "https://cli-mcp-server:8443/sse",
-				CustomHeaders: map[string]string{
-					"X-Session-ID": "{{.SESSION_ID}}",
-				},
+				Type:              config.TransportTypeSSE,
+				URL:               "https://cli-mcp-server:8443/sse",
+				SessionCleanupURL: "https://cli-mcp-server:8443/sessions/{{.SESSION_ID}}",
 			},
 			want: true,
 		},
 		{
-			name: "http without custom headers",
+			name: "http without session_cleanup_url",
 			cfg: config.TransportConfig{
 				Type: config.TransportTypeHTTP,
 				URL:  "https://kubernetes-mcp-server:8443/mcp",
-			},
-			want: false,
-		},
-		{
-			name: "http empty url",
-			cfg: config.TransportConfig{
-				Type: config.TransportTypeHTTP,
 				CustomHeaders: map[string]string{
 					"X-Session-ID": "{{.SESSION_ID}}",
 				},
@@ -79,21 +71,19 @@ func TestNeedsSessionCleanup(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "http headers without SESSION_ID template",
+			name: "stdio with session_cleanup_url still opts in",
+			cfg: config.TransportConfig{
+				Type:              config.TransportTypeStdio,
+				Command:           "npx",
+				SessionCleanupURL: "https://cli-mcp-server:8443/sessions/{{.SESSION_ID}}",
+			},
+			want: true,
+		},
+		{
+			name: "empty session_cleanup_url",
 			cfg: config.TransportConfig{
 				Type: config.TransportTypeHTTP,
 				URL:  "https://cli-mcp-server:8443/mcp",
-				CustomHeaders: map[string]string{
-					"X-Tenant": "static",
-				},
-			},
-			want: false,
-		},
-		{
-			name: "stdio",
-			cfg: config.TransportConfig{
-				Type:    config.TransportTypeStdio,
-				Command: "npx",
 			},
 			want: false,
 		},
@@ -132,12 +122,17 @@ func TestCleanupSessions(t *testing.T) {
 				CustomHeaders: map[string]string{
 					"X-Session-ID": "{{.SESSION_ID}}",
 				},
+				SessionCleanupURL: server.URL + "/sessions/{{.SESSION_ID}}",
 			},
 		},
 		"other": {
 			Transport: config.TransportConfig{
 				Type: config.TransportTypeHTTP,
 				URL:  server.URL + "/mcp",
+				// custom_headers alone must not trigger cleanup
+				CustomHeaders: map[string]string{
+					"X-Session-ID": "{{.SESSION_ID}}",
+				},
 			},
 		},
 		"nil-entry": nil,
@@ -172,12 +167,10 @@ func TestCleanupSessions_ErrorAndStatusPaths(t *testing.T) {
 		registry := config.NewMCPServerRegistry(map[string]*config.MCPServerConfig{
 			"cli-mcp-server": {
 				Transport: config.TransportConfig{
-					Type:      config.TransportTypeHTTP,
-					URL:       server.URL + "/mcp",
-					VerifySSL: &verifySSL,
-					CustomHeaders: map[string]string{
-						"X-Session-ID": "{{.SESSION_ID}}",
-					},
+					Type:              config.TransportTypeHTTP,
+					URL:               server.URL + "/mcp",
+					VerifySSL:         &verifySSL,
+					SessionCleanupURL: server.URL + "/sessions/{{.SESSION_ID}}",
 				},
 			},
 		})
@@ -195,12 +188,10 @@ func TestCleanupSessions_ErrorAndStatusPaths(t *testing.T) {
 		registry := config.NewMCPServerRegistry(map[string]*config.MCPServerConfig{
 			"cli-mcp-server": {
 				Transport: config.TransportConfig{
-					Type:      config.TransportTypeHTTP,
-					URL:       server.URL + "/mcp",
-					VerifySSL: &verifySSL,
-					CustomHeaders: map[string]string{
-						"X-Session-ID": "{{.SESSION_ID}}",
-					},
+					Type:              config.TransportTypeHTTP,
+					URL:               server.URL + "/mcp",
+					VerifySSL:         &verifySSL,
+					SessionCleanupURL: server.URL + "/sessions/{{.SESSION_ID}}",
 				},
 			},
 		})
@@ -218,12 +209,10 @@ func TestCleanupSessions_ErrorAndStatusPaths(t *testing.T) {
 		registry := config.NewMCPServerRegistry(map[string]*config.MCPServerConfig{
 			"cli-mcp-server": {
 				Transport: config.TransportConfig{
-					Type:      config.TransportTypeHTTP,
-					URL:       server.URL + "/mcp",
-					VerifySSL: &verifySSL,
-					CustomHeaders: map[string]string{
-						"X-Session-ID": "{{.SESSION_ID}}",
-					},
+					Type:              config.TransportTypeHTTP,
+					URL:               server.URL + "/mcp",
+					VerifySSL:         &verifySSL,
+					SessionCleanupURL: server.URL + "/sessions/{{.SESSION_ID}}",
 				},
 			},
 		})
@@ -234,33 +223,30 @@ func TestCleanupSessions_ErrorAndStatusPaths(t *testing.T) {
 		server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusNoContent)
 		}))
-		url := server.URL + "/mcp"
+		cleanupURL := server.URL + "/sessions/{{.SESSION_ID}}"
+		mcpURL := server.URL + "/mcp"
 		server.Close() // force client.Do failure
 
 		registry := config.NewMCPServerRegistry(map[string]*config.MCPServerConfig{
 			"cli-mcp-server": {
 				Transport: config.TransportConfig{
-					Type:      config.TransportTypeHTTP,
-					URL:       url,
-					VerifySSL: &verifySSL,
-					CustomHeaders: map[string]string{
-						"X-Session-ID": "{{.SESSION_ID}}",
-					},
+					Type:              config.TransportTypeHTTP,
+					URL:               mcpURL,
+					VerifySSL:         &verifySSL,
+					SessionCleanupURL: cleanupURL,
 				},
 			},
 		})
 		CleanupSessions(context.Background(), registry, "down", logger)
 	})
 
-	t.Run("invalid mcp url is logged and ignored", func(_ *testing.T) {
+	t.Run("invalid cleanup url template is logged and ignored", func(_ *testing.T) {
 		registry := config.NewMCPServerRegistry(map[string]*config.MCPServerConfig{
 			"cli-mcp-server": {
 				Transport: config.TransportConfig{
-					Type: config.TransportTypeHTTP,
-					URL:  "://not-a-url",
-					CustomHeaders: map[string]string{
-						"X-Session-ID": "{{.SESSION_ID}}",
-					},
+					Type:              config.TransportTypeHTTP,
+					URL:               "https://cli-mcp-server:8443/mcp",
+					SessionCleanupURL: "https://cli-mcp-server:8443/sessions/{{.SESSION_ID}}{{",
 				},
 			},
 		})
@@ -274,10 +260,9 @@ func TestCleanupSessions_ErrorAndStatusPaths(t *testing.T) {
 					Type: config.TransportTypeHTTP,
 					URL:  "https://cli-mcp-server:8443/mcp",
 					CustomHeaders: map[string]string{
-						// Still matches needsSessionCleanup (contains {{.SESSION_ID}})
-						// but fails template parse (trailing unclosed action).
 						"X-Session-ID": "{{.SESSION_ID}}{{",
 					},
+					SessionCleanupURL: "https://cli-mcp-server:8443/sessions/{{.SESSION_ID}}",
 				},
 			},
 		})
@@ -289,20 +274,23 @@ func TestDeleteSession_Direct(t *testing.T) {
 	verifySSL := false
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodDelete, r.Method)
+		assert.Equal(t, "/sessions/direct-1", r.URL.Path)
 		w.WriteHeader(http.StatusNoContent)
 	}))
 	t.Cleanup(server.Close)
 
 	err := deleteSession(context.Background(), config.TransportConfig{
-		Type:      config.TransportTypeHTTP,
-		URL:       server.URL + "/mcp",
-		VerifySSL: &verifySSL,
+		Type:              config.TransportTypeHTTP,
+		URL:               server.URL + "/mcp",
+		VerifySSL:         &verifySSL,
+		SessionCleanupURL: server.URL + "/sessions/{{.SESSION_ID}}",
 	}, "direct-1")
 	require.NoError(t, err)
 
 	err = deleteSession(context.Background(), config.TransportConfig{
-		Type: config.TransportTypeHTTP,
-		URL:  "://bad",
+		Type:              config.TransportTypeHTTP,
+		URL:               "https://example.com/mcp",
+		SessionCleanupURL: "{{.SESSION_ID}}{{",
 	}, "x")
 	require.Error(t, err)
 }

--- a/pkg/mcp/session_cleanup_test.go
+++ b/pkg/mcp/session_cleanup_test.go
@@ -23,24 +23,86 @@ func TestSessionCleanupURL(t *testing.T) {
 	got, err = sessionCleanupURL("https://cli-mcp-server:8443/mcp/", "sess-1")
 	require.NoError(t, err)
 	assert.Equal(t, "https://cli-mcp-server:8443/sessions/sess-1", got)
+
+	got, err = sessionCleanupURL("https://cli-mcp-server:8443/api/mcp?x=1#frag", "sess-2")
+	require.NoError(t, err)
+	assert.Equal(t, "https://cli-mcp-server:8443/api/sessions/sess-2", got)
+
+	_, err = sessionCleanupURL("://bad", "sess-1")
+	require.Error(t, err)
 }
 
 func TestNeedsSessionCleanup(t *testing.T) {
-	assert.True(t, needsSessionCleanup(config.TransportConfig{
-		Type: config.TransportTypeHTTP,
-		URL:  "https://cli-mcp-server:8443/mcp",
-		CustomHeaders: map[string]string{
-			"X-Session-ID": "{{.SESSION_ID}}",
+	tests := []struct {
+		name string
+		cfg  config.TransportConfig
+		want bool
+	}{
+		{
+			name: "http with SESSION_ID header",
+			cfg: config.TransportConfig{
+				Type: config.TransportTypeHTTP,
+				URL:  "https://cli-mcp-server:8443/mcp",
+				CustomHeaders: map[string]string{
+					"X-Session-ID": "{{.SESSION_ID}}",
+				},
+			},
+			want: true,
 		},
-	}))
-	assert.False(t, needsSessionCleanup(config.TransportConfig{
-		Type: config.TransportTypeHTTP,
-		URL:  "https://kubernetes-mcp-server:8443/mcp",
-	}))
-	assert.False(t, needsSessionCleanup(config.TransportConfig{
-		Type:    config.TransportTypeStdio,
-		Command: "npx",
-	}))
+		{
+			name: "sse with SESSION_ID header",
+			cfg: config.TransportConfig{
+				Type: config.TransportTypeSSE,
+				URL:  "https://cli-mcp-server:8443/sse",
+				CustomHeaders: map[string]string{
+					"X-Session-ID": "{{.SESSION_ID}}",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "http without custom headers",
+			cfg: config.TransportConfig{
+				Type: config.TransportTypeHTTP,
+				URL:  "https://kubernetes-mcp-server:8443/mcp",
+			},
+			want: false,
+		},
+		{
+			name: "http empty url",
+			cfg: config.TransportConfig{
+				Type: config.TransportTypeHTTP,
+				CustomHeaders: map[string]string{
+					"X-Session-ID": "{{.SESSION_ID}}",
+				},
+			},
+			want: false,
+		},
+		{
+			name: "http headers without SESSION_ID template",
+			cfg: config.TransportConfig{
+				Type: config.TransportTypeHTTP,
+				URL:  "https://cli-mcp-server:8443/mcp",
+				CustomHeaders: map[string]string{
+					"X-Tenant": "static",
+				},
+			},
+			want: false,
+		},
+		{
+			name: "stdio",
+			cfg: config.TransportConfig{
+				Type:    config.TransportTypeStdio,
+				Command: "npx",
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, needsSessionCleanup(tt.cfg))
+		})
+	}
 }
 
 func TestCleanupSessions(t *testing.T) {
@@ -78,6 +140,7 @@ func TestCleanupSessions(t *testing.T) {
 				URL:  server.URL + "/mcp",
 			},
 		},
+		"nil-entry": nil,
 	})
 
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
@@ -86,4 +149,160 @@ func TestCleanupSessions(t *testing.T) {
 	assert.True(t, deleted.Load(), "expected DELETE /sessions/inv-42")
 	assert.Equal(t, "Bearer tok", gotAuth)
 	assert.Equal(t, "inv-42", gotSessionHeader)
+}
+
+func TestCleanupSessions_SkipPaths(t *testing.T) {
+	CleanupSessions(context.Background(), nil, "sess", nil)
+	CleanupSessions(context.Background(), config.NewMCPServerRegistry(nil), "", nil)
+
+	// nil logger uses slog.Default(); empty registry is a no-op.
+	CleanupSessions(context.Background(), config.NewMCPServerRegistry(nil), "sess", nil)
+}
+
+func TestCleanupSessions_ErrorAndStatusPaths(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	verifySSL := false
+
+	t.Run("unexpected status is logged and ignored", func(t *testing.T) {
+		server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		t.Cleanup(server.Close)
+
+		registry := config.NewMCPServerRegistry(map[string]*config.MCPServerConfig{
+			"cli-mcp-server": {
+				Transport: config.TransportConfig{
+					Type:      config.TransportTypeHTTP,
+					URL:       server.URL + "/mcp",
+					VerifySSL: &verifySSL,
+					CustomHeaders: map[string]string{
+						"X-Session-ID": "{{.SESSION_ID}}",
+					},
+				},
+			},
+		})
+		CleanupSessions(context.Background(), registry, "inv-err", logger)
+	})
+
+	t.Run("404 treated as success", func(t *testing.T) {
+		var hit atomic.Bool
+		server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			hit.Store(true)
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		t.Cleanup(server.Close)
+
+		registry := config.NewMCPServerRegistry(map[string]*config.MCPServerConfig{
+			"cli-mcp-server": {
+				Transport: config.TransportConfig{
+					Type:      config.TransportTypeHTTP,
+					URL:       server.URL + "/mcp",
+					VerifySSL: &verifySSL,
+					CustomHeaders: map[string]string{
+						"X-Session-ID": "{{.SESSION_ID}}",
+					},
+				},
+			},
+		})
+		CleanupSessions(context.Background(), registry, "gone", logger)
+		assert.True(t, hit.Load())
+	})
+
+	t.Run("200 ok treated as success", func(t *testing.T) {
+		server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"ok":true}`))
+		}))
+		t.Cleanup(server.Close)
+
+		registry := config.NewMCPServerRegistry(map[string]*config.MCPServerConfig{
+			"cli-mcp-server": {
+				Transport: config.TransportConfig{
+					Type:      config.TransportTypeHTTP,
+					URL:       server.URL + "/mcp",
+					VerifySSL: &verifySSL,
+					CustomHeaders: map[string]string{
+						"X-Session-ID": "{{.SESSION_ID}}",
+					},
+				},
+			},
+		})
+		CleanupSessions(context.Background(), registry, "ok-sess", logger)
+	})
+
+	t.Run("transport do error is logged and ignored", func(t *testing.T) {
+		server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		}))
+		url := server.URL + "/mcp"
+		server.Close() // force client.Do failure
+
+		registry := config.NewMCPServerRegistry(map[string]*config.MCPServerConfig{
+			"cli-mcp-server": {
+				Transport: config.TransportConfig{
+					Type:      config.TransportTypeHTTP,
+					URL:       url,
+					VerifySSL: &verifySSL,
+					CustomHeaders: map[string]string{
+						"X-Session-ID": "{{.SESSION_ID}}",
+					},
+				},
+			},
+		})
+		CleanupSessions(context.Background(), registry, "down", logger)
+	})
+
+	t.Run("invalid mcp url is logged and ignored", func(t *testing.T) {
+		registry := config.NewMCPServerRegistry(map[string]*config.MCPServerConfig{
+			"cli-mcp-server": {
+				Transport: config.TransportConfig{
+					Type: config.TransportTypeHTTP,
+					URL:  "://not-a-url",
+					CustomHeaders: map[string]string{
+						"X-Session-ID": "{{.SESSION_ID}}",
+					},
+				},
+			},
+		})
+		CleanupSessions(context.Background(), registry, "bad-url", logger)
+	})
+
+	t.Run("buildHTTPClient error is logged and ignored", func(t *testing.T) {
+		registry := config.NewMCPServerRegistry(map[string]*config.MCPServerConfig{
+			"cli-mcp-server": {
+				Transport: config.TransportConfig{
+					Type: config.TransportTypeHTTP,
+					URL:  "https://cli-mcp-server:8443/mcp",
+					CustomHeaders: map[string]string{
+						// Still matches needsSessionCleanup (contains {{.SESSION_ID}})
+						// but fails template parse (trailing unclosed action).
+						"X-Session-ID": "{{.SESSION_ID}}{{",
+					},
+				},
+			},
+		})
+		CleanupSessions(context.Background(), registry, "bad-header", logger)
+	})
+}
+
+func TestDeleteSession_Direct(t *testing.T) {
+	verifySSL := false
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(server.Close)
+
+	err := deleteSession(context.Background(), config.TransportConfig{
+		Type:      config.TransportTypeHTTP,
+		URL:       server.URL + "/mcp",
+		VerifySSL: &verifySSL,
+	}, "direct-1")
+	require.NoError(t, err)
+
+	err = deleteSession(context.Background(), config.TransportConfig{
+		Type: config.TransportTypeHTTP,
+		URL:  "://bad",
+	}, "x")
+	require.Error(t, err)
 }

--- a/pkg/mcp/session_cleanup_test.go
+++ b/pkg/mcp/session_cleanup_test.go
@@ -1,0 +1,89 @@
+package mcp
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/codeready-toolchain/tarsy/pkg/config"
+)
+
+func TestSessionCleanupURL(t *testing.T) {
+	got, err := sessionCleanupURL("https://cli-mcp-server:8443/mcp", "sess-1")
+	require.NoError(t, err)
+	assert.Equal(t, "https://cli-mcp-server:8443/sessions/sess-1", got)
+
+	got, err = sessionCleanupURL("https://cli-mcp-server:8443/mcp/", "sess-1")
+	require.NoError(t, err)
+	assert.Equal(t, "https://cli-mcp-server:8443/sessions/sess-1", got)
+}
+
+func TestNeedsSessionCleanup(t *testing.T) {
+	assert.True(t, needsSessionCleanup(config.TransportConfig{
+		Type: config.TransportTypeHTTP,
+		URL:  "https://cli-mcp-server:8443/mcp",
+		CustomHeaders: map[string]string{
+			"X-Session-ID": "{{.SESSION_ID}}",
+		},
+	}))
+	assert.False(t, needsSessionCleanup(config.TransportConfig{
+		Type: config.TransportTypeHTTP,
+		URL:  "https://kubernetes-mcp-server:8443/mcp",
+	}))
+	assert.False(t, needsSessionCleanup(config.TransportConfig{
+		Type:    config.TransportTypeStdio,
+		Command: "npx",
+	}))
+}
+
+func TestCleanupSessions(t *testing.T) {
+	var deleted atomic.Bool
+	var gotAuth, gotSessionHeader string
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete && r.URL.Path == "/sessions/inv-42" {
+			deleted.Store(true)
+			gotAuth = r.Header.Get("Authorization")
+			gotSessionHeader = r.Header.Get("X-Session-ID")
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(server.Close)
+
+	verifySSL := false
+	registry := config.NewMCPServerRegistry(map[string]*config.MCPServerConfig{
+		"cli-mcp-server": {
+			Transport: config.TransportConfig{
+				Type:        config.TransportTypeHTTP,
+				URL:         server.URL + "/mcp",
+				BearerToken: "tok",
+				VerifySSL:   &verifySSL,
+				CustomHeaders: map[string]string{
+					"X-Session-ID": "{{.SESSION_ID}}",
+				},
+			},
+		},
+		"other": {
+			Transport: config.TransportConfig{
+				Type: config.TransportTypeHTTP,
+				URL:  server.URL + "/mcp",
+			},
+		},
+	})
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	CleanupSessions(context.Background(), registry, "inv-42", logger)
+
+	assert.True(t, deleted.Load(), "expected DELETE /sessions/inv-42")
+	assert.Equal(t, "Bearer tok", gotAuth)
+	assert.Equal(t, "inv-42", gotSessionHeader)
+}

--- a/pkg/mcp/session_cleanup_test.go
+++ b/pkg/mcp/session_cleanup_test.go
@@ -151,7 +151,7 @@ func TestCleanupSessions(t *testing.T) {
 	assert.Equal(t, "inv-42", gotSessionHeader)
 }
 
-func TestCleanupSessions_SkipPaths(t *testing.T) {
+func TestCleanupSessions_SkipPaths(_ *testing.T) {
 	CleanupSessions(context.Background(), nil, "sess", nil)
 	CleanupSessions(context.Background(), config.NewMCPServerRegistry(nil), "", nil)
 
@@ -164,7 +164,7 @@ func TestCleanupSessions_ErrorAndStatusPaths(t *testing.T) {
 	verifySSL := false
 
 	t.Run("unexpected status is logged and ignored", func(t *testing.T) {
-		server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusInternalServerError)
 		}))
 		t.Cleanup(server.Close)
@@ -186,7 +186,7 @@ func TestCleanupSessions_ErrorAndStatusPaths(t *testing.T) {
 
 	t.Run("404 treated as success", func(t *testing.T) {
 		var hit atomic.Bool
-		server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			hit.Store(true)
 			w.WriteHeader(http.StatusNotFound)
 		}))
@@ -209,7 +209,7 @@ func TestCleanupSessions_ErrorAndStatusPaths(t *testing.T) {
 	})
 
 	t.Run("200 ok treated as success", func(t *testing.T) {
-		server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(`{"ok":true}`))
 		}))
@@ -230,8 +230,8 @@ func TestCleanupSessions_ErrorAndStatusPaths(t *testing.T) {
 		CleanupSessions(context.Background(), registry, "ok-sess", logger)
 	})
 
-	t.Run("transport do error is logged and ignored", func(t *testing.T) {
-		server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	t.Run("transport do error is logged and ignored", func(_ *testing.T) {
+		server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusNoContent)
 		}))
 		url := server.URL + "/mcp"
@@ -252,7 +252,7 @@ func TestCleanupSessions_ErrorAndStatusPaths(t *testing.T) {
 		CleanupSessions(context.Background(), registry, "down", logger)
 	})
 
-	t.Run("invalid mcp url is logged and ignored", func(t *testing.T) {
+	t.Run("invalid mcp url is logged and ignored", func(_ *testing.T) {
 		registry := config.NewMCPServerRegistry(map[string]*config.MCPServerConfig{
 			"cli-mcp-server": {
 				Transport: config.TransportConfig{
@@ -267,7 +267,7 @@ func TestCleanupSessions_ErrorAndStatusPaths(t *testing.T) {
 		CleanupSessions(context.Background(), registry, "bad-url", logger)
 	})
 
-	t.Run("buildHTTPClient error is logged and ignored", func(t *testing.T) {
+	t.Run("buildHTTPClient error is logged and ignored", func(_ *testing.T) {
 		registry := config.NewMCPServerRegistry(map[string]*config.MCPServerConfig{
 			"cli-mcp-server": {
 				Transport: config.TransportConfig{

--- a/pkg/mcp/session_cleanup_test.go
+++ b/pkg/mcp/session_cleanup_test.go
@@ -294,3 +294,64 @@ func TestDeleteSession_Direct(t *testing.T) {
 	}, "x")
 	require.Error(t, err)
 }
+
+func TestClient_Close_TriggersSessionCleanup(t *testing.T) {
+	var deleted atomic.Bool
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete && r.URL.Path == "/sessions/exec-close-1" {
+			deleted.Store(true)
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(server.Close)
+
+	verifySSL := false
+	registry := config.NewMCPServerRegistry(map[string]*config.MCPServerConfig{
+		"cli-mcp-server": {
+			Transport: config.TransportConfig{
+				Type:              config.TransportTypeHTTP,
+				URL:               server.URL + "/mcp",
+				VerifySSL:         &verifySSL,
+				SessionCleanupURL: server.URL + "/sessions/{{.SESSION_ID}}",
+			},
+		},
+	})
+
+	client := newClient(registry, "exec-close-1")
+	require.NoError(t, client.Close())
+	assert.True(t, deleted.Load(), "Client.Close must DELETE sandbox for agent execution ID")
+
+	exec := NewToolExecutor(newClient(registry, "exec-close-1"), registry, nil, nil, nil)
+	deleted.Store(false)
+	require.NoError(t, exec.Close())
+	assert.True(t, deleted.Load(), "ToolExecutor.Close must DELETE sandbox for agent execution ID")
+}
+
+func TestClient_Close_SkipsCleanupWithoutSessionID(t *testing.T) {
+	var deleted atomic.Bool
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete {
+			deleted.Store(true)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(server.Close)
+
+	verifySSL := false
+	registry := config.NewMCPServerRegistry(map[string]*config.MCPServerConfig{
+		"cli-mcp-server": {
+			Transport: config.TransportConfig{
+				Type:              config.TransportTypeHTTP,
+				URL:               server.URL + "/mcp",
+				VerifySSL:         &verifySSL,
+				SessionCleanupURL: server.URL + "/sessions/{{.SESSION_ID}}",
+			},
+		},
+	})
+
+	client := newClient(registry, "") // health/startup clients
+	require.NoError(t, client.Close())
+	assert.False(t, deleted.Load(), "empty sessionID must not trigger sandbox DELETE")
+}

--- a/pkg/mcp/session_cleanup_test.go
+++ b/pkg/mcp/session_cleanup_test.go
@@ -146,6 +146,59 @@ func TestCleanupSessions(t *testing.T) {
 	assert.Equal(t, "exec-42", gotSessionHeader)
 }
 
+// TestCleanupSessions_AuthHeadersScopedToCleanupHost verifies DELETE auth and
+// custom headers follow the cleanup URL host when it differs from the MCP URL.
+func TestCleanupSessions_AuthHeadersScopedToCleanupHost(t *testing.T) {
+	var mcpDeleted atomic.Bool
+	mcpServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete {
+			mcpDeleted.Store(true)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(mcpServer.Close)
+
+	var deleted atomic.Bool
+	var gotAuth, gotSessionHeader string
+	cleanupServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete && r.URL.Path == "/sessions/exec-host" {
+			deleted.Store(true)
+			gotAuth = r.Header.Get("Authorization")
+			gotSessionHeader = r.Header.Get("X-Session-ID")
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(cleanupServer.Close)
+
+	require.NotEqual(t, mcpServer.URL, cleanupServer.URL, "test requires distinct hosts")
+
+	verifySSL := false
+	registry := config.NewMCPServerRegistry(map[string]*config.MCPServerConfig{
+		"cli-mcp-server": {
+			Transport: config.TransportConfig{
+				Type:        config.TransportTypeHTTP,
+				URL:         mcpServer.URL + "/mcp",
+				BearerToken: "cleanup-tok",
+				VerifySSL:   &verifySSL,
+				CustomHeaders: map[string]string{
+					"X-Session-ID": "{{.SESSION_ID}}",
+				},
+				SessionCleanupURL: cleanupServer.URL + "/sessions/{{.SESSION_ID}}",
+			},
+		},
+	})
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	CleanupSessions(context.Background(), registry, "exec-host", []string{"cli-mcp-server"}, logger)
+
+	assert.True(t, deleted.Load(), "DELETE must hit cleanup host")
+	assert.False(t, mcpDeleted.Load(), "DELETE must not hit MCP host")
+	assert.Equal(t, "Bearer cleanup-tok", gotAuth)
+	assert.Equal(t, "exec-host", gotSessionHeader)
+}
+
 func TestCleanupSessions_OnlyRequestedServers(t *testing.T) {
 	var deleted atomic.Bool
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -367,6 +420,51 @@ func TestClient_Close_TriggersSessionCleanup(t *testing.T) {
 	deleteCount.Store(0)
 	require.NoError(t, exec.Close())
 	assert.Equal(t, int32(1), deleteCount.Load(), "ToolExecutor.Close must DELETE sandbox for agent execution ID")
+}
+
+func TestClient_Close_CleansUpMultipleRequestedServers(t *testing.T) {
+	var deleteCount atomic.Int32
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete && r.URL.Path == "/sessions/exec-multi" {
+			deleteCount.Add(1)
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(server.Close)
+
+	verifySSL := false
+	cleanupURL := server.URL + "/sessions/{{.SESSION_ID}}"
+	registry := config.NewMCPServerRegistry(map[string]*config.MCPServerConfig{
+		"cli-a": {
+			Transport: config.TransportConfig{
+				Type:              config.TransportTypeHTTP,
+				URL:               server.URL + "/mcp-a",
+				VerifySSL:         &verifySSL,
+				SessionCleanupURL: cleanupURL,
+			},
+		},
+		"cli-b": {
+			Transport: config.TransportConfig{
+				Type:              config.TransportTypeHTTP,
+				URL:               server.URL + "/mcp-b",
+				VerifySSL:         &verifySSL,
+				SessionCleanupURL: cleanupURL,
+			},
+		},
+		"no-cleanup": {
+			Transport: config.TransportConfig{
+				Type: config.TransportTypeHTTP,
+				URL:  server.URL + "/mcp-c",
+			},
+		},
+	})
+
+	client := newClient(registry, "exec-multi")
+	client.recordRequestedServers([]string{"cli-a", "cli-b", "no-cleanup"})
+	require.NoError(t, client.Close())
+	assert.Equal(t, int32(2), deleteCount.Load(), "Close must DELETE once per opted-in requested server")
 }
 
 func TestClient_Close_SkipsCleanupForUnrequestedServers(t *testing.T) {

--- a/pkg/mcp/session_cleanup_test.go
+++ b/pkg/mcp/session_cleanup_test.go
@@ -100,7 +100,7 @@ func TestCleanupSessions(t *testing.T) {
 	var gotAuth, gotSessionHeader string
 
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == http.MethodDelete && r.URL.Path == "/sessions/inv-42" {
+		if r.Method == http.MethodDelete && r.URL.Path == "/sessions/exec-42" {
 			deleted.Store(true)
 			gotAuth = r.Header.Get("Authorization")
 			gotSessionHeader = r.Header.Get("X-Session-ID")
@@ -139,19 +139,46 @@ func TestCleanupSessions(t *testing.T) {
 	})
 
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	CleanupSessions(context.Background(), registry, "inv-42", logger)
+	CleanupSessions(context.Background(), registry, "exec-42", []string{"cli-mcp-server", "other", "nil-entry"}, logger)
 
-	assert.True(t, deleted.Load(), "expected DELETE /sessions/inv-42")
+	assert.True(t, deleted.Load(), "expected DELETE /sessions/exec-42")
 	assert.Equal(t, "Bearer tok", gotAuth)
-	assert.Equal(t, "inv-42", gotSessionHeader)
+	assert.Equal(t, "exec-42", gotSessionHeader)
+}
+
+func TestCleanupSessions_OnlyRequestedServers(t *testing.T) {
+	var deleted atomic.Bool
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete {
+			deleted.Store(true)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(server.Close)
+
+	verifySSL := false
+	registry := config.NewMCPServerRegistry(map[string]*config.MCPServerConfig{
+		"cli-mcp-server": {
+			Transport: config.TransportConfig{
+				Type:              config.TransportTypeHTTP,
+				URL:               server.URL + "/mcp",
+				VerifySSL:         &verifySSL,
+				SessionCleanupURL: server.URL + "/sessions/{{.SESSION_ID}}",
+			},
+		},
+	})
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	// Agent only used kubernetes-server — must not DELETE on cli-mcp.
+	CleanupSessions(context.Background(), registry, "exec-k8s-only", []string{"kubernetes-server"}, logger)
+	assert.False(t, deleted.Load(), "cleanup must not touch unrequested servers")
 }
 
 func TestCleanupSessions_SkipPaths(_ *testing.T) {
-	CleanupSessions(context.Background(), nil, "sess", nil)
-	CleanupSessions(context.Background(), config.NewMCPServerRegistry(nil), "", nil)
-
-	// nil logger uses slog.Default(); empty registry is a no-op.
-	CleanupSessions(context.Background(), config.NewMCPServerRegistry(nil), "sess", nil)
+	CleanupSessions(context.Background(), nil, "sess", []string{"cli"}, nil)
+	CleanupSessions(context.Background(), config.NewMCPServerRegistry(nil), "", []string{"cli"}, nil)
+	CleanupSessions(context.Background(), config.NewMCPServerRegistry(nil), "sess", nil, nil)
+	CleanupSessions(context.Background(), config.NewMCPServerRegistry(nil), "sess", []string{}, nil)
 }
 
 func TestCleanupSessions_ErrorAndStatusPaths(t *testing.T) {
@@ -174,7 +201,7 @@ func TestCleanupSessions_ErrorAndStatusPaths(t *testing.T) {
 				},
 			},
 		})
-		CleanupSessions(context.Background(), registry, "inv-err", logger)
+		CleanupSessions(context.Background(), registry, "exec-err", []string{"cli-mcp-server"}, logger)
 	})
 
 	t.Run("404 treated as success", func(t *testing.T) {
@@ -195,7 +222,7 @@ func TestCleanupSessions_ErrorAndStatusPaths(t *testing.T) {
 				},
 			},
 		})
-		CleanupSessions(context.Background(), registry, "gone", logger)
+		CleanupSessions(context.Background(), registry, "gone", []string{"cli-mcp-server"}, logger)
 		assert.True(t, hit.Load())
 	})
 
@@ -216,7 +243,7 @@ func TestCleanupSessions_ErrorAndStatusPaths(t *testing.T) {
 				},
 			},
 		})
-		CleanupSessions(context.Background(), registry, "ok-sess", logger)
+		CleanupSessions(context.Background(), registry, "ok-sess", []string{"cli-mcp-server"}, logger)
 	})
 
 	t.Run("transport do error is logged and ignored", func(_ *testing.T) {
@@ -237,7 +264,7 @@ func TestCleanupSessions_ErrorAndStatusPaths(t *testing.T) {
 				},
 			},
 		})
-		CleanupSessions(context.Background(), registry, "down", logger)
+		CleanupSessions(context.Background(), registry, "down", []string{"cli-mcp-server"}, logger)
 	})
 
 	t.Run("invalid cleanup url template is logged and ignored", func(_ *testing.T) {
@@ -250,7 +277,7 @@ func TestCleanupSessions_ErrorAndStatusPaths(t *testing.T) {
 				},
 			},
 		})
-		CleanupSessions(context.Background(), registry, "bad-url", logger)
+		CleanupSessions(context.Background(), registry, "bad-url", []string{"cli-mcp-server"}, logger)
 	})
 
 	t.Run("buildHTTPClient error is logged and ignored", func(_ *testing.T) {
@@ -266,7 +293,7 @@ func TestCleanupSessions_ErrorAndStatusPaths(t *testing.T) {
 				},
 			},
 		})
-		CleanupSessions(context.Background(), registry, "bad-header", logger)
+		CleanupSessions(context.Background(), registry, "bad-header", []string{"cli-mcp-server"}, logger)
 	})
 }
 
@@ -296,10 +323,10 @@ func TestDeleteSession_Direct(t *testing.T) {
 }
 
 func TestClient_Close_TriggersSessionCleanup(t *testing.T) {
-	var deleted atomic.Bool
+	var deleteCount atomic.Int32
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodDelete && r.URL.Path == "/sessions/exec-close-1" {
-			deleted.Store(true)
+			deleteCount.Add(1)
 			w.WriteHeader(http.StatusNoContent)
 			return
 		}
@@ -317,16 +344,57 @@ func TestClient_Close_TriggersSessionCleanup(t *testing.T) {
 				SessionCleanupURL: server.URL + "/sessions/{{.SESSION_ID}}",
 			},
 		},
+		"kubernetes-server": {
+			Transport: config.TransportConfig{
+				Type: config.TransportTypeHTTP,
+				URL:  server.URL + "/k8s",
+			},
+		},
 	})
 
 	client := newClient(registry, "exec-close-1")
+	client.recordRequestedServers([]string{"cli-mcp-server"})
 	require.NoError(t, client.Close())
-	assert.True(t, deleted.Load(), "Client.Close must DELETE sandbox for agent execution ID")
+	assert.Equal(t, int32(1), deleteCount.Load(), "Client.Close must DELETE sandbox for agent execution ID")
 
-	exec := NewToolExecutor(newClient(registry, "exec-close-1"), registry, nil, nil, nil)
-	deleted.Store(false)
+	// Second Close must not DELETE again (idempotent).
+	require.NoError(t, client.Close())
+	assert.Equal(t, int32(1), deleteCount.Load(), "second Close must not re-DELETE")
+
+	execClient := newClient(registry, "exec-close-1")
+	execClient.recordRequestedServers([]string{"cli-mcp-server"})
+	exec := NewToolExecutor(execClient, registry, []string{"cli-mcp-server"}, nil, nil)
+	deleteCount.Store(0)
 	require.NoError(t, exec.Close())
-	assert.True(t, deleted.Load(), "ToolExecutor.Close must DELETE sandbox for agent execution ID")
+	assert.Equal(t, int32(1), deleteCount.Load(), "ToolExecutor.Close must DELETE sandbox for agent execution ID")
+}
+
+func TestClient_Close_SkipsCleanupForUnrequestedServers(t *testing.T) {
+	var deleted atomic.Bool
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete {
+			deleted.Store(true)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(server.Close)
+
+	verifySSL := false
+	registry := config.NewMCPServerRegistry(map[string]*config.MCPServerConfig{
+		"cli-mcp-server": {
+			Transport: config.TransportConfig{
+				Type:              config.TransportTypeHTTP,
+				URL:               server.URL + "/mcp",
+				VerifySSL:         &verifySSL,
+				SessionCleanupURL: server.URL + "/sessions/{{.SESSION_ID}}",
+			},
+		},
+	})
+
+	client := newClient(registry, "exec-k8s-only")
+	client.recordRequestedServers([]string{"kubernetes-server"})
+	require.NoError(t, client.Close())
+	assert.False(t, deleted.Load(), "must not DELETE cli-mcp when it was not requested")
 }
 
 func TestClient_Close_SkipsCleanupWithoutSessionID(t *testing.T) {
@@ -352,6 +420,7 @@ func TestClient_Close_SkipsCleanupWithoutSessionID(t *testing.T) {
 	})
 
 	client := newClient(registry, "") // health/startup clients
+	client.recordRequestedServers([]string{"cli-mcp-server"})
 	require.NoError(t, client.Close())
-	assert.False(t, deleted.Load(), "empty sessionID must not trigger sandbox DELETE")
+	assert.False(t, deleted.Load(), "empty mcpSessionID must not trigger sandbox DELETE")
 }

--- a/pkg/mcp/testing.go
+++ b/pkg/mcp/testing.go
@@ -24,14 +24,14 @@ func (c *Client) InjectSession(serverID string, sdkClient *mcpsdk.Client, sessio
 // NewTestClientFactory creates a ClientFactory that uses injectFn to wire
 // sessions into each new Client instead of calling Initialize().
 // Each call to CreateClient/CreateToolExecutor invokes injectFn on the
-// freshly-created Client, allowing tests to inject in-memory MCP sessions.
-func NewTestClientFactory(registry *config.MCPServerRegistry, injectFn func(c *Client)) *ClientFactory {
+// freshly-created Client with the mcpSessionID used for that client.
+func NewTestClientFactory(registry *config.MCPServerRegistry, injectFn func(c *Client, mcpSessionID string)) *ClientFactory {
 	return &ClientFactory{
 		registry: registry,
 		createClientFn: func(_ context.Context, serverIDs []string, mcpSessionID string) (*Client, error) {
 			c := newClient(registry, mcpSessionID)
 			c.recordRequestedServers(serverIDs)
-			injectFn(c)
+			injectFn(c, mcpSessionID)
 			return c, nil
 		},
 	}

--- a/pkg/mcp/testing.go
+++ b/pkg/mcp/testing.go
@@ -25,8 +25,8 @@ func (c *Client) InjectSession(serverID string, sdkClient *mcpsdk.Client, sessio
 func NewTestClientFactory(registry *config.MCPServerRegistry, injectFn func(c *Client)) *ClientFactory {
 	return &ClientFactory{
 		registry: registry,
-		createClientFn: func(_ context.Context, _ []string) (*Client, error) {
-			c := newClient(registry)
+		createClientFn: func(_ context.Context, _ []string, sessionID string) (*Client, error) {
+			c := newClient(registry, sessionID)
 			injectFn(c)
 			return c, nil
 		},

--- a/pkg/mcp/testing.go
+++ b/pkg/mcp/testing.go
@@ -16,6 +16,9 @@ func (c *Client) InjectSession(serverID string, sdkClient *mcpsdk.Client, sessio
 	defer c.mu.Unlock()
 	c.sessions[serverID] = session
 	c.clients[serverID] = sdkClient
+	if serverID != "" {
+		c.requestedServers[serverID] = struct{}{}
+	}
 }
 
 // NewTestClientFactory creates a ClientFactory that uses injectFn to wire
@@ -25,8 +28,9 @@ func (c *Client) InjectSession(serverID string, sdkClient *mcpsdk.Client, sessio
 func NewTestClientFactory(registry *config.MCPServerRegistry, injectFn func(c *Client)) *ClientFactory {
 	return &ClientFactory{
 		registry: registry,
-		createClientFn: func(_ context.Context, _ []string, sessionID string) (*Client, error) {
-			c := newClient(registry, sessionID)
+		createClientFn: func(_ context.Context, serverIDs []string, mcpSessionID string) (*Client, error) {
+			c := newClient(registry, mcpSessionID)
+			c.recordRequestedServers(serverIDs)
 			injectFn(c)
 			return c, nil
 		},

--- a/pkg/mcp/transport.go
+++ b/pkg/mcp/transport.go
@@ -18,9 +18,9 @@ import (
 )
 
 // createTransport creates an MCP SDK transport from config.
-// sessionVars supplies per-execution template values (e.g. SESSION_ID = agent
+// sessionVars supplies per-execution template values (SESSION_ID = agent
 // execution ID) used to resolve custom_headers. May be nil or empty for
-// health/startup clients.
+// health/startup clients (blank X-Session-ID is omitted).
 func createTransport(cfg config.TransportConfig, sessionVars map[string]string) (mcpsdk.Transport, error) {
 	switch cfg.Type {
 	case config.TransportTypeStdio:
@@ -145,8 +145,8 @@ func buildHTTPClient(cfg config.TransportConfig, sessionVars map[string]string) 
 }
 
 // resolveHeaderTemplates expands {{.VAR}} templates in header values using
-// sessionVars. Empty results are omitted so health/startup clients without a
-// session ID do not send blank headers (e.g. X-Session-ID: "").
+// sessionVars. Empty results are omitted so health/startup clients without an
+// mcp session ID do not send blank headers (e.g. X-Session-ID: "").
 func resolveHeaderTemplates(headers map[string]string, sessionVars map[string]string) (map[string]string, error) {
 	if len(headers) == 0 {
 		return nil, nil

--- a/pkg/mcp/transport.go
+++ b/pkg/mcp/transport.go
@@ -18,8 +18,9 @@ import (
 )
 
 // createTransport creates an MCP SDK transport from config.
-// sessionVars supplies per-session template values (e.g. SESSION_ID) used to
-// resolve custom_headers. May be nil or empty for health/startup clients.
+// sessionVars supplies per-execution template values (e.g. SESSION_ID = agent
+// execution ID) used to resolve custom_headers. May be nil or empty for
+// health/startup clients.
 func createTransport(cfg config.TransportConfig, sessionVars map[string]string) (mcpsdk.Transport, error) {
 	switch cfg.Type {
 	case config.TransportTypeStdio:

--- a/pkg/mcp/transport.go
+++ b/pkg/mcp/transport.go
@@ -1,11 +1,14 @@
 package mcp
 
 import (
+	"bytes"
 	"crypto/tls"
 	"fmt"
 	"net/http"
 	"os"
 	"os/exec"
+	"strings"
+	"text/template"
 	"time"
 
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
@@ -14,14 +17,16 @@ import (
 )
 
 // createTransport creates an MCP SDK transport from config.
-func createTransport(cfg config.TransportConfig) (mcpsdk.Transport, error) {
+// sessionVars supplies per-session template values (e.g. SESSION_ID) used to
+// resolve custom_headers. May be nil or empty for health/startup clients.
+func createTransport(cfg config.TransportConfig, sessionVars map[string]string) (mcpsdk.Transport, error) {
 	switch cfg.Type {
 	case config.TransportTypeStdio:
 		return createStdioTransport(cfg)
 	case config.TransportTypeHTTP:
-		return createHTTPTransport(cfg)
+		return createHTTPTransport(cfg, sessionVars)
 	case config.TransportTypeSSE:
-		return createSSETransport(cfg)
+		return createSSETransport(cfg, sessionVars)
 	default:
 		return nil, fmt.Errorf("unsupported transport type: %s", cfg.Type)
 	}
@@ -45,34 +50,46 @@ func createStdioTransport(cfg config.TransportConfig) (*mcpsdk.CommandTransport,
 	return &mcpsdk.CommandTransport{Command: cmd}, nil
 }
 
-func createHTTPTransport(cfg config.TransportConfig) (*mcpsdk.StreamableClientTransport, error) {
+func createHTTPTransport(cfg config.TransportConfig, sessionVars map[string]string) (*mcpsdk.StreamableClientTransport, error) {
 	if cfg.URL == "" {
 		return nil, fmt.Errorf("HTTP transport requires url")
 	}
 	transport := &mcpsdk.StreamableClientTransport{
 		Endpoint: cfg.URL,
 	}
-	if cfg.BearerToken != "" || cfg.VerifySSL != nil || cfg.Timeout > 0 {
-		transport.HTTPClient = buildHTTPClient(cfg)
+	if needsCustomHTTPClient(cfg) {
+		httpClient, err := buildHTTPClient(cfg, sessionVars)
+		if err != nil {
+			return nil, err
+		}
+		transport.HTTPClient = httpClient
 	}
 	return transport, nil
 }
 
-func createSSETransport(cfg config.TransportConfig) (*mcpsdk.SSEClientTransport, error) {
+func createSSETransport(cfg config.TransportConfig, sessionVars map[string]string) (*mcpsdk.SSEClientTransport, error) {
 	if cfg.URL == "" {
 		return nil, fmt.Errorf("SSE transport requires url")
 	}
 	transport := &mcpsdk.SSEClientTransport{
 		Endpoint: cfg.URL,
 	}
-	if cfg.BearerToken != "" || cfg.VerifySSL != nil || cfg.Timeout > 0 {
-		transport.HTTPClient = buildHTTPClient(cfg)
+	if needsCustomHTTPClient(cfg) {
+		httpClient, err := buildHTTPClient(cfg, sessionVars)
+		if err != nil {
+			return nil, err
+		}
+		transport.HTTPClient = httpClient
 	}
 	return transport, nil
 }
 
-// buildHTTPClient creates an http.Client with auth, TLS, and timeout settings.
-func buildHTTPClient(cfg config.TransportConfig) *http.Client {
+func needsCustomHTTPClient(cfg config.TransportConfig) bool {
+	return cfg.BearerToken != "" || cfg.VerifySSL != nil || cfg.Timeout > 0 || len(cfg.CustomHeaders) > 0
+}
+
+// buildHTTPClient creates an http.Client with auth, TLS, timeout, and custom headers.
+func buildHTTPClient(cfg config.TransportConfig, sessionVars map[string]string) (*http.Client, error) {
 	httpTransport := http.DefaultTransport.(*http.Transport).Clone()
 
 	// TLS verification
@@ -95,12 +112,60 @@ func buildHTTPClient(cfg config.TransportConfig) *http.Client {
 		}
 	}
 
+	if len(cfg.CustomHeaders) > 0 {
+		headers, err := resolveHeaderTemplates(cfg.CustomHeaders, sessionVars)
+		if err != nil {
+			return nil, fmt.Errorf("resolve custom_headers: %w", err)
+		}
+		if len(headers) > 0 {
+			client.Transport = &customHeadersTransport{
+				base:    client.Transport,
+				headers: headers,
+			}
+		}
+	}
+
 	// Timeout
 	if cfg.Timeout > 0 {
 		client.Timeout = time.Duration(cfg.Timeout) * time.Second
 	}
 
-	return client
+	return client, nil
+}
+
+// resolveHeaderTemplates expands {{.VAR}} templates in header values using
+// sessionVars. Empty results are omitted so health/startup clients without a
+// session ID do not send blank headers (e.g. X-Session-ID: "").
+func resolveHeaderTemplates(headers map[string]string, sessionVars map[string]string) (map[string]string, error) {
+	if len(headers) == 0 {
+		return nil, nil
+	}
+	vars := sessionVars
+	if vars == nil {
+		vars = map[string]string{}
+	}
+
+	resolved := make(map[string]string, len(headers))
+	for name, value := range headers {
+		if !strings.Contains(value, "{{") {
+			if value != "" {
+				resolved[name] = value
+			}
+			continue
+		}
+		tmpl, err := template.New("header").Option("missingkey=zero").Parse(value)
+		if err != nil {
+			return nil, fmt.Errorf("header %q: %w", name, err)
+		}
+		var buf bytes.Buffer
+		if err := tmpl.Execute(&buf, vars); err != nil {
+			return nil, fmt.Errorf("header %q: %w", name, err)
+		}
+		if out := buf.String(); out != "" {
+			resolved[name] = out
+		}
+	}
+	return resolved, nil
 }
 
 // bearerTokenTransport wraps an http.RoundTripper to add Authorization headers.
@@ -112,5 +177,19 @@ type bearerTokenTransport struct {
 func (t *bearerTokenTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	req = req.Clone(req.Context())
 	req.Header.Set("Authorization", "Bearer "+t.token)
+	return t.base.RoundTrip(req)
+}
+
+// customHeadersTransport wraps an http.RoundTripper to add resolved custom headers.
+type customHeadersTransport struct {
+	base    http.RoundTripper
+	headers map[string]string
+}
+
+func (t *customHeadersTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req = req.Clone(req.Context())
+	for k, v := range t.headers {
+		req.Header.Set(k, v)
+	}
 	return t.base.RoundTrip(req)
 }

--- a/pkg/mcp/transport.go
+++ b/pkg/mcp/transport.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"strings"
@@ -104,11 +105,19 @@ func buildHTTPClient(cfg config.TransportConfig, sessionVars map[string]string) 
 		Transport: httpTransport,
 	}
 
+	// Restrict secret headers to the configured endpoint host so cross-origin
+	// redirects do not receive Authorization / X-Session-ID / etc.
+	endpointHost := ""
+	if u, err := url.Parse(cfg.URL); err == nil {
+		endpointHost = u.Host
+	}
+
 	// Bearer token via round-tripper wrapper
 	if cfg.BearerToken != "" {
 		client.Transport = &bearerTokenTransport{
 			base:  client.Transport,
 			token: cfg.BearerToken,
+			host:  endpointHost,
 		}
 	}
 
@@ -121,6 +130,7 @@ func buildHTTPClient(cfg config.TransportConfig, sessionVars map[string]string) 
 			client.Transport = &customHeadersTransport{
 				base:    client.Transport,
 				headers: headers,
+				host:    endpointHost,
 			}
 		}
 	}
@@ -169,27 +179,37 @@ func resolveHeaderTemplates(headers map[string]string, sessionVars map[string]st
 }
 
 // bearerTokenTransport wraps an http.RoundTripper to add Authorization headers.
+// When host is set, the token is only attached to requests for that host so
+// cross-origin redirects cannot receive the credential.
 type bearerTokenTransport struct {
 	base  http.RoundTripper
 	token string
+	host  string
 }
 
 func (t *bearerTokenTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	req = req.Clone(req.Context())
-	req.Header.Set("Authorization", "Bearer "+t.token)
+	if t.host == "" || req.URL.Host == t.host {
+		req.Header.Set("Authorization", "Bearer "+t.token)
+	}
 	return t.base.RoundTrip(req)
 }
 
 // customHeadersTransport wraps an http.RoundTripper to add resolved custom headers.
+// When host is set, headers are only attached to requests for that host so
+// cross-origin redirects cannot receive session/secret headers.
 type customHeadersTransport struct {
 	base    http.RoundTripper
 	headers map[string]string
+	host    string
 }
 
 func (t *customHeadersTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	req = req.Clone(req.Context())
-	for k, v := range t.headers {
-		req.Header.Set(k, v)
+	if t.host == "" || req.URL.Host == t.host {
+		for k, v := range t.headers {
+			req.Header.Set(k, v)
+		}
 	}
 	return t.base.RoundTrip(req)
 }

--- a/pkg/mcp/transport_test.go
+++ b/pkg/mcp/transport_test.go
@@ -1,6 +1,9 @@
 package mcp
 
 import (
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
@@ -18,7 +21,7 @@ func TestCreateTransport_Stdio(t *testing.T) {
 		Env:     map[string]string{"KUBECONFIG": "/home/test/.kube/config"},
 	}
 
-	transport, err := createTransport(cfg)
+	transport, err := createTransport(cfg, nil)
 	require.NoError(t, err)
 
 	cmdTransport, ok := transport.(*mcpsdk.CommandTransport)
@@ -44,7 +47,7 @@ func TestCreateTransport_Stdio_MissingCommand(t *testing.T) {
 		Type: config.TransportTypeStdio,
 	}
 
-	_, err := createTransport(cfg)
+	_, err := createTransport(cfg, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "requires command")
 }
@@ -55,7 +58,7 @@ func TestCreateTransport_HTTP(t *testing.T) {
 		URL:  "https://mcp.example.com/v1",
 	}
 
-	transport, err := createTransport(cfg)
+	transport, err := createTransport(cfg, nil)
 	require.NoError(t, err)
 
 	httpTransport, ok := transport.(*mcpsdk.StreamableClientTransport)
@@ -72,7 +75,7 @@ func TestCreateTransport_HTTP_WithAuth(t *testing.T) {
 		Timeout:     30,
 	}
 
-	transport, err := createTransport(cfg)
+	transport, err := createTransport(cfg, nil)
 	require.NoError(t, err)
 
 	httpTransport, ok := transport.(*mcpsdk.StreamableClientTransport)
@@ -85,7 +88,7 @@ func TestCreateTransport_HTTP_MissingURL(t *testing.T) {
 		Type: config.TransportTypeHTTP,
 	}
 
-	_, err := createTransport(cfg)
+	_, err := createTransport(cfg, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "requires url")
 }
@@ -96,7 +99,7 @@ func TestCreateTransport_SSE(t *testing.T) {
 		URL:  "https://mcp.example.com/sse",
 	}
 
-	transport, err := createTransport(cfg)
+	transport, err := createTransport(cfg, nil)
 	require.NoError(t, err)
 
 	sseTransport, ok := transport.(*mcpsdk.SSEClientTransport)
@@ -109,7 +112,7 @@ func TestCreateTransport_SSE_MissingURL(t *testing.T) {
 		Type: config.TransportTypeSSE,
 	}
 
-	_, err := createTransport(cfg)
+	_, err := createTransport(cfg, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "requires url")
 }
@@ -119,7 +122,7 @@ func TestCreateTransport_UnknownType(t *testing.T) {
 		Type: "grpc",
 	}
 
-	_, err := createTransport(cfg)
+	_, err := createTransport(cfg, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported transport type")
 }
@@ -132,10 +135,68 @@ func TestCreateTransport_SSE_WithVerifySSLFalse(t *testing.T) {
 		VerifySSL: &verifySSL,
 	}
 
-	transport, err := createTransport(cfg)
+	transport, err := createTransport(cfg, nil)
 	require.NoError(t, err)
 
 	sseTransport, ok := transport.(*mcpsdk.SSEClientTransport)
 	require.True(t, ok)
 	assert.NotNil(t, sseTransport.HTTPClient, "expected custom HTTP client for VerifySSL=false")
+}
+
+func TestCreateTransport_HTTP_WithCustomHeaders(t *testing.T) {
+	cfg := config.TransportConfig{
+		Type: config.TransportTypeHTTP,
+		URL:  "https://mcp.example.com/v1",
+		CustomHeaders: map[string]string{
+			"X-Session-ID": "{{.SESSION_ID}}",
+		},
+	}
+
+	transport, err := createTransport(cfg, map[string]string{"SESSION_ID": "inv-abc123"})
+	require.NoError(t, err)
+
+	httpTransport, ok := transport.(*mcpsdk.StreamableClientTransport)
+	require.True(t, ok)
+	require.NotNil(t, httpTransport.HTTPClient)
+
+	var gotSessionID, gotAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotSessionID = r.Header.Get("X-Session-ID")
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	cfg.URL = server.URL
+	cfg.BearerToken = "secret-token"
+	client, err := buildHTTPClient(cfg, map[string]string{"SESSION_ID": "inv-abc123"})
+	require.NoError(t, err)
+
+	resp, err := client.Get(server.URL)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	assert.Equal(t, "inv-abc123", gotSessionID)
+	assert.Equal(t, "Bearer secret-token", gotAuth)
+}
+
+func TestResolveHeaderTemplates(t *testing.T) {
+	t.Run("resolves SESSION_ID", func(t *testing.T) {
+		got, err := resolveHeaderTemplates(map[string]string{
+			"X-Session-ID": "{{.SESSION_ID}}",
+			"X-Static":     "fixed",
+		}, map[string]string{"SESSION_ID": "sess-1"})
+		require.NoError(t, err)
+		assert.Equal(t, "sess-1", got["X-Session-ID"])
+		assert.Equal(t, "fixed", got["X-Static"])
+	})
+
+	t.Run("omits empty after resolution", func(t *testing.T) {
+		got, err := resolveHeaderTemplates(map[string]string{
+			"X-Session-ID": "{{.SESSION_ID}}",
+		}, nil)
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
 }

--- a/pkg/mcp/transport_test.go
+++ b/pkg/mcp/transport_test.go
@@ -153,7 +153,7 @@ func TestCreateTransport_HTTP_WithCustomHeaders(t *testing.T) {
 		},
 	}
 
-	transport, err := createTransport(cfg, map[string]string{"SESSION_ID": "inv-abc123"})
+	transport, err := createTransport(cfg, map[string]string{"SESSION_ID": "exec-abc123"})
 	require.NoError(t, err)
 
 	httpTransport, ok := transport.(*mcpsdk.StreamableClientTransport)
@@ -170,7 +170,7 @@ func TestCreateTransport_HTTP_WithCustomHeaders(t *testing.T) {
 
 	cfg.URL = server.URL
 	cfg.BearerToken = "secret-token"
-	client, err := buildHTTPClient(cfg, map[string]string{"SESSION_ID": "inv-abc123"})
+	client, err := buildHTTPClient(cfg, map[string]string{"SESSION_ID": "exec-abc123"})
 	require.NoError(t, err)
 
 	resp, err := client.Get(server.URL)
@@ -178,7 +178,7 @@ func TestCreateTransport_HTTP_WithCustomHeaders(t *testing.T) {
 	defer func() { _ = resp.Body.Close() }()
 	_, _ = io.Copy(io.Discard, resp.Body)
 
-	assert.Equal(t, "inv-abc123", gotSessionID)
+	assert.Equal(t, "exec-abc123", gotSessionID)
 	assert.Equal(t, "Bearer secret-token", gotAuth)
 }
 
@@ -283,7 +283,7 @@ func TestBuildHTTPClient_SameOriginRedirectKeepsHeaders(t *testing.T) {
 			"X-Session-ID": "{{.SESSION_ID}}",
 		},
 	}
-	client, err := buildHTTPClient(cfg, map[string]string{"SESSION_ID": "inv-same"})
+	client, err := buildHTTPClient(cfg, map[string]string{"SESSION_ID": "exec-same"})
 	require.NoError(t, err)
 
 	resp, err := client.Get(server.URL + "/start")
@@ -293,7 +293,7 @@ func TestBuildHTTPClient_SameOriginRedirectKeepsHeaders(t *testing.T) {
 
 	assert.Equal(t, int32(2), hops.Load())
 	assert.Equal(t, "Bearer secret-token", secondAuth)
-	assert.Equal(t, "inv-same", secondSession)
+	assert.Equal(t, "exec-same", secondSession)
 }
 
 func TestBuildHTTPClient_SecretHeadersNotSentOnCrossOriginRedirect(t *testing.T) {
@@ -322,7 +322,7 @@ func TestBuildHTTPClient_SecretHeadersNotSentOnCrossOriginRedirect(t *testing.T)
 			"X-Session-ID": "{{.SESSION_ID}}",
 		},
 	}
-	client, err := buildHTTPClient(cfg, map[string]string{"SESSION_ID": "inv-abc123"})
+	client, err := buildHTTPClient(cfg, map[string]string{"SESSION_ID": "exec-abc123"})
 	require.NoError(t, err)
 
 	resp, err := client.Get(origin.URL)
@@ -331,7 +331,7 @@ func TestBuildHTTPClient_SecretHeadersNotSentOnCrossOriginRedirect(t *testing.T)
 	_, _ = io.Copy(io.Discard, resp.Body)
 
 	assert.Equal(t, "Bearer secret-token", originAuth)
-	assert.Equal(t, "inv-abc123", originSession)
+	assert.Equal(t, "exec-abc123", originSession)
 	assert.Empty(t, redirectAuth, "Authorization must not follow cross-origin redirect")
 	assert.Empty(t, redirectSession, "X-Session-ID must not follow cross-origin redirect")
 }

--- a/pkg/mcp/transport_test.go
+++ b/pkg/mcp/transport_test.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
@@ -199,4 +200,138 @@ func TestResolveHeaderTemplates(t *testing.T) {
 		require.NoError(t, err)
 		assert.Empty(t, got)
 	})
+
+	t.Run("empty headers map", func(t *testing.T) {
+		got, err := resolveHeaderTemplates(nil, map[string]string{"SESSION_ID": "x"})
+		require.NoError(t, err)
+		assert.Nil(t, got)
+	})
+
+	t.Run("omits empty static values", func(t *testing.T) {
+		got, err := resolveHeaderTemplates(map[string]string{
+			"X-Empty": "",
+			"X-Ok":    "v",
+		}, nil)
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{"X-Ok": "v"}, got)
+	})
+
+	t.Run("malformed template", func(t *testing.T) {
+		_, err := resolveHeaderTemplates(map[string]string{
+			"X-Bad": "{{.SESSION_ID}",
+		}, map[string]string{"SESSION_ID": "x"})
+		require.Error(t, err)
+	})
+
+	t.Run("execute error", func(t *testing.T) {
+		_, err := resolveHeaderTemplates(map[string]string{
+			"X-Bad": "{{call .SESSION_ID}}",
+		}, map[string]string{"SESSION_ID": "not-a-func"})
+		require.Error(t, err)
+	})
+}
+
+func TestBuildHTTPClient_ResolveHeaderError(t *testing.T) {
+	badHeaders := map[string]string{"X-Bad": "{{.SESSION_ID}}{{"}
+
+	_, err := buildHTTPClient(config.TransportConfig{
+		Type:          config.TransportTypeHTTP,
+		URL:           "https://mcp.example.com/mcp",
+		CustomHeaders: badHeaders,
+	}, map[string]string{"SESSION_ID": "x"})
+	require.Error(t, err)
+
+	_, err = createHTTPTransport(config.TransportConfig{
+		Type:          config.TransportTypeHTTP,
+		URL:           "https://mcp.example.com/mcp",
+		CustomHeaders: badHeaders,
+	}, map[string]string{"SESSION_ID": "x"})
+	require.Error(t, err)
+
+	_, err = createSSETransport(config.TransportConfig{
+		Type:          config.TransportTypeSSE,
+		URL:           "https://mcp.example.com/sse",
+		CustomHeaders: badHeaders,
+	}, map[string]string{"SESSION_ID": "x"})
+	require.Error(t, err)
+}
+
+func TestBuildHTTPClient_SameOriginRedirectKeepsHeaders(t *testing.T) {
+	var hops atomic.Int32
+	var secondAuth, secondSession string
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	mux.HandleFunc("/start", func(w http.ResponseWriter, r *http.Request) {
+		hops.Add(1)
+		http.Redirect(w, r, server.URL+"/end", http.StatusFound)
+	})
+	mux.HandleFunc("/end", func(w http.ResponseWriter, r *http.Request) {
+		hops.Add(1)
+		secondAuth = r.Header.Get("Authorization")
+		secondSession = r.Header.Get("X-Session-ID")
+		w.WriteHeader(http.StatusOK)
+	})
+
+	cfg := config.TransportConfig{
+		Type:        config.TransportTypeHTTP,
+		URL:         server.URL,
+		BearerToken: "secret-token",
+		CustomHeaders: map[string]string{
+			"X-Session-ID": "{{.SESSION_ID}}",
+		},
+	}
+	client, err := buildHTTPClient(cfg, map[string]string{"SESSION_ID": "inv-same"})
+	require.NoError(t, err)
+
+	resp, err := client.Get(server.URL + "/start")
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	assert.Equal(t, int32(2), hops.Load())
+	assert.Equal(t, "Bearer secret-token", secondAuth)
+	assert.Equal(t, "inv-same", secondSession)
+}
+
+func TestBuildHTTPClient_SecretHeadersNotSentOnCrossOriginRedirect(t *testing.T) {
+	var redirectAuth, redirectSession string
+	var originAuth, originSession string
+
+	redirectTarget := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		redirectAuth = r.Header.Get("Authorization")
+		redirectSession = r.Header.Get("X-Session-ID")
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(redirectTarget.Close)
+
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		originAuth = r.Header.Get("Authorization")
+		originSession = r.Header.Get("X-Session-ID")
+		http.Redirect(w, r, redirectTarget.URL+"/elsewhere", http.StatusFound)
+	}))
+	t.Cleanup(origin.Close)
+
+	cfg := config.TransportConfig{
+		Type:        config.TransportTypeHTTP,
+		URL:         origin.URL,
+		BearerToken: "secret-token",
+		CustomHeaders: map[string]string{
+			"X-Session-ID": "{{.SESSION_ID}}",
+		},
+	}
+	client, err := buildHTTPClient(cfg, map[string]string{"SESSION_ID": "inv-abc123"})
+	require.NoError(t, err)
+
+	resp, err := client.Get(origin.URL)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	assert.Equal(t, "Bearer secret-token", originAuth)
+	assert.Equal(t, "inv-abc123", originSession)
+	assert.Empty(t, redirectAuth, "Authorization must not follow cross-origin redirect")
+	assert.Empty(t, redirectSession, "X-Session-ID must not follow cross-origin redirect")
 }

--- a/pkg/queue/chat_executor.go
+++ b/pkg/queue/chat_executor.go
@@ -241,14 +241,6 @@ func (e *ChatMessageExecutor) execute(parentCtx context.Context, input ChatExecu
 	)
 	logger.Info("Chat executor: starting execution")
 
-	// Best-effort cleanup of session-scoped MCP sandboxes (cli-mcp-server).
-	// Runs on all exit paths; idle TTL remains the safety net on failure.
-	defer func() {
-		if e.cfg != nil && e.cfg.MCPServerRegistry != nil {
-			mcp.CleanupSessions(context.Background(), e.cfg.MCPServerRegistry, input.Session.ID, logger)
-		}
-	}()
-
 	// Create cancellable context with timeout
 	execCtx, cancel := context.WithTimeout(parentCtx, e.execConfig.SessionTimeout)
 	defer cancel()
@@ -362,8 +354,8 @@ func (e *ChatMessageExecutor) execute(parentCtx context.Context, input ChatExecu
 	defer cancelHeartbeat()
 	go e.runChatHeartbeat(heartbeatCtx, input.Chat.ID)
 
-	// 7. Create MCP ToolExecutor (shared helper, same as investigation)
-	toolExecutor, failedServers := createToolExecutor(execCtx, e.mcpFactory, serverIDs, toolFilter, input.Session.ID, logger)
+	// 7. Create MCP ToolExecutor (sandbox session key = agent execution ID)
+	toolExecutor, failedServers := createToolExecutor(execCtx, e.mcpFactory, serverIDs, toolFilter, exec.ID, logger)
 	defer func() { _ = toolExecutor.Close() }()
 
 	var chatSubCollector agent.SubAgentResultCollector

--- a/pkg/queue/chat_executor.go
+++ b/pkg/queue/chat_executor.go
@@ -241,6 +241,14 @@ func (e *ChatMessageExecutor) execute(parentCtx context.Context, input ChatExecu
 	)
 	logger.Info("Chat executor: starting execution")
 
+	// Best-effort cleanup of session-scoped MCP sandboxes (cli-mcp-server).
+	// Runs on all exit paths; idle TTL remains the safety net on failure.
+	defer func() {
+		if e.cfg != nil && e.cfg.MCPServerRegistry != nil {
+			mcp.CleanupSessions(context.Background(), e.cfg.MCPServerRegistry, input.Session.ID, logger)
+		}
+	}()
+
 	// Create cancellable context with timeout
 	execCtx, cancel := context.WithTimeout(parentCtx, e.execConfig.SessionTimeout)
 	defer cancel()

--- a/pkg/queue/chat_executor.go
+++ b/pkg/queue/chat_executor.go
@@ -355,7 +355,7 @@ func (e *ChatMessageExecutor) execute(parentCtx context.Context, input ChatExecu
 	go e.runChatHeartbeat(heartbeatCtx, input.Chat.ID)
 
 	// 7. Create MCP ToolExecutor (shared helper, same as investigation)
-	toolExecutor, failedServers := createToolExecutor(execCtx, e.mcpFactory, serverIDs, toolFilter, logger)
+	toolExecutor, failedServers := createToolExecutor(execCtx, e.mcpFactory, serverIDs, toolFilter, input.Session.ID, logger)
 	defer func() { _ = toolExecutor.Close() }()
 
 	var chatSubCollector agent.SubAgentResultCollector

--- a/pkg/queue/executor.go
+++ b/pkg/queue/executor.go
@@ -173,6 +173,14 @@ func (e *RealSessionExecutor) Execute(ctx context.Context, session *ent.AlertSes
 	)
 	logger.Info("Session executor: starting execution")
 
+	// Best-effort cleanup of session-scoped MCP sandboxes (cli-mcp-server).
+	// Runs on all exit paths; idle TTL remains the safety net on failure.
+	defer func() {
+		if e.cfg != nil && e.cfg.MCPServerRegistry != nil {
+			mcp.CleanupSessions(context.Background(), e.cfg.MCPServerRegistry, session.ID, logger)
+		}
+	}()
+
 	// 1. Resolve chain configuration
 	chain, err := e.cfg.GetChain(session.ChainID)
 	if err != nil {
@@ -635,7 +643,7 @@ func (e *RealSessionExecutor) executeAgent(
 	}
 
 	// Create MCP tool executor
-	toolExecutor, failedServers := createToolExecutor(ctx, e.mcpFactory, serverIDs, toolFilter, logger)
+	toolExecutor, failedServers := createToolExecutor(ctx, e.mcpFactory, serverIDs, toolFilter, input.session.ID, logger)
 	defer func() { _ = toolExecutor.Close() }()
 
 	// Retrieve memories for auto-injection into system prompt (only for agent types

--- a/pkg/queue/executor.go
+++ b/pkg/queue/executor.go
@@ -173,14 +173,6 @@ func (e *RealSessionExecutor) Execute(ctx context.Context, session *ent.AlertSes
 	)
 	logger.Info("Session executor: starting execution")
 
-	// Best-effort cleanup of session-scoped MCP sandboxes (cli-mcp-server).
-	// Runs on all exit paths; idle TTL remains the safety net on failure.
-	defer func() {
-		if e.cfg != nil && e.cfg.MCPServerRegistry != nil {
-			mcp.CleanupSessions(context.Background(), e.cfg.MCPServerRegistry, session.ID, logger)
-		}
-	}()
-
 	// 1. Resolve chain configuration
 	chain, err := e.cfg.GetChain(session.ChainID)
 	if err != nil {
@@ -642,8 +634,8 @@ func (e *RealSessionExecutor) executeAgent(
 		}
 	}
 
-	// Create MCP tool executor
-	toolExecutor, failedServers := createToolExecutor(ctx, e.mcpFactory, serverIDs, toolFilter, input.session.ID, logger)
+	// Create MCP tool executor (sandbox session key = agent execution ID)
+	toolExecutor, failedServers := createToolExecutor(ctx, e.mcpFactory, serverIDs, toolFilter, exec.ID, logger)
 	defer func() { _ = toolExecutor.Close() }()
 
 	// Retrieve memories for auto-injection into system prompt (only for agent types

--- a/pkg/queue/executor_helpers.go
+++ b/pkg/queue/executor_helpers.go
@@ -27,15 +27,17 @@ import (
 
 // createToolExecutor creates an MCP tool executor or falls back to a stub.
 // Package-level function shared by RealSessionExecutor and ChatMessageExecutor.
+// sessionID is forwarded for per-session custom_headers (e.g. X-Session-ID).
 func createToolExecutor(
 	ctx context.Context,
 	mcpFactory *mcp.ClientFactory,
 	serverIDs []string,
 	toolFilter map[string][]string,
+	sessionID string,
 	logger *slog.Logger,
 ) (agent.ToolExecutor, map[string]string) {
 	if mcpFactory != nil && len(serverIDs) > 0 {
-		mcpExecutor, mcpClient, mcpErr := mcpFactory.CreateToolExecutor(ctx, serverIDs, toolFilter)
+		mcpExecutor, mcpClient, mcpErr := mcpFactory.CreateToolExecutor(ctx, serverIDs, toolFilter, sessionID)
 		if mcpErr != nil {
 			logger.Warn("Failed to create MCP tool executor, using stub", "error", mcpErr)
 			return agent.NewStubToolExecutor(nil), nil

--- a/pkg/queue/executor_helpers.go
+++ b/pkg/queue/executor_helpers.go
@@ -27,17 +27,18 @@ import (
 
 // createToolExecutor creates an MCP tool executor or falls back to a stub.
 // Package-level function shared by RealSessionExecutor and ChatMessageExecutor.
-// sessionID is forwarded for per-session custom_headers (e.g. X-Session-ID).
+// mcpSessionID is the agent execution ID used for per-execution custom_headers
+// (e.g. X-Session-ID for cli-mcp sandbox isolation).
 func createToolExecutor(
 	ctx context.Context,
 	mcpFactory *mcp.ClientFactory,
 	serverIDs []string,
 	toolFilter map[string][]string,
-	sessionID string,
+	mcpSessionID string,
 	logger *slog.Logger,
 ) (agent.ToolExecutor, map[string]string) {
 	if mcpFactory != nil && len(serverIDs) > 0 {
-		mcpExecutor, mcpClient, mcpErr := mcpFactory.CreateToolExecutor(ctx, serverIDs, toolFilter, sessionID)
+		mcpExecutor, mcpClient, mcpErr := mcpFactory.CreateToolExecutor(ctx, serverIDs, toolFilter, mcpSessionID)
 		if mcpErr != nil {
 			logger.Warn("Failed to create MCP tool executor, using stub", "error", mcpErr)
 			return agent.NewStubToolExecutor(nil), nil

--- a/test/e2e/harness.go
+++ b/test/e2e/harness.go
@@ -60,6 +60,7 @@ type testAppConfig struct {
 	cfg                   *config.Config
 	llmClient             *ScriptedLLMClient
 	mcpServers            map[string]map[string]mcpsdk.ToolHandler
+	mcpFactory            *mcp.ClientFactory
 	workerCount           int
 	maxConcurrentSessions int
 	sessionTimeout        time.Duration
@@ -88,6 +89,12 @@ func WithLLMClient(client *ScriptedLLMClient) TestAppOption {
 // Maps serverID → (toolName → handler).
 func WithMCPServers(servers map[string]map[string]mcpsdk.ToolHandler) TestAppOption {
 	return func(c *testAppConfig) { c.mcpServers = servers }
+}
+
+// WithMCPFactory sets a real MCP client factory (e.g. for HTTP transport e2e).
+// When set, it takes precedence over WithMCPServers.
+func WithMCPFactory(factory *mcp.ClientFactory) TestAppOption {
+	return func(c *testAppConfig) { c.mcpFactory = factory }
 }
 
 // WithWorkerCount sets the number of worker pool goroutines.
@@ -210,9 +217,12 @@ func NewTestApp(t *testing.T, opts ...TestAppOption) *TestApp {
 	require.NoError(t, notifyListener.Start(ctx))
 	connManager.SetListener(notifyListener)
 
-	// 5. MCP — in-memory servers if configured.
+	// 5. MCP — explicit factory, else in-memory servers if configured.
 	var mcpFactory *mcp.ClientFactory
-	if len(tc.mcpServers) > 0 {
+	switch {
+	case tc.mcpFactory != nil:
+		mcpFactory = tc.mcpFactory
+	case len(tc.mcpServers) > 0:
 		mcpFactory = SetupInMemoryMCP(t, tc.mcpServers)
 	}
 

--- a/test/e2e/mcp_helpers.go
+++ b/test/e2e/mcp_helpers.go
@@ -52,7 +52,7 @@ func SetupInMemoryMCP(t *testing.T, servers map[string]map[string]mcpsdk.ToolHan
 	registry := config.NewMCPServerRegistry(mcpConfigs)
 
 	// Create a ClientFactory that spins up fresh in-memory transports per call.
-	return mcp.NewTestClientFactory(registry, func(c *mcp.Client) {
+	return mcp.NewTestClientFactory(registry, func(c *mcp.Client, _ string) {
 		for _, spec := range specs {
 			server := mcpsdk.NewServer(&mcpsdk.Implementation{
 				Name: spec.serverID, Version: "test",

--- a/test/e2e/session_headers_test.go
+++ b/test/e2e/session_headers_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/codeready-toolchain/tarsy/ent"
 	"github.com/codeready-toolchain/tarsy/pkg/agent"
 	"github.com/codeready-toolchain/tarsy/pkg/mcp"
 	"github.com/codeready-toolchain/tarsy/test/e2e/testdata/configs"
@@ -86,10 +87,8 @@ func startSessionScopedMCPServer(t *testing.T, recorder *sessionMCPRecorder) *ht
 	return httpServer
 }
 
-// TestE2E_SessionHeadersAndCleanup verifies that when configured:
-//   - X-Session-ID custom header is set to the investigation/chat session ID
-//   - session_cleanup_url DELETE is called after investigation and chat
-func TestE2E_SessionHeadersAndCleanup(t *testing.T) {
+func setupSessionHeadersApp(t *testing.T, llm *ScriptedLLMClient) (*sessionMCPRecorder, *TestApp) {
+	t.Helper()
 	recorder := &sessionMCPRecorder{}
 	mcpServer := startSessionScopedMCPServer(t, recorder)
 
@@ -99,6 +98,71 @@ func TestE2E_SessionHeadersAndCleanup(t *testing.T) {
 	serverCfg.Transport.URL = mcpServer.URL + "/mcp"
 	serverCfg.Transport.SessionCleanupURL = mcpServer.URL + "/sessions/{{.SESSION_ID}}"
 
+	factory := mcp.NewClientFactory(cfg.MCPServerRegistry, nil)
+	app := NewTestApp(t,
+		WithConfig(cfg),
+		WithLLMClient(llm),
+		WithMCPFactory(factory),
+	)
+	return recorder, app
+}
+
+func executionIDs(execs []*ent.AgentExecution) map[string]struct{} {
+	ids := make(map[string]struct{}, len(execs))
+	for _, e := range execs {
+		ids[e.ID] = struct{}{}
+	}
+	return ids
+}
+
+func findExecByName(t *testing.T, execs []*ent.AgentExecution, name string) *ent.AgentExecution {
+	t.Helper()
+	for _, e := range execs {
+		if e.AgentName == name {
+			return e
+		}
+	}
+	require.FailNow(t, "execution not found", "agent_name=%s", name)
+	return nil
+}
+
+func assertHeadersAreExecutionIDs(t *testing.T, headers []string, execIDs map[string]struct{}, investigationID string) {
+	t.Helper()
+	require.NotEmpty(t, headers, "expected X-Session-ID on MCP requests")
+	for _, h := range headers {
+		assert.NotEqual(t, investigationID, h, "investigation session ID must not be used as X-Session-ID")
+		assert.NotEmpty(t, h, "X-Session-ID must not be blank")
+		_, ok := execIDs[h]
+		assert.True(t, ok, "X-Session-ID %q must be an agent execution ID", h)
+	}
+}
+
+func waitForDeletes(t *testing.T, recorder *sessionMCPRecorder, wantIDs ...string) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		got := recorder.deletes()
+		for _, want := range wantIDs {
+			found := false
+			for _, id := range got {
+				if id == want {
+					found = true
+					break
+				}
+			}
+			if !found {
+				return false
+			}
+		}
+		return true
+	}, 10*time.Second, 50*time.Millisecond,
+		"expected DELETE for execution IDs %v, got %v", wantIDs, recorder.deletes())
+}
+
+// TestE2E_SessionHeadersAndCleanup verifies per-agent-execution sandbox keys:
+//   - X-Session-ID is the agent execution ID (not investigation session ID)
+//   - DELETE /sessions/{executionID} runs when that execution's MCP client closes
+//   - Chat uses a distinct chat execution ID
+func TestE2E_SessionHeadersAndCleanup(t *testing.T) {
 	llm := NewScriptedLLMClient()
 	// Investigation: tool call then final answer.
 	llm.AddSequential(LLMScriptEntry{
@@ -114,6 +178,8 @@ func TestE2E_SessionHeadersAndCleanup(t *testing.T) {
 			&agent.UsageChunk{InputTokens: 10, OutputTokens: 5, TotalTokens: 15},
 		},
 	})
+	// Executive summary (always runs; fail-open if missing — keep scripts deterministic).
+	llm.AddSequential(LLMScriptEntry{Text: "Session MCP investigation summary."})
 	// Chat: tool call then final answer.
 	llm.AddSequential(LLMScriptEntry{
 		Chunks: []agent.Chunk{
@@ -129,12 +195,7 @@ func TestE2E_SessionHeadersAndCleanup(t *testing.T) {
 		},
 	})
 
-	factory := mcp.NewClientFactory(cfg.MCPServerRegistry, nil)
-	app := NewTestApp(t,
-		WithConfig(cfg),
-		WithLLMClient(llm),
-		WithMCPFactory(factory),
-	)
+	recorder, app := setupSessionHeadersApp(t, llm)
 
 	resp := app.SubmitAlert(t, "test-session-headers", "session header probe")
 	sessionID := resp["session_id"].(string)
@@ -142,37 +203,194 @@ func TestE2E_SessionHeadersAndCleanup(t *testing.T) {
 
 	app.WaitForSessionStatus(t, sessionID, "completed")
 
-	require.Eventually(t, func() bool {
-		for _, id := range recorder.deletes() {
-			if id == sessionID {
-				return true
-			}
-		}
-		return false
-	}, 10*time.Second, 50*time.Millisecond, "expected investigation cleanup DELETE for %s", sessionID)
+	invExecs := app.QueryExecutions(t, sessionID)
+	require.NotEmpty(t, invExecs)
+	invAgent := findExecByName(t, invExecs, "SessionAgent")
+	waitForDeletes(t, recorder, invAgent.ID)
 
 	headersAfterInvestigation := recorder.headers()
-	require.NotEmpty(t, headersAfterInvestigation, "expected X-Session-ID on MCP requests")
+	assertHeadersAreExecutionIDs(t, headersAfterInvestigation, executionIDs(invExecs), sessionID)
 	for _, h := range headersAfterInvestigation {
-		assert.Equal(t, sessionID, h, "investigation MCP requests must carry session ID")
+		assert.Equal(t, invAgent.ID, h, "investigation MCP traffic must use SessionAgent execution ID")
 	}
 
 	deletesAfterInvestigation := len(recorder.deletes())
+	assert.NotContains(t, recorder.deletes(), sessionID)
 
 	chatResp := app.SendChatMessage(t, sessionID, "Follow up with session MCP")
 	chatStageID := chatResp["stage_id"].(string)
 	require.NotEmpty(t, chatStageID)
 	app.WaitForStageStatus(t, chatStageID, "completed")
 
-	require.Eventually(t, func() bool {
-		return len(recorder.deletes()) > deletesAfterInvestigation
-	}, 10*time.Second, 50*time.Millisecond, "expected chat cleanup DELETE")
+	allExecs := app.QueryExecutions(t, sessionID)
+	chatAgent := findExecByName(t, allExecs, "ChatAgent")
+	assert.NotEqual(t, invAgent.ID, chatAgent.ID, "chat must create its own agent execution")
 
-	deletes := recorder.deletes()
-	assert.Contains(t, deletes, sessionID)
-	assert.GreaterOrEqual(t, len(deletes), 2, "cleanup should run after investigation and chat")
+	waitForDeletes(t, recorder, chatAgent.ID)
+	require.Greater(t, len(recorder.deletes()), deletesAfterInvestigation)
 
+	assert.Contains(t, recorder.deletes(), invAgent.ID)
+	assert.Contains(t, recorder.deletes(), chatAgent.ID)
+	assert.NotContains(t, recorder.deletes(), sessionID)
+
+	assertHeadersAreExecutionIDs(t, recorder.headers(), executionIDs(allExecs), sessionID)
+}
+
+// TestE2E_SessionHeaders_ParallelAgents verifies parallel stage agents get
+// distinct sandbox session IDs and each is cleaned up independently.
+func TestE2E_SessionHeaders_ParallelAgents(t *testing.T) {
+	llm := NewScriptedLLMClient()
+
+	llm.AddRouted("SessionAgentA", LLMScriptEntry{
+		Chunks: []agent.Chunk{
+			&agent.ToolCallChunk{CallID: "a-1", Name: "session-mcp__echo", Arguments: `{}`},
+			&agent.UsageChunk{InputTokens: 10, OutputTokens: 5, TotalTokens: 15},
+		},
+	})
+	llm.AddRouted("SessionAgentA", LLMScriptEntry{
+		Chunks: []agent.Chunk{
+			&agent.TextChunk{Content: "AgentA done."},
+			&agent.UsageChunk{InputTokens: 10, OutputTokens: 5, TotalTokens: 15},
+		},
+	})
+	llm.AddRouted("SessionAgentB", LLMScriptEntry{
+		Chunks: []agent.Chunk{
+			&agent.ToolCallChunk{CallID: "b-1", Name: "session-mcp__echo", Arguments: `{}`},
+			&agent.UsageChunk{InputTokens: 10, OutputTokens: 5, TotalTokens: 15},
+		},
+	})
+	llm.AddRouted("SessionAgentB", LLMScriptEntry{
+		Chunks: []agent.Chunk{
+			&agent.TextChunk{Content: "AgentB done."},
+			&agent.UsageChunk{InputTokens: 10, OutputTokens: 5, TotalTokens: 15},
+		},
+	})
+	// Mandatory synthesis after multi-agent stage.
+	llm.AddSequential(LLMScriptEntry{
+		Chunks: []agent.Chunk{
+			&agent.TextChunk{Content: "Combined: both agents confirmed session MCP isolation."},
+			&agent.UsageChunk{InputTokens: 20, OutputTokens: 10, TotalTokens: 30},
+		},
+	})
+	llm.AddSequential(LLMScriptEntry{Text: "Parallel session MCP summary."})
+
+	recorder, app := setupSessionHeadersApp(t, llm)
+
+	resp := app.SubmitAlert(t, "test-session-headers-parallel", "parallel session header probe")
+	sessionID := resp["session_id"].(string)
+	require.NotEmpty(t, sessionID)
+
+	app.WaitForSessionStatus(t, sessionID, "completed")
+
+	execs := app.QueryExecutions(t, sessionID)
+	agentA := findExecByName(t, execs, "SessionAgentA")
+	agentB := findExecByName(t, execs, "SessionAgentB")
+	assert.NotEqual(t, agentA.ID, agentB.ID)
+
+	waitForDeletes(t, recorder, agentA.ID, agentB.ID)
+
+	uniqueHeaders := map[string]struct{}{}
 	for _, h := range recorder.headers() {
-		assert.Equal(t, sessionID, h, "all MCP requests must carry session ID")
+		uniqueHeaders[h] = struct{}{}
 	}
+	assert.Contains(t, uniqueHeaders, agentA.ID)
+	assert.Contains(t, uniqueHeaders, agentB.ID)
+	assert.NotContains(t, uniqueHeaders, sessionID)
+
+	assertHeadersAreExecutionIDs(t, recorder.headers(), executionIDs(execs), sessionID)
+	assert.NotContains(t, recorder.deletes(), sessionID)
+}
+
+// TestE2E_SessionHeaders_SubAgents verifies orchestrator parent and sub-agent
+// each get their own sandbox session ID and cleanup DELETE.
+func TestE2E_SessionHeaders_SubAgents(t *testing.T) {
+	llm := NewScriptedLLMClient()
+
+	subAgentGate := make(chan struct{})
+	orchIter2Gate := make(chan struct{})
+	orchIter2Ready := make(chan struct{}, 1)
+
+	// Iteration 1: parent uses session-mcp then dispatches SessionWorker.
+	llm.AddRouted("SessionOrchestrator", LLMScriptEntry{
+		Chunks: []agent.Chunk{
+			&agent.ToolCallChunk{CallID: "orch-echo", Name: "session-mcp__echo", Arguments: `{}`},
+			&agent.ToolCallChunk{CallID: "orch-dispatch", Name: "dispatch_agent",
+				Arguments: `{"name":"SessionWorker","task":"Probe session MCP in isolation"}`},
+			&agent.UsageChunk{InputTokens: 50, OutputTokens: 20, TotalTokens: 70},
+		},
+	})
+	// Iteration 2: wait for sub-agent.
+	llm.AddRouted("SessionOrchestrator", LLMScriptEntry{
+		WaitCh:  orchIter2Gate,
+		OnBlock: orchIter2Ready,
+		Chunks: []agent.Chunk{
+			&agent.TextChunk{Content: "Waiting for SessionWorker."},
+			&agent.UsageChunk{InputTokens: 60, OutputTokens: 10, TotalTokens: 70},
+		},
+	})
+	// Iteration 3: final answer.
+	llm.AddRouted("SessionOrchestrator", LLMScriptEntry{
+		Chunks: []agent.Chunk{
+			&agent.TextChunk{Content: "Investigation complete: parent and sub-agent used isolated sandboxes."},
+			&agent.UsageChunk{InputTokens: 80, OutputTokens: 20, TotalTokens: 100},
+		},
+	})
+
+	llm.AddRouted("SessionWorker", LLMScriptEntry{
+		WaitCh: subAgentGate,
+		Chunks: []agent.Chunk{
+			&agent.ToolCallChunk{CallID: "worker-echo", Name: "session-mcp__echo", Arguments: `{}`},
+			&agent.UsageChunk{InputTokens: 30, OutputTokens: 10, TotalTokens: 40},
+		},
+	})
+	llm.AddRouted("SessionWorker", LLMScriptEntry{
+		Chunks: []agent.Chunk{
+			&agent.TextChunk{Content: "SessionWorker finished with isolated session MCP."},
+			&agent.UsageChunk{InputTokens: 40, OutputTokens: 15, TotalTokens: 55},
+		},
+	})
+	llm.AddSequential(LLMScriptEntry{Text: "Orchestrator session MCP summary."})
+
+	recorder, app := setupSessionHeadersApp(t, llm)
+
+	resp := app.SubmitAlert(t, "test-session-headers-orchestrator", "orchestrator session header probe")
+	sessionID := resp["session_id"].(string)
+	require.NotEmpty(t, sessionID)
+
+	app.WaitForSessionStatus(t, sessionID, "in_progress")
+	go func() {
+		<-orchIter2Ready
+		baseline, err := app.CountLLMInteractions(sessionID)
+		if err != nil {
+			t.Errorf("CountLLMInteractions failed: %v", err)
+		}
+		close(orchIter2Gate)
+		if !app.AwaitLLMInteractionIncrease(sessionID, baseline) {
+			t.Errorf("AwaitLLMInteractionIncrease timed out (baseline=%d)", baseline)
+		}
+		close(subAgentGate)
+	}()
+
+	app.WaitForSessionStatus(t, sessionID, "completed")
+
+	execs := app.QueryExecutions(t, sessionID)
+	orch := findExecByName(t, execs, "SessionOrchestrator")
+	worker := findExecByName(t, execs, "SessionWorker")
+	require.NotNil(t, worker.ParentExecutionID)
+	assert.Equal(t, orch.ID, *worker.ParentExecutionID)
+	assert.NotEqual(t, orch.ID, worker.ID)
+
+	waitForDeletes(t, recorder, orch.ID, worker.ID)
+
+	uniqueHeaders := map[string]struct{}{}
+	for _, h := range recorder.headers() {
+		uniqueHeaders[h] = struct{}{}
+	}
+	assert.Contains(t, uniqueHeaders, orch.ID, "parent must send its execution ID as X-Session-ID")
+	assert.Contains(t, uniqueHeaders, worker.ID, "sub-agent must send its execution ID as X-Session-ID")
+	assert.NotContains(t, uniqueHeaders, sessionID)
+
+	assertHeadersAreExecutionIDs(t, recorder.headers(), executionIDs(execs), sessionID)
+	assert.NotContains(t, recorder.deletes(), sessionID)
+	assert.GreaterOrEqual(t, len(uniqueHeaders), 2, "expected at least parent + sub sandbox IDs")
 }

--- a/test/e2e/session_headers_test.go
+++ b/test/e2e/session_headers_test.go
@@ -296,9 +296,13 @@ func TestE2E_SessionHeaders_ParallelAgents(t *testing.T) {
 	assert.Contains(t, uniqueHeaders, agentA.ID)
 	assert.Contains(t, uniqueHeaders, agentB.ID)
 	assert.NotContains(t, uniqueHeaders, sessionID)
+	assert.Len(t, uniqueHeaders, 2, "exactly two sandbox IDs for two parallel agents")
 
 	assertHeadersAreExecutionIDs(t, recorder.headers(), executionIDs(execs), sessionID)
-	assert.NotContains(t, recorder.deletes(), sessionID)
+	deletes := recorder.deletes()
+	assert.NotContains(t, deletes, sessionID)
+	assert.ElementsMatch(t, []string{agentA.ID, agentB.ID}, deletes,
+		"exactly one DELETE per parallel agent execution")
 }
 
 // TestE2E_SessionHeaders_SubAgents verifies orchestrator parent and sub-agent

--- a/test/e2e/session_headers_test.go
+++ b/test/e2e/session_headers_test.go
@@ -1,0 +1,178 @@
+package e2e
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/codeready-toolchain/tarsy/pkg/agent"
+	"github.com/codeready-toolchain/tarsy/pkg/mcp"
+	"github.com/codeready-toolchain/tarsy/test/e2e/testdata/configs"
+)
+
+// sessionMCPRecorder captures X-Session-ID on MCP traffic and DELETE /sessions/{id}.
+type sessionMCPRecorder struct {
+	mu              sync.Mutex
+	sessionHeaders  []string
+	deletedSessions []string
+}
+
+func (r *sessionMCPRecorder) recordHeader(v string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.sessionHeaders = append(r.sessionHeaders, v)
+}
+
+func (r *sessionMCPRecorder) recordDelete(id string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.deletedSessions = append(r.deletedSessions, id)
+}
+
+func (r *sessionMCPRecorder) headers() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]string, len(r.sessionHeaders))
+	copy(out, r.sessionHeaders)
+	return out
+}
+
+func (r *sessionMCPRecorder) deletes() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]string, len(r.deletedSessions))
+	copy(out, r.deletedSessions)
+	return out
+}
+
+func startSessionScopedMCPServer(t *testing.T, recorder *sessionMCPRecorder) *httptest.Server {
+	t.Helper()
+
+	server := mcpsdk.NewServer(&mcpsdk.Implementation{Name: "session-mcp", Version: "test"}, nil)
+	server.AddTool(&mcpsdk.Tool{
+		Name:        "echo",
+		Description: "echo tool for session header e2e",
+		InputSchema: emptySchema,
+	}, StaticToolHandler(`{"ok":true}`))
+
+	mcpHandler := mcpsdk.NewStreamableHTTPHandler(func(_ *http.Request) *mcpsdk.Server {
+		return server
+	}, &mcpsdk.StreamableHTTPOptions{JSONResponse: true, Stateless: true})
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/mcp", func(w http.ResponseWriter, req *http.Request) {
+		recorder.recordHeader(req.Header.Get("X-Session-ID"))
+		mcpHandler.ServeHTTP(w, req)
+	})
+	mux.HandleFunc("/sessions/", func(w http.ResponseWriter, req *http.Request) {
+		if req.Method != http.MethodDelete {
+			http.NotFound(w, req)
+			return
+		}
+		id := strings.TrimPrefix(req.URL.Path, "/sessions/")
+		recorder.recordDelete(id)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	httpServer := httptest.NewServer(mux)
+	t.Cleanup(httpServer.Close)
+	return httpServer
+}
+
+// TestE2E_SessionHeadersAndCleanup verifies that when configured:
+//   - X-Session-ID custom header is set to the investigation/chat session ID
+//   - session_cleanup_url DELETE is called after investigation and chat
+func TestE2E_SessionHeadersAndCleanup(t *testing.T) {
+	recorder := &sessionMCPRecorder{}
+	mcpServer := startSessionScopedMCPServer(t, recorder)
+
+	cfg := configs.Load(t, "session-headers")
+	serverCfg, err := cfg.MCPServerRegistry.Get("session-mcp")
+	require.NoError(t, err)
+	serverCfg.Transport.URL = mcpServer.URL + "/mcp"
+	serverCfg.Transport.SessionCleanupURL = mcpServer.URL + "/sessions/{{.SESSION_ID}}"
+
+	llm := NewScriptedLLMClient()
+	// Investigation: tool call then final answer.
+	llm.AddSequential(LLMScriptEntry{
+		Chunks: []agent.Chunk{
+			&agent.TextChunk{Content: "Checking via session MCP."},
+			&agent.ToolCallChunk{CallID: "call-1", Name: "session-mcp__echo", Arguments: `{}`},
+			&agent.UsageChunk{InputTokens: 10, OutputTokens: 5, TotalTokens: 15},
+		},
+	})
+	llm.AddSequential(LLMScriptEntry{
+		Chunks: []agent.Chunk{
+			&agent.TextChunk{Content: "Investigation complete: session MCP ok."},
+			&agent.UsageChunk{InputTokens: 10, OutputTokens: 5, TotalTokens: 15},
+		},
+	})
+	// Chat: tool call then final answer.
+	llm.AddSequential(LLMScriptEntry{
+		Chunks: []agent.Chunk{
+			&agent.TextChunk{Content: "Following up via session MCP."},
+			&agent.ToolCallChunk{CallID: "call-chat-1", Name: "session-mcp__echo", Arguments: `{}`},
+			&agent.UsageChunk{InputTokens: 10, OutputTokens: 5, TotalTokens: 15},
+		},
+	})
+	llm.AddSequential(LLMScriptEntry{
+		Chunks: []agent.Chunk{
+			&agent.TextChunk{Content: "Chat complete: session MCP ok."},
+			&agent.UsageChunk{InputTokens: 10, OutputTokens: 5, TotalTokens: 15},
+		},
+	})
+
+	factory := mcp.NewClientFactory(cfg.MCPServerRegistry, nil)
+	app := NewTestApp(t,
+		WithConfig(cfg),
+		WithLLMClient(llm),
+		WithMCPFactory(factory),
+	)
+
+	resp := app.SubmitAlert(t, "test-session-headers", "session header probe")
+	sessionID := resp["session_id"].(string)
+	require.NotEmpty(t, sessionID)
+
+	app.WaitForSessionStatus(t, sessionID, "completed")
+
+	require.Eventually(t, func() bool {
+		for _, id := range recorder.deletes() {
+			if id == sessionID {
+				return true
+			}
+		}
+		return false
+	}, 10*time.Second, 50*time.Millisecond, "expected investigation cleanup DELETE for %s", sessionID)
+
+	headersAfterInvestigation := recorder.headers()
+	require.NotEmpty(t, headersAfterInvestigation, "expected X-Session-ID on MCP requests")
+	for _, h := range headersAfterInvestigation {
+		assert.Equal(t, sessionID, h, "investigation MCP requests must carry session ID")
+	}
+
+	deletesAfterInvestigation := len(recorder.deletes())
+
+	chatResp := app.SendChatMessage(t, sessionID, "Follow up with session MCP")
+	chatStageID := chatResp["stage_id"].(string)
+	require.NotEmpty(t, chatStageID)
+	app.WaitForStageStatus(t, chatStageID, "completed")
+
+	require.Eventually(t, func() bool {
+		return len(recorder.deletes()) > deletesAfterInvestigation
+	}, 10*time.Second, 50*time.Millisecond, "expected chat cleanup DELETE")
+
+	deletes := recorder.deletes()
+	assert.Contains(t, deletes, sessionID)
+	assert.GreaterOrEqual(t, len(deletes), 2, "cleanup should run after investigation and chat")
+
+	for _, h := range recorder.headers() {
+		assert.Equal(t, sessionID, h, "all MCP requests must carry session ID")
+	}
+}

--- a/test/e2e/testdata/configs/session-headers/llm-providers.yaml
+++ b/test/e2e/testdata/configs/session-headers/llm-providers.yaml
@@ -1,0 +1,5 @@
+llm_providers:
+  test-provider:
+    type: google
+    model: test-model
+    max_tool_result_tokens: 10000

--- a/test/e2e/testdata/configs/session-headers/tarsy.yaml
+++ b/test/e2e/testdata/configs/session-headers/tarsy.yaml
@@ -23,11 +23,53 @@ agents:
   SessionAgent:
     mcp_servers: [session-mcp]
     custom_instructions: "You are SessionAgent. Use session-mcp tools when investigating."
+  SessionAgentA:
+    mcp_servers: [session-mcp]
+    custom_instructions: "You are SessionAgentA. Use session-mcp tools when investigating."
+  SessionAgentB:
+    mcp_servers: [session-mcp]
+    custom_instructions: "You are SessionAgentB. Use session-mcp tools when investigating."
+  ChatAgent:
+    mcp_servers: [session-mcp]
+    custom_instructions: "You are ChatAgent. Use session-mcp tools for follow-ups."
+  SessionOrchestrator:
+    description: "Orchestrator for session-header isolation e2e"
+    mcp_servers: [session-mcp]
+    custom_instructions: "You are SessionOrchestrator. Dispatch sub-agents and use session-mcp when needed."
+    orchestrator:
+      max_concurrent_agents: 5
+      agent_timeout: 300s
+  SessionWorker:
+    description: "Sub-agent with session-mcp"
+    mcp_servers: [session-mcp]
+    max_iterations: 2
+    custom_instructions: "You are SessionWorker. Use session-mcp tools for deep work."
 
 agent_chains:
   session-headers-chain:
     alert_types: [test-session-headers]
+    chat:
+      enabled: true
+      agent: "ChatAgent"
+      llm_backend: "google-native"
     stages:
       - name: investigation
         agents:
           - name: SessionAgent
+
+  session-headers-parallel-chain:
+    alert_types: [test-session-headers-parallel]
+    stages:
+      - name: investigation
+        agents:
+          - name: SessionAgentA
+          - name: SessionAgentB
+
+  session-headers-orchestrator-chain:
+    alert_types: [test-session-headers-orchestrator]
+    stages:
+      - name: orchestrate
+        agents:
+          - name: SessionOrchestrator
+            sub_agents:
+              - name: SessionWorker

--- a/test/e2e/testdata/configs/session-headers/tarsy.yaml
+++ b/test/e2e/testdata/configs/session-headers/tarsy.yaml
@@ -1,0 +1,33 @@
+defaults:
+  llm_provider: "test-provider"
+  llm_backend: "google-native"
+  max_iterations: 3
+
+mcp_servers:
+  # Built-in KubernetesAgent requires this server for validation.
+  kubernetes-server:
+    transport:
+      type: stdio
+      command: mock
+  # Placeholder URL is overwritten at runtime to the httptest MCP mock.
+  session-mcp:
+    transport:
+      type: http
+      url: "http://127.0.0.1:9/mcp"
+      bearer_token: "e2e-session-token"
+      custom_headers:
+        X-Session-ID: "{{.SESSION_ID}}"
+      session_cleanup_url: "http://127.0.0.1:9/sessions/{{.SESSION_ID}}"
+
+agents:
+  SessionAgent:
+    mcp_servers: [session-mcp]
+    custom_instructions: "You are SessionAgent. Use session-mcp tools when investigating."
+
+agent_chains:
+  session-headers-chain:
+    alert_types: [test-session-headers]
+    stages:
+      - name: investigation
+        agents:
+          - name: SessionAgent


### PR DESCRIPTION
- Add HTTP/SSE MCP `custom_headers` with per-investigation `{{.SESSION_ID}}` resolution (not process env), so cli-mcp can bind bash pods via `X-Session-ID`.
- Preserve `SESSION_ID` through config env expansion and wire the investigation/chat session ID into MCP client creation.
- Best-effort `DELETE /sessions/{id}` cleanup after alert/chat investigations for servers that use session-scoped headers; idle TTL remains the safety net.
- Document a `cli-mcp-server` example in `tarsy.yaml.example` (bearer token + `custom_headers`).

Assisted By: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MCP `X-Session-ID` and `session_cleanup_url` are now scoped to the agent execution, so sandboxes are cleaned up per execution.
  * Added/expanded the example MCP configuration to demonstrate execution-scoped headers, masking, and cleanup.
* **Bug Fixes**
  * Prevented `custom_headers` and authorization from being sent to cross-origin redirect targets.
  * Improved transport sanitization to return allowlisted custom header key names (without exposing values) and to avoid leaking templated session header data.
  * Cleanup is more reliable and idempotent, and only runs for explicitly requested executions/servers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->