### PR TITLE
feat: Add Tier 0 calendar and staffing context for agents

### DIFF
--- a/deploy/config/tarsy.yaml.example
+++ b/deploy/config/tarsy.yaml.example
@@ -80,8 +80,23 @@ system:
     channel: "C12345678"           # Slack channel ID (required when enabled)
 
   # Global holidays for Tier 0 calendar / staffing context (UTC, year-agnostic MM-DD).
-  # When omitted or empty, TARSy uses a small built-in list (Christmas, New Year's Day, …).
-  # When set, this list REPLACES the built-in defaults.
+  #
+  # At prompt-build time TARSy injects wall-clock UTC into every investigation /
+  # chat / action agent system prompt as Tier 0 Context, for example:
+  #   Calendar context (UTC): 2026-12-25 — Thursday — GLOBAL_HOLIDAY (Christmas)
+  #   Staffing: reduced (humans less likely to review promptly)
+  # Saturday/Sunday classify as WEEKEND even when not listed here. Matching a
+  # holiday date classifies as GLOBAL_HOLIDAY (<name>) and takes priority over
+  # WEEKEND. Agents should read this block — they must not re-derive weekday or
+  # holiday from alert/session timestamps.
+  #
+  # Typical use: give agents a soft signal when humans are less likely to review
+  # promptly (weekends / global holidays). It does not by itself trigger actions.
+  #
+  # When omitted or empty, TARSy uses a small built-in list (New Year's Day,
+  # Christmas). When set, this list REPLACES the built-in defaults — include
+  # every date you want classified as a holiday (e.g. a multi-day break).
+  # See docs/adr/0022-tier0-calendar-staffing.md.
   # holidays:
   #   - date: "12-25"
   #     name: "Christmas"

--- a/deploy/config/tarsy.yaml.example
+++ b/deploy/config/tarsy.yaml.example
@@ -83,7 +83,7 @@ system:
   #
   # At prompt-build time TARSy injects wall-clock UTC into every investigation /
   # chat / action agent system prompt as Tier 0 Context, for example:
-  #   Calendar context (UTC): 2026-12-25 — Thursday — GLOBAL_HOLIDAY (Christmas)
+  #   Calendar context (UTC): 2026-12-25 — Friday — GLOBAL_HOLIDAY (Christmas)
   #   Staffing: reduced (humans less likely to review promptly)
   # Saturday/Sunday classify as WEEKEND even when not listed here. Matching a
   # holiday date classifies as GLOBAL_HOLIDAY (<name>) and takes priority over

--- a/deploy/config/tarsy.yaml.example
+++ b/deploy/config/tarsy.yaml.example
@@ -79,6 +79,15 @@ system:
     token_env: "SLACK_BOT_TOKEN"   # Env var name for bot token (default: SLACK_BOT_TOKEN)
     channel: "C12345678"           # Slack channel ID (required when enabled)
 
+  # Global holidays for Tier 0 calendar / staffing context (UTC, year-agnostic MM-DD).
+  # When omitted or empty, TARSy uses a small built-in list (Christmas, New Year's Day, …).
+  # When set, this list REPLACES the built-in defaults.
+  # holidays:
+  #   - date: "12-25"
+  #     name: "Christmas"
+  #   - date: "01-01"
+  #     name: "New Year's Day"
+
   # LLM usage cost estimation (list-price estimates, not invoice truth).
   # Enabled by default when this block is omitted. When disabled, token usage
   # is still tracked but estimated USD is not computed or shown.

--- a/docs/adr/0022-tier0-calendar-staffing.md
+++ b/docs/adr/0022-tier0-calendar-staffing.md
@@ -23,8 +23,8 @@ This decision extends existing Tier 0 prompt context (already injecting `Current
 ```text
 ## Context
 
-Current time: 2026-12-25T08:00:00Z (Thursday)
-Calendar context (UTC): 2026-12-25 — Thursday — GLOBAL_HOLIDAY (Christmas)
+Current time: 2026-12-25T08:00:00Z (Friday)
+Calendar context (UTC): 2026-12-25 — Friday — GLOBAL_HOLIDAY (Christmas)
 Staffing: reduced (humans less likely to review promptly)
 ```
 

--- a/docs/adr/0022-tier0-calendar-staffing.md
+++ b/docs/adr/0022-tier0-calendar-staffing.md
@@ -1,0 +1,61 @@
+# ADR-0022: Tier 0 Calendar and Staffing Context
+
+**Status:** Implemented  
+**Date:** 2026-08-12  
+**Related:** [ADR-0007: Automated Actions](0007-automated-actions.md) (action agents consume Tier 0; this ADR does not change the action type)
+
+## Overview
+
+Action and investigation agents sometimes need to know whether humans are likely available **when the decision is made** — for example so domain-specific `custom_instructions` can treat weekends or global holidays as reduced-review windows. Leaving weekday/holiday inference to the LLM is unreliable (models mis-map dates; alert timestamps are the wrong clock).
+
+This decision extends existing Tier 0 prompt context (already injecting `Current time: <RFC3339> (<Weekday>)` via `ComposeInstructions` / `ComposeChatInstructions`) with an explicit **calendar classification** and **staffing hint**, computed server-side from wall-clock UTC at prompt-build time. Optional `system.holidays` in `tarsy.yaml` lets deployments own the holiday list.
+
+## Design Principles
+
+1. **Server-side classification** — TARSy labels `WEEKEND` / `GLOBAL_HOLIDAY` / `WEEKDAY`; agents read the block and must not re-derive dates from alert or session timestamps.
+2. **Wall-clock “now”** — use `time.Now().UTC()` when the prompt is built (when remediation/investigation runs), not the alert fire time or session `created_at`. Staffing gaps are about human availability at decision time.
+3. **Extend Tier 0, don’t add a tool** — calendar context is not an MCP tool and not a separate prompt tier; it stays beside the existing current-time line.
+4. **Soft signal only** — reduced staffing informs agent judgment when operators are less available; it does not by itself authorize or execute actions.
+5. **Deployments own product holidays** — small built-in defaults; non-empty `system.holidays` **replaces** defaults so a product can list a multi-day break without forking code.
+
+## Prompt shape
+
+```text
+## Context
+
+Current time: 2026-12-25T08:00:00Z (Thursday)
+Calendar context (UTC): 2026-12-25 — Thursday — GLOBAL_HOLIDAY (Christmas)
+Staffing: reduced (humans less likely to review promptly)
+```
+
+Weekend example:
+
+```text
+Calendar context (UTC): 2026-08-01 — Saturday — WEEKEND
+Staffing: reduced (humans less likely to review promptly)
+```
+
+## Configuration
+
+```yaml
+system:
+  holidays:
+    - date: "12-24"
+      name: "Christmas Eve"
+    - date: "12-25"
+      name: "Christmas"
+    # ... through 01-01 as needed
+```
+
+Documented in `deploy/config/tarsy.yaml.example`. Holidays are resolved onto `Config` and passed into `NewPromptBuilder`.
+
+## Consequences
+
+- Action agent `custom_instructions` can reference Tier 0 staffing without embedding holiday calendars in every deployment’s agent text.
+- Golden / e2e normalizers must stabilize `Calendar context` and `Staffing` lines the same way they stabilize `Current time`.
+- Changing product holiday policy is a config change (replace list), not a TARSy code change.
+
+## Follow-ups
+
+- Locale-aware or region-specific calendars (explicitly out of v1).
+- Optional per-agent opt-out of Tier 0 (not needed today; all Compose* consumers get the same context).

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -406,6 +406,7 @@ graph LR
 
 Each agent operates with a tiered knowledge system composed into its system prompt:
 
+0. **Dynamic context** (Tier 0): Wall-clock UTC time plus `WEEKEND` / `GLOBAL_HOLIDAY` / `WEEKDAY` classification and a staffing hint (`system.holidays` in `tarsy.yaml`; defaults to New Year's Day and Christmas when unset). Agents read this block rather than deriving dates from alert timestamps — typically as a soft signal when humans are less likely to review promptly. See [ADR-0022: Tier 0 Calendar and Staffing Context](adr/0022-tier0-calendar-staffing.md).
 1. **General SRE Instructions**: Universal best practices for incident response
 2. **MCP Server Instructions**: Tool-specific guidance from each configured MCP server
 3. **Required Skills** (Tier 2.5): Domain knowledge injected directly from `required_skills` — always present in the prompt

--- a/docs/functional-areas-design.md
+++ b/docs/functional-areas-design.md
@@ -538,8 +538,8 @@ Tier 4:   Lessons from Past Investigations (auto-injected memories, investigatio
 ```text
 ## Context
 
-Current time: 2026-12-25T08:00:00Z (Thursday)
-Calendar context (UTC): 2026-12-25 — Thursday — GLOBAL_HOLIDAY (Christmas)
+Current time: 2026-12-25T08:00:00Z (Friday)
+Calendar context (UTC): 2026-12-25 — Friday — GLOBAL_HOLIDAY (Christmas)
 Staffing: reduced (humans less likely to review promptly)
 ```
 

--- a/docs/functional-areas-design.md
+++ b/docs/functional-areas-design.md
@@ -524,6 +524,7 @@ Any agent that resolves a non-empty sub-agent catalog at runtime gains orchestra
 
 **Tiered system** (`pkg/agent/prompt/builder.go`, `pkg/agent/prompt/instructions.go`, `pkg/agent/prompt/skills.go`):
 ```
+Tier 0:   Dynamic context                  (wall-clock UTC time + WEEKEND / GLOBAL_HOLIDAY + staffing hint)
 Tier 1:   General SRE Instructions        (hardcoded)
 Tier 2:   MCP Server Instructions          (per configured server)
 Tier 2.5: Required Skill Content           (from required_skills — injected bodies)
@@ -531,6 +532,8 @@ Tier 2.6: On-Demand Skill Catalog          (names + descriptions, with load_skil
 Tier 3:   Agent Custom Instructions        (from custom_instructions)
 Tier 4:   Lessons from Past Investigations (auto-injected memories, investigation sessions only)
 ```
+
+Tier 0 is computed at prompt-build time via `time.Now().UTC()` (not alert/session timestamps). Saturday/Sunday classify as `WEEKEND`; dates matching `system.holidays` (or built-in defaults when unset) classify as `GLOBAL_HOLIDAY (<name>)`. Reduced staffing guidance is injected on weekends/holidays so action agents can apply softer freeloading thresholds without deriving weekday/holiday from dates themselves.
 
 **Agent Skills** (`pkg/agent/skill/tool_executor.go`) provide reusable domain knowledge. Required skills are injected as content (Tier 2.5); on-demand skills appear as a catalog with a `load_skill` tool (Tier 2.6). Skill resolution happens in `config_resolver.go` — the prompt builder only formats pre-resolved data from `ResolvedAgentConfig.RequiredSkillContent` and `ResolvedAgentConfig.OnDemandSkills`. `SkillToolExecutor` wraps the inner tool executor and intercepts `load_skill` calls, reading from the in-memory `SkillRegistry`. See [ADR-0012: Agent Skills](adr/0012-agent-skills.md).
 
@@ -1308,6 +1311,7 @@ Two Ent edges connect memories to sessions:
 Memories are injected into the system prompt as Tier 4 (after custom instructions):
 
 ```text
+Tier 0:   Dynamic context (UTC time + WEEKEND / GLOBAL_HOLIDAY + staffing)
 Tier 1:   General SRE Instructions
 Tier 2:   MCP Server Instructions
 Tier 2.5: Required Skill Content

--- a/docs/functional-areas-design.md
+++ b/docs/functional-areas-design.md
@@ -533,7 +533,25 @@ Tier 3:   Agent Custom Instructions        (from custom_instructions)
 Tier 4:   Lessons from Past Investigations (auto-injected memories, investigation sessions only)
 ```
 
-Tier 0 is computed at prompt-build time via `time.Now().UTC()` (not alert/session timestamps). Saturday/Sunday classify as `WEEKEND`; dates matching `system.holidays` (or built-in defaults when unset) classify as `GLOBAL_HOLIDAY (<name>)`. Reduced staffing guidance is injected on weekends/holidays so action agents can apply softer freeloading thresholds without deriving weekday/holiday from dates themselves.
+**Tier 0 — calendar / staffing context.** At prompt-build time TARSy injects wall-clock UTC (`time.Now().UTC()`, not alert or session timestamps) into every investigation, chat, and action agent system prompt. Example:
+
+```text
+## Context
+
+Current time: 2026-12-25T08:00:00Z (Thursday)
+Calendar context (UTC): 2026-12-25 — Thursday — GLOBAL_HOLIDAY (Christmas)
+Staffing: reduced (humans less likely to review promptly)
+```
+
+Classification (priority: holiday over weekend):
+
+- Matching `system.holidays` (year-agnostic `MM-DD`) → `GLOBAL_HOLIDAY (<name>)` + reduced staffing
+- Saturday / Sunday UTC → `WEEKEND` + reduced staffing
+- Otherwise → `WEEKDAY` + normal staffing
+
+Agents must **read** this block — they must not re-derive weekday or holiday from alert metadata. Typical use is giving agents a soft signal when humans are less likely to review promptly; Tier 0 does not by itself trigger actions. Configure via `system.holidays` in `tarsy.yaml` (see `deploy/config/tarsy.yaml.example`). When omitted or empty, TARSy uses a small built-in list (New Year's Day, Christmas). When set, the list **replaces** those defaults — include every date that should count as a holiday (for example a multi-day Christmas break).
+
+**For detailed design**: See [ADR-0022: Tier 0 Calendar and Staffing Context](adr/0022-tier0-calendar-staffing.md).
 
 **Agent Skills** (`pkg/agent/skill/tool_executor.go`) provide reusable domain knowledge. Required skills are injected as content (Tier 2.5); on-demand skills appear as a catalog with a `load_skill` tool (Tier 2.6). Skill resolution happens in `config_resolver.go` — the prompt builder only formats pre-resolved data from `ResolvedAgentConfig.RequiredSkillContent` and `ResolvedAgentConfig.OnDemandSkills`. `SkillToolExecutor` wraps the inner tool executor and intercepts `load_skill` calls, reading from the in-memory `SkillRegistry`. See [ADR-0012: Agent Skills](adr/0012-agent-skills.md).
 
@@ -1319,6 +1337,8 @@ Tier 2.6: On-Demand Skill Catalog
 Tier 3:   Agent Custom Instructions
 Tier 4:   Lessons from Past Investigations (auto-injected memories)
 ```
+
+Tier 0 calendar / staffing behavior is described under [Instruction Composition](#instruction-composition).
 
 #### Configuration
 

--- a/pkg/agent/controller/factory_test.go
+++ b/pkg/agent/controller/factory_test.go
@@ -39,7 +39,7 @@ func TestFactory_CreateController(t *testing.T) {
 	})
 
 	t.Run("synthesis type returns SingleShotController", func(t *testing.T) {
-		pb := prompt.NewPromptBuilder(config.NewMCPServerRegistry(map[string]*config.MCPServerConfig{}))
+		pb := prompt.NewPromptBuilder(config.NewMCPServerRegistry(map[string]*config.MCPServerConfig{}), nil)
 		synthExecCtx := &agent.ExecutionContext{
 			SessionID:     "test-session",
 			StageID:       "test-stage",
@@ -65,7 +65,7 @@ func TestFactory_CreateController(t *testing.T) {
 	})
 
 	t.Run("exec_summary type returns SingleShotController", func(t *testing.T) {
-		pb := prompt.NewPromptBuilder(config.NewMCPServerRegistry(map[string]*config.MCPServerConfig{}))
+		pb := prompt.NewPromptBuilder(config.NewMCPServerRegistry(map[string]*config.MCPServerConfig{}), nil)
 		esExecCtx := &agent.ExecutionContext{
 			SessionID:     "test-session",
 			StageID:       "test-stage",

--- a/pkg/agent/controller/lifecycle_integration_test.go
+++ b/pkg/agent/controller/lifecycle_integration_test.go
@@ -219,7 +219,7 @@ func TestIteratingController_SummarizationIntegration(t *testing.T) {
 			},
 		},
 	})
-	pb := prompt.NewPromptBuilder(registry)
+	pb := prompt.NewPromptBuilder(registry, nil)
 
 	execCtx := newTestExecCtx(t, llm, executor)
 	execCtx.PromptBuilder = pb
@@ -273,7 +273,7 @@ func TestIteratingController_SummarizationFailOpen(t *testing.T) {
 			},
 		},
 	})
-	pb := prompt.NewPromptBuilder(registry)
+	pb := prompt.NewPromptBuilder(registry, nil)
 
 	execCtx := newTestExecCtx(t, llm, executor)
 	execCtx.PromptBuilder = pb
@@ -477,7 +477,7 @@ func TestGoogleNativeController_SummarizationIntegration(t *testing.T) {
 			},
 		},
 	})
-	pb := prompt.NewPromptBuilder(registry)
+	pb := prompt.NewPromptBuilder(registry, nil)
 
 	execCtx := newTestExecCtx(t, llm, executor)
 	execCtx.Config.LLMBackend = config.LLMBackendNativeGemini
@@ -533,7 +533,7 @@ func TestGoogleNativeController_SummarizationFailOpen(t *testing.T) {
 			},
 		},
 	})
-	pb := prompt.NewPromptBuilder(registry)
+	pb := prompt.NewPromptBuilder(registry, nil)
 
 	execCtx := newTestExecCtx(t, llm, executor)
 	execCtx.Config.LLMBackend = config.LLMBackendNativeGemini

--- a/pkg/agent/controller/summarize_test.go
+++ b/pkg/agent/controller/summarize_test.go
@@ -71,7 +71,7 @@ func TestMaybeSummarize(t *testing.T) {
 				Summarization: nil, // nil = enabled with defaults
 			},
 		})
-		pb := prompt.NewPromptBuilder(registry)
+		pb := prompt.NewPromptBuilder(registry, nil)
 		execCtx := &agent.ExecutionContext{
 			PromptBuilder: pb,
 			Config: &agent.ResolvedAgentConfig{
@@ -95,7 +95,7 @@ func TestMaybeSummarize(t *testing.T) {
 				},
 			},
 		})
-		pb := prompt.NewPromptBuilder(registry)
+		pb := prompt.NewPromptBuilder(registry, nil)
 		execCtx := &agent.ExecutionContext{
 			PromptBuilder: pb,
 			Config: &agent.ResolvedAgentConfig{
@@ -119,7 +119,7 @@ func TestMaybeSummarize(t *testing.T) {
 				},
 			},
 		})
-		pb := prompt.NewPromptBuilder(registry)
+		pb := prompt.NewPromptBuilder(registry, nil)
 		execCtx := &agent.ExecutionContext{
 			PromptBuilder: pb,
 			Config: &agent.ResolvedAgentConfig{
@@ -137,7 +137,7 @@ func TestMaybeSummarize(t *testing.T) {
 
 	t.Run("returns raw content when server not found", func(t *testing.T) {
 		registry := config.NewMCPServerRegistry(map[string]*config.MCPServerConfig{})
-		pb := prompt.NewPromptBuilder(registry)
+		pb := prompt.NewPromptBuilder(registry, nil)
 		execCtx := &agent.ExecutionContext{
 			PromptBuilder: pb,
 			Config: &agent.ResolvedAgentConfig{
@@ -176,7 +176,7 @@ func TestMaybeSummarize(t *testing.T) {
 				Summarization: nil, // nil = enabled with defaults (threshold = DefaultSizeThresholdTokens)
 			},
 		})
-		pb := prompt.NewPromptBuilder(registry)
+		pb := prompt.NewPromptBuilder(registry, nil)
 
 		execCtx := newTestExecCtx(t, mockLLM, agent.NewStubToolExecutor(nil))
 		execCtx.PromptBuilder = pb
@@ -207,7 +207,7 @@ func TestMaybeSummarize(t *testing.T) {
 				},
 			},
 		})
-		pb := prompt.NewPromptBuilder(registry)
+		pb := prompt.NewPromptBuilder(registry, nil)
 
 		execCtx := newTestExecCtx(t, mockLLM, agent.NewStubToolExecutor(nil))
 		execCtx.PromptBuilder = pb
@@ -242,7 +242,7 @@ func TestMaybeSummarize(t *testing.T) {
 				},
 			},
 		})
-		pb := prompt.NewPromptBuilder(registry)
+		pb := prompt.NewPromptBuilder(registry, nil)
 
 		execCtx := newTestExecCtx(t, mockLLM, agent.NewStubToolExecutor(nil))
 		execCtx.PromptBuilder = pb
@@ -299,7 +299,7 @@ func TestMaybeSummarize(t *testing.T) {
 				},
 			},
 		})
-		pb := prompt.NewPromptBuilder(registry)
+		pb := prompt.NewPromptBuilder(registry, nil)
 
 		execCtx := newTestExecCtx(t, mockLLM, agent.NewStubToolExecutor(nil))
 		execCtx.PromptBuilder = pb
@@ -327,7 +327,7 @@ func TestMaybeSummarize(t *testing.T) {
 				},
 			},
 		})
-		pb := prompt.NewPromptBuilder(registry)
+		pb := prompt.NewPromptBuilder(registry, nil)
 
 		execCtx := newTestExecCtx(t, mockLLM, agent.NewStubToolExecutor(nil))
 		execCtx.PromptBuilder = pb

--- a/pkg/agent/controller/test_helpers_test.go
+++ b/pkg/agent/controller/test_helpers_test.go
@@ -167,7 +167,7 @@ func newTestExecCtx(t *testing.T, llm agent.LLMClient, toolExec agent.ToolExecut
 	require.NoError(t, err)
 
 	testRegistry := config.NewMCPServerRegistry(map[string]*config.MCPServerConfig{})
-	pb := prompt.NewPromptBuilder(testRegistry)
+	pb := prompt.NewPromptBuilder(testRegistry, nil)
 
 	return &agent.ExecutionContext{
 		SessionID:   sessionID,

--- a/pkg/agent/prompt/builder.go
+++ b/pkg/agent/prompt/builder.go
@@ -14,16 +14,22 @@ import (
 // parameters. Thread-safe — no mutable state.
 type PromptBuilder struct {
 	mcpRegistry *config.MCPServerRegistry
+	holidays    []config.Holiday
 }
 
 // NewPromptBuilder creates a PromptBuilder with access to MCP server configs.
 // Panics if mcpRegistry is nil — callers must provide a valid registry.
-func NewPromptBuilder(mcpRegistry *config.MCPServerRegistry) *PromptBuilder {
+// When holidays is nil, the built-in default global holiday list is used.
+func NewPromptBuilder(mcpRegistry *config.MCPServerRegistry, holidays []config.Holiday) *PromptBuilder {
 	if mcpRegistry == nil {
 		panic("prompt.NewPromptBuilder: mcpRegistry must not be nil")
 	}
+	if holidays == nil {
+		holidays = config.DefaultHolidays()
+	}
 	return &PromptBuilder{
 		mcpRegistry: mcpRegistry,
+		holidays:    holidays,
 	}
 }
 

--- a/pkg/agent/prompt/builder_integration_test.go
+++ b/pkg/agent/prompt/builder_integration_test.go
@@ -16,6 +16,8 @@ import (
 )
 
 var currentTimeLineRe = regexp.MustCompile(`Current time: [^\n]+`)
+var calendarContextLineRe = regexp.MustCompile(`Calendar context \(UTC\): [^\n]+`)
+var staffingLineRe = regexp.MustCompile(`Staffing: [^\n]+`)
 
 var update = flag.Bool("update", false, "update golden files")
 
@@ -73,7 +75,10 @@ func assertGolden(t *testing.T, name string, actual string) {
 }
 
 func normalizeGolden(s string) string {
-	return currentTimeLineRe.ReplaceAllString(s, "Current time: {CURRENT_TIME}")
+	s = currentTimeLineRe.ReplaceAllString(s, "Current time: {CURRENT_TIME}")
+	s = calendarContextLineRe.ReplaceAllString(s, "Calendar context (UTC): {CALENDAR_CONTEXT}")
+	s = staffingLineRe.ReplaceAllString(s, "Staffing: {STAFFING}")
+	return s
 }
 
 // findFirstDiff produces a human-readable description of where two strings diverge.
@@ -153,7 +158,7 @@ func newIntegrationBuilder() *PromptBuilder {
 	registry := newTestMCPRegistry(map[string]*config.MCPServerConfig{
 		"kubernetes-server": {Instructions: k8sServerInstructions},
 	})
-	return NewPromptBuilder(registry)
+	return NewPromptBuilder(registry, nil)
 }
 
 func newIntegrationExecCtx() *agent.ExecutionContext {

--- a/pkg/agent/prompt/builder_test.go
+++ b/pkg/agent/prompt/builder_test.go
@@ -13,7 +13,7 @@ func newBuilderForTest() *PromptBuilder {
 	registry := newTestMCPRegistry(map[string]*config.MCPServerConfig{
 		"kubernetes-server": {Instructions: "K8s server instructions."},
 	})
-	return NewPromptBuilder(registry)
+	return NewPromptBuilder(registry, nil)
 }
 
 func newFullExecCtx() *agent.ExecutionContext {

--- a/pkg/agent/prompt/calendar_test.go
+++ b/pkg/agent/prompt/calendar_test.go
@@ -1,0 +1,252 @@
+package prompt
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/codeready-toolchain/tarsy/pkg/agent"
+	"github.com/codeready-toolchain/tarsy/pkg/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func freezeUTC(t *testing.T, now time.Time) {
+	t.Helper()
+	prev := nowUTC
+	nowUTC = func() time.Time { return now }
+	t.Cleanup(func() { nowUTC = prev })
+}
+
+func TestFormatCurrentTimeSection(t *testing.T) {
+	defaultHolidays := config.DefaultHolidays()
+	// Product list shaped like sandbox-sre Christmas break (Eve → New Year's Day).
+	christmasBreak := []config.Holiday{
+		{Date: "12-24", Name: "Christmas Eve"},
+		{Date: "12-25", Name: "Christmas"},
+		{Date: "12-26", Name: "Christmas holiday"},
+		{Date: "12-27", Name: "Christmas holiday"},
+		{Date: "12-28", Name: "Christmas holiday"},
+		{Date: "12-29", Name: "Christmas holiday"},
+		{Date: "12-30", Name: "Christmas holiday"},
+		{Date: "12-31", Name: "New Year's Eve"},
+		{Date: "01-01", Name: "New Year's Day"},
+	}
+
+	tests := []struct {
+		name     string
+		now      time.Time
+		holidays []config.Holiday
+		want     string
+	}{
+		{
+			name:     "weekday normal staffing",
+			now:      time.Date(2026, 8, 12, 15, 30, 0, 0, time.UTC), // Wednesday
+			holidays: defaultHolidays,
+			want: strings.Join([]string{
+				"## Context",
+				"",
+				"Current time: 2026-08-12T15:30:00Z (Wednesday)",
+				"Calendar context (UTC): 2026-08-12 — Wednesday — WEEKDAY",
+				"Staffing: normal",
+			}, "\n"),
+		},
+		{
+			name:     "saturday weekend reduced staffing",
+			now:      time.Date(2026, 8, 1, 10, 0, 0, 0, time.UTC), // Saturday
+			holidays: defaultHolidays,
+			want: strings.Join([]string{
+				"## Context",
+				"",
+				"Current time: 2026-08-01T10:00:00Z (Saturday)",
+				"Calendar context (UTC): 2026-08-01 — Saturday — WEEKEND",
+				"Staffing: reduced (more aggressive freeloading idle thresholds apply)",
+			}, "\n"),
+		},
+		{
+			name:     "sunday weekend reduced staffing",
+			now:      time.Date(2026, 8, 2, 10, 0, 0, 0, time.UTC), // Sunday
+			holidays: defaultHolidays,
+			want: strings.Join([]string{
+				"## Context",
+				"",
+				"Current time: 2026-08-02T10:00:00Z (Sunday)",
+				"Calendar context (UTC): 2026-08-02 — Sunday — WEEKEND",
+				"Staffing: reduced (more aggressive freeloading idle thresholds apply)",
+			}, "\n"),
+		},
+		{
+			name:     "default christmas on weekday",
+			now:      time.Date(2026, 12, 25, 8, 0, 0, 0, time.UTC), // Friday
+			holidays: defaultHolidays,
+			want: strings.Join([]string{
+				"## Context",
+				"",
+				"Current time: 2026-12-25T08:00:00Z (Friday)",
+				"Calendar context (UTC): 2026-12-25 — Friday — GLOBAL_HOLIDAY (Christmas)",
+				"Staffing: reduced (more aggressive freeloading idle thresholds apply)",
+			}, "\n"),
+		},
+		{
+			name:     "holiday takes priority over weekend",
+			now:      time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC), // Sunday New Year's
+			holidays: defaultHolidays,
+			want: strings.Join([]string{
+				"## Context",
+				"",
+				"Current time: 2023-01-01T12:00:00Z (Sunday)",
+				"Calendar context (UTC): 2023-01-01 — Sunday — GLOBAL_HOLIDAY (New Year's Day)",
+				"Staffing: reduced (more aggressive freeloading idle thresholds apply)",
+			}, "\n"),
+		},
+		{
+			name: "defaults miss mid christmas break weekday",
+			// Monday 2026-12-28 is between Christmas and New Year; not in DefaultHolidays.
+			now:      time.Date(2026, 12, 28, 9, 0, 0, 0, time.UTC),
+			holidays: defaultHolidays,
+			want: strings.Join([]string{
+				"## Context",
+				"",
+				"Current time: 2026-12-28T09:00:00Z (Monday)",
+				"Calendar context (UTC): 2026-12-28 — Monday — WEEKDAY",
+				"Staffing: normal",
+			}, "\n"),
+		},
+		{
+			name:     "product christmas break covers midweek day",
+			now:      time.Date(2026, 12, 28, 9, 0, 0, 0, time.UTC), // Monday
+			holidays: christmasBreak,
+			want: strings.Join([]string{
+				"## Context",
+				"",
+				"Current time: 2026-12-28T09:00:00Z (Monday)",
+				"Calendar context (UTC): 2026-12-28 — Monday — GLOBAL_HOLIDAY (Christmas holiday)",
+				"Staffing: reduced (more aggressive freeloading idle thresholds apply)",
+			}, "\n"),
+		},
+		{
+			name:     "product christmas eve",
+			now:      time.Date(2026, 12, 24, 18, 0, 0, 0, time.UTC), // Thursday
+			holidays: christmasBreak,
+			want: strings.Join([]string{
+				"## Context",
+				"",
+				"Current time: 2026-12-24T18:00:00Z (Thursday)",
+				"Calendar context (UTC): 2026-12-24 — Thursday — GLOBAL_HOLIDAY (Christmas Eve)",
+				"Staffing: reduced (more aggressive freeloading idle thresholds apply)",
+			}, "\n"),
+		},
+		{
+			name:     "custom list replaces christmas",
+			now:      time.Date(2026, 12, 25, 8, 0, 0, 0, time.UTC),
+			holidays: []config.Holiday{{Date: "07-04", Name: "Independence Day"}},
+			want: strings.Join([]string{
+				"## Context",
+				"",
+				"Current time: 2026-12-25T08:00:00Z (Friday)",
+				"Calendar context (UTC): 2026-12-25 — Friday — WEEKDAY",
+				"Staffing: normal",
+			}, "\n"),
+		},
+		{
+			name:     "custom holiday on weekend still GLOBAL_HOLIDAY",
+			now:      time.Date(2026, 7, 4, 8, 0, 0, 0, time.UTC), // Saturday
+			holidays: []config.Holiday{{Date: "07-04", Name: "Independence Day"}},
+			want: strings.Join([]string{
+				"## Context",
+				"",
+				"Current time: 2026-07-04T08:00:00Z (Saturday)",
+				"Calendar context (UTC): 2026-07-04 — Saturday — GLOBAL_HOLIDAY (Independence Day)",
+				"Staffing: reduced (more aggressive freeloading idle thresholds apply)",
+			}, "\n"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.name == "holiday takes priority over weekend" {
+				require.Equal(t, time.Sunday, tt.now.Weekday())
+			}
+			assert.Equal(t, tt.want, formatCurrentTimeSection(tt.now, tt.holidays))
+		})
+	}
+}
+
+func TestFormatCurrentTimeSection_ChristmasBreakAllDays(t *testing.T) {
+	christmasBreak := []config.Holiday{
+		{Date: "12-24", Name: "Christmas Eve"},
+		{Date: "12-25", Name: "Christmas"},
+		{Date: "12-26", Name: "Christmas holiday"},
+		{Date: "12-27", Name: "Christmas holiday"},
+		{Date: "12-28", Name: "Christmas holiday"},
+		{Date: "12-29", Name: "Christmas holiday"},
+		{Date: "12-30", Name: "Christmas holiday"},
+		{Date: "12-31", Name: "New Year's Eve"},
+		{Date: "01-01", Name: "New Year's Day"},
+	}
+
+	// Walk Christmas Eve 2026 through New Year's Day 2027 (UTC).
+	for d := time.Date(2026, 12, 24, 12, 0, 0, 0, time.UTC); !d.After(time.Date(2027, 1, 1, 12, 0, 0, 0, time.UTC)); d = d.Add(24 * time.Hour) {
+		t.Run(d.Format("2006-01-02"), func(t *testing.T) {
+			got := formatCurrentTimeSection(d, christmasBreak)
+			assert.Contains(t, got, "GLOBAL_HOLIDAY (")
+			assert.Contains(t, got, "Staffing: reduced (more aggressive freeloading idle thresholds apply)")
+			assert.NotContains(t, got, "Staffing: normal")
+			assert.NotContains(t, got, "— WEEKDAY")
+			assert.NotContains(t, got, "— WEEKEND")
+		})
+	}
+}
+
+func TestComposeInstructions_Tier0CalendarUsesBuilderHolidays(t *testing.T) {
+	freezeUTC(t, time.Date(2026, 12, 28, 9, 0, 0, 0, time.UTC)) // Monday mid Christmas break
+
+	registry := newTestMCPRegistry(nil)
+	builder := NewPromptBuilder(registry, []config.Holiday{
+		{Date: "12-28", Name: "Christmas holiday"},
+	})
+	result := builder.ComposeInstructions(newTestExecCtx())
+
+	assert.Contains(t, result, "Calendar context (UTC): 2026-12-28 — Monday — GLOBAL_HOLIDAY (Christmas holiday)")
+	assert.Contains(t, result, "Staffing: reduced (more aggressive freeloading idle thresholds apply)")
+	assert.True(t, strings.Index(result, "## Context") < strings.Index(result, "General SRE Agent Instructions"),
+		"Tier 0 Context should precede Tier 1 general instructions")
+}
+
+func TestComposeInstructions_Tier0UsesDefaultHolidaysWhenNil(t *testing.T) {
+	freezeUTC(t, time.Date(2026, 12, 25, 8, 0, 0, 0, time.UTC))
+
+	builder := NewPromptBuilder(newTestMCPRegistry(nil), nil)
+	result := builder.ComposeInstructions(newTestExecCtx())
+
+	assert.Contains(t, result, "GLOBAL_HOLIDAY (Christmas)")
+	assert.Contains(t, result, "Staffing: reduced")
+}
+
+func TestComposeChatInstructions_Tier0Calendar(t *testing.T) {
+	freezeUTC(t, time.Date(2026, 8, 1, 10, 0, 0, 0, time.UTC)) // Saturday
+
+	builder := NewPromptBuilder(newTestMCPRegistry(nil), config.DefaultHolidays())
+	result := builder.ComposeChatInstructions(newTestExecCtx())
+
+	assert.Contains(t, result, "Calendar context (UTC): 2026-08-01 — Saturday — WEEKEND")
+	assert.Contains(t, result, "Staffing: reduced")
+}
+
+func TestBuildActionMessages_IncludesTier0Calendar(t *testing.T) {
+	freezeUTC(t, time.Date(2026, 12, 24, 18, 0, 0, 0, time.UTC)) // Christmas Eve
+
+	builder := NewPromptBuilder(newTestMCPRegistry(nil), []config.Holiday{
+		{Date: "12-24", Name: "Christmas Eve"},
+	})
+	execCtx := newTestExecCtx()
+	execCtx.Config.Type = config.AgentTypeAction
+	execCtx.AlertData = `{"alertname":"test"}`
+	execCtx.AlertType = "SecurityInvestigation"
+
+	messages := builder.buildActionMessages(execCtx, "prior stage findings")
+	require.NotEmpty(t, messages)
+	assert.Equal(t, agent.RoleSystem, messages[0].Role)
+	assert.Contains(t, messages[0].Content, "GLOBAL_HOLIDAY (Christmas Eve)")
+	assert.Contains(t, messages[0].Content, "Staffing: reduced")
+}

--- a/pkg/agent/prompt/calendar_test.go
+++ b/pkg/agent/prompt/calendar_test.go
@@ -60,7 +60,7 @@ func TestFormatCurrentTimeSection(t *testing.T) {
 				"",
 				"Current time: 2026-08-01T10:00:00Z (Saturday)",
 				"Calendar context (UTC): 2026-08-01 — Saturday — WEEKEND",
-				"Staffing: reduced (more aggressive freeloading idle thresholds apply)",
+				"Staffing: reduced (humans less likely to review promptly)",
 			}, "\n"),
 		},
 		{
@@ -72,7 +72,7 @@ func TestFormatCurrentTimeSection(t *testing.T) {
 				"",
 				"Current time: 2026-08-02T10:00:00Z (Sunday)",
 				"Calendar context (UTC): 2026-08-02 — Sunday — WEEKEND",
-				"Staffing: reduced (more aggressive freeloading idle thresholds apply)",
+				"Staffing: reduced (humans less likely to review promptly)",
 			}, "\n"),
 		},
 		{
@@ -84,7 +84,7 @@ func TestFormatCurrentTimeSection(t *testing.T) {
 				"",
 				"Current time: 2026-12-25T08:00:00Z (Friday)",
 				"Calendar context (UTC): 2026-12-25 — Friday — GLOBAL_HOLIDAY (Christmas)",
-				"Staffing: reduced (more aggressive freeloading idle thresholds apply)",
+				"Staffing: reduced (humans less likely to review promptly)",
 			}, "\n"),
 		},
 		{
@@ -96,7 +96,7 @@ func TestFormatCurrentTimeSection(t *testing.T) {
 				"",
 				"Current time: 2023-01-01T12:00:00Z (Sunday)",
 				"Calendar context (UTC): 2023-01-01 — Sunday — GLOBAL_HOLIDAY (New Year's Day)",
-				"Staffing: reduced (more aggressive freeloading idle thresholds apply)",
+				"Staffing: reduced (humans less likely to review promptly)",
 			}, "\n"),
 		},
 		{
@@ -121,7 +121,7 @@ func TestFormatCurrentTimeSection(t *testing.T) {
 				"",
 				"Current time: 2026-12-28T09:00:00Z (Monday)",
 				"Calendar context (UTC): 2026-12-28 — Monday — GLOBAL_HOLIDAY (Christmas holiday)",
-				"Staffing: reduced (more aggressive freeloading idle thresholds apply)",
+				"Staffing: reduced (humans less likely to review promptly)",
 			}, "\n"),
 		},
 		{
@@ -133,7 +133,7 @@ func TestFormatCurrentTimeSection(t *testing.T) {
 				"",
 				"Current time: 2026-12-24T18:00:00Z (Thursday)",
 				"Calendar context (UTC): 2026-12-24 — Thursday — GLOBAL_HOLIDAY (Christmas Eve)",
-				"Staffing: reduced (more aggressive freeloading idle thresholds apply)",
+				"Staffing: reduced (humans less likely to review promptly)",
 			}, "\n"),
 		},
 		{
@@ -157,7 +157,7 @@ func TestFormatCurrentTimeSection(t *testing.T) {
 				"",
 				"Current time: 2026-07-04T08:00:00Z (Saturday)",
 				"Calendar context (UTC): 2026-07-04 — Saturday — GLOBAL_HOLIDAY (Independence Day)",
-				"Staffing: reduced (more aggressive freeloading idle thresholds apply)",
+				"Staffing: reduced (humans less likely to review promptly)",
 			}, "\n"),
 		},
 	}
@@ -190,7 +190,7 @@ func TestFormatCurrentTimeSection_ChristmasBreakAllDays(t *testing.T) {
 		t.Run(d.Format("2006-01-02"), func(t *testing.T) {
 			got := formatCurrentTimeSection(d, christmasBreak)
 			assert.Contains(t, got, "GLOBAL_HOLIDAY (")
-			assert.Contains(t, got, "Staffing: reduced (more aggressive freeloading idle thresholds apply)")
+			assert.Contains(t, got, "Staffing: reduced (humans less likely to review promptly)")
 			assert.NotContains(t, got, "Staffing: normal")
 			assert.NotContains(t, got, "— WEEKDAY")
 			assert.NotContains(t, got, "— WEEKEND")
@@ -208,7 +208,7 @@ func TestComposeInstructions_Tier0CalendarUsesBuilderHolidays(t *testing.T) {
 	result := builder.ComposeInstructions(newTestExecCtx())
 
 	assert.Contains(t, result, "Calendar context (UTC): 2026-12-28 — Monday — GLOBAL_HOLIDAY (Christmas holiday)")
-	assert.Contains(t, result, "Staffing: reduced (more aggressive freeloading idle thresholds apply)")
+	assert.Contains(t, result, "Staffing: reduced (humans less likely to review promptly)")
 	assert.True(t, strings.Index(result, "## Context") < strings.Index(result, "General SRE Agent Instructions"),
 		"Tier 0 Context should precede Tier 1 general instructions")
 }

--- a/pkg/agent/prompt/instructions.go
+++ b/pkg/agent/prompt/instructions.go
@@ -248,10 +248,10 @@ func formatCurrentTimeSection(now time.Time, holidays []config.Holiday) string {
 	staffing := "normal"
 	if name, ok := holidayName(mmdd, holidays); ok {
 		classification = fmt.Sprintf("GLOBAL_HOLIDAY (%s)", name)
-		staffing = "reduced (more aggressive freeloading idle thresholds apply)"
+		staffing = "reduced (humans less likely to review promptly)"
 	} else if now.Weekday() == time.Saturday || now.Weekday() == time.Sunday {
 		classification = "WEEKEND"
-		staffing = "reduced (more aggressive freeloading idle thresholds apply)"
+		staffing = "reduced (humans less likely to review promptly)"
 	}
 
 	return fmt.Sprintf(

--- a/pkg/agent/prompt/instructions.go
+++ b/pkg/agent/prompt/instructions.go
@@ -95,8 +95,8 @@ const chatResponseGuidelines = `## Response Guidelines
 func (b *PromptBuilder) ComposeInstructions(execCtx *agent.ExecutionContext) string {
 	var sections []string
 
-	// Tier 0: Dynamic context (current time)
-	sections = append(sections, currentTimeSection())
+	// Tier 0: Dynamic context (current time + calendar / staffing)
+	sections = append(sections, b.currentTimeSection())
 
 	// Tier 1: General SRE instructions
 	sections = append(sections, generalInstructions)
@@ -125,8 +125,8 @@ func (b *PromptBuilder) ComposeInstructions(execCtx *agent.ExecutionContext) str
 func (b *PromptBuilder) ComposeChatInstructions(execCtx *agent.ExecutionContext) string {
 	var sections []string
 
-	// Tier 0: Dynamic context (current time)
-	sections = append(sections, currentTimeSection())
+	// Tier 0: Dynamic context (current time + calendar / staffing)
+	sections = append(sections, b.currentTimeSection())
 
 	// Tier 1: Chat-specific general instructions
 	sections = append(sections, chatGeneralInstructions)
@@ -227,10 +227,45 @@ func appendSkillSections(sections []string, execCtx *agent.ExecutionContext) []s
 	return sections
 }
 
-func currentTimeSection() string {
-	now := time.Now().UTC()
-	return fmt.Sprintf("## Context\n\nCurrent time: %s (%s)",
-		now.Format(time.RFC3339), now.Format("Monday"))
+// nowUTC returns the wall-clock time used for Tier 0 calendar context.
+// Tests override this to freeze time.
+var nowUTC = time.Now
+
+func (b *PromptBuilder) currentTimeSection() string {
+	return formatCurrentTimeSection(nowUTC().UTC(), b.holidays)
+}
+
+// formatCurrentTimeSection builds Tier 0 context: wall-clock UTC time plus
+// WEEKEND / GLOBAL_HOLIDAY classification and staffing guidance.
+// Holidays are matched year-agnostically by MM-DD (UTC). Priority:
+// GLOBAL_HOLIDAY > WEEKEND > WEEKDAY.
+func formatCurrentTimeSection(now time.Time, holidays []config.Holiday) string {
+	weekday := now.Format("Monday")
+	date := now.Format("2006-01-02")
+	mmdd := now.Format("01-02")
+
+	classification := "WEEKDAY"
+	staffing := "normal"
+	if name, ok := holidayName(mmdd, holidays); ok {
+		classification = fmt.Sprintf("GLOBAL_HOLIDAY (%s)", name)
+		staffing = "reduced (more aggressive freeloading idle thresholds apply)"
+	} else if now.Weekday() == time.Saturday || now.Weekday() == time.Sunday {
+		classification = "WEEKEND"
+		staffing = "reduced (more aggressive freeloading idle thresholds apply)"
+	}
+
+	return fmt.Sprintf(
+		"## Context\n\nCurrent time: %s (%s)\nCalendar context (UTC): %s — %s — %s\nStaffing: %s",
+		now.Format(time.RFC3339), weekday, date, weekday, classification, staffing)
+}
+
+func holidayName(mmdd string, holidays []config.Holiday) (string, bool) {
+	for _, h := range holidays {
+		if h.Date == mmdd {
+			return h.Name, true
+		}
+	}
+	return "", false
 }
 
 // appendMemorySection adds Tier 4 memory hints from past investigations.

--- a/pkg/agent/prompt/instructions_test.go
+++ b/pkg/agent/prompt/instructions_test.go
@@ -31,7 +31,7 @@ func TestComposeInstructions_ThreeTiers(t *testing.T) {
 			Instructions: "Always check node status first.",
 		},
 	})
-	builder := NewPromptBuilder(registry)
+	builder := NewPromptBuilder(registry, nil)
 	execCtx := newTestExecCtx()
 
 	result := builder.ComposeInstructions(execCtx)
@@ -59,7 +59,7 @@ func TestComposeInstructions_NoMCPInstructions(t *testing.T) {
 			Instructions: "", // Empty instructions
 		},
 	})
-	builder := NewPromptBuilder(registry)
+	builder := NewPromptBuilder(registry, nil)
 	execCtx := newTestExecCtx()
 
 	result := builder.ComposeInstructions(execCtx)
@@ -68,7 +68,7 @@ func TestComposeInstructions_NoMCPInstructions(t *testing.T) {
 
 func TestComposeInstructions_NoCustomInstructions(t *testing.T) {
 	registry := newTestMCPRegistry(nil)
-	builder := NewPromptBuilder(registry)
+	builder := NewPromptBuilder(registry, nil)
 	execCtx := &agent.ExecutionContext{
 		Config: &agent.ResolvedAgentConfig{
 			CustomInstructions: "",
@@ -83,7 +83,7 @@ func TestComposeInstructions_NoCustomInstructions(t *testing.T) {
 func TestComposeInstructions_MissingMCPServer(t *testing.T) {
 	// Server referenced but not in registry — should be silently skipped
 	registry := newTestMCPRegistry(nil)
-	builder := NewPromptBuilder(registry)
+	builder := NewPromptBuilder(registry, nil)
 	execCtx := newTestExecCtx()
 
 	result := builder.ComposeInstructions(execCtx)
@@ -98,7 +98,7 @@ func TestComposeChatInstructions_UsesChatGeneralInstructions(t *testing.T) {
 			Instructions: "K8s instructions.",
 		},
 	})
-	builder := NewPromptBuilder(registry)
+	builder := NewPromptBuilder(registry, nil)
 	execCtx := newTestExecCtx()
 
 	result := builder.ComposeChatInstructions(execCtx)
@@ -124,7 +124,7 @@ func TestComposeChatInstructions_UsesChatGeneralInstructions(t *testing.T) {
 
 func TestComposeInstructions_FailedServers(t *testing.T) {
 	registry := newTestMCPRegistry(nil)
-	builder := NewPromptBuilder(registry)
+	builder := NewPromptBuilder(registry, nil)
 	execCtx := &agent.ExecutionContext{
 		Config: &agent.ResolvedAgentConfig{},
 		FailedServers: map[string]string{
@@ -145,7 +145,7 @@ func TestComposeInstructions_FailedServers(t *testing.T) {
 
 func TestComposeChatInstructions_FailedServers(t *testing.T) {
 	registry := newTestMCPRegistry(nil)
-	builder := NewPromptBuilder(registry)
+	builder := NewPromptBuilder(registry, nil)
 	execCtx := &agent.ExecutionContext{
 		Config: &agent.ResolvedAgentConfig{},
 		FailedServers: map[string]string{
@@ -162,7 +162,7 @@ func TestComposeChatInstructions_FailedServers(t *testing.T) {
 
 func TestComposeInstructions_NoFailedServers(t *testing.T) {
 	registry := newTestMCPRegistry(nil)
-	builder := NewPromptBuilder(registry)
+	builder := NewPromptBuilder(registry, nil)
 	execCtx := &agent.ExecutionContext{
 		Config: &agent.ResolvedAgentConfig{},
 	}
@@ -175,7 +175,7 @@ func TestComposeInstructions_OrderingPreserved(t *testing.T) {
 	registry := newTestMCPRegistry(map[string]*config.MCPServerConfig{
 		"kubernetes-server": {Instructions: "MCP_TIER2_MARKER"},
 	})
-	builder := NewPromptBuilder(registry)
+	builder := NewPromptBuilder(registry, nil)
 	execCtx := &agent.ExecutionContext{
 		Config: &agent.ResolvedAgentConfig{
 			MCPServers:         []string{"kubernetes-server"},
@@ -204,7 +204,7 @@ func TestComposeInstructions_SkillTierOrdering(t *testing.T) {
 	registry := newTestMCPRegistry(map[string]*config.MCPServerConfig{
 		"kubernetes-server": {Instructions: "MCP_TIER2_MARKER"},
 	})
-	builder := NewPromptBuilder(registry)
+	builder := NewPromptBuilder(registry, nil)
 	execCtx := &agent.ExecutionContext{
 		Config: &agent.ResolvedAgentConfig{
 			MCPServers:         []string{"kubernetes-server"},
@@ -246,7 +246,7 @@ func TestComposeChatInstructions_SkillTierOrdering(t *testing.T) {
 	registry := newTestMCPRegistry(map[string]*config.MCPServerConfig{
 		"kubernetes-server": {Instructions: "MCP_TIER2_MARKER"},
 	})
-	builder := NewPromptBuilder(registry)
+	builder := NewPromptBuilder(registry, nil)
 	execCtx := &agent.ExecutionContext{
 		Config: &agent.ResolvedAgentConfig{
 			MCPServers:         []string{"kubernetes-server"},
@@ -279,7 +279,7 @@ func TestComposeChatInstructions_SkillTierOrdering(t *testing.T) {
 
 func TestComposeInstructions_NoSkills(t *testing.T) {
 	registry := newTestMCPRegistry(nil)
-	builder := NewPromptBuilder(registry)
+	builder := NewPromptBuilder(registry, nil)
 	execCtx := &agent.ExecutionContext{
 		Config: &agent.ResolvedAgentConfig{},
 	}
@@ -292,7 +292,7 @@ func TestComposeInstructions_NoSkills(t *testing.T) {
 
 func TestComposeChatInstructions_NoSkills(t *testing.T) {
 	registry := newTestMCPRegistry(nil)
-	builder := NewPromptBuilder(registry)
+	builder := NewPromptBuilder(registry, nil)
 	execCtx := &agent.ExecutionContext{
 		Config: &agent.ResolvedAgentConfig{},
 	}
@@ -305,7 +305,7 @@ func TestComposeChatInstructions_NoSkills(t *testing.T) {
 
 func TestComposeInstructions_OnlyRequiredSkills(t *testing.T) {
 	registry := newTestMCPRegistry(nil)
-	builder := NewPromptBuilder(registry)
+	builder := NewPromptBuilder(registry, nil)
 	execCtx := &agent.ExecutionContext{
 		Config: &agent.ResolvedAgentConfig{
 			RequiredSkillContent: []agent.ResolvedSkill{
@@ -324,7 +324,7 @@ func TestComposeInstructions_OnlyRequiredSkills(t *testing.T) {
 
 func TestComposeInstructions_MultipleRequiredSkills(t *testing.T) {
 	registry := newTestMCPRegistry(nil)
-	builder := NewPromptBuilder(registry)
+	builder := NewPromptBuilder(registry, nil)
 	execCtx := &agent.ExecutionContext{
 		Config: &agent.ResolvedAgentConfig{
 			RequiredSkillContent: []agent.ResolvedSkill{
@@ -349,7 +349,7 @@ func TestComposeInstructions_MultipleRequiredSkills(t *testing.T) {
 
 func TestComposeInstructions_MemoryTier4(t *testing.T) {
 	registry := newTestMCPRegistry(nil)
-	builder := NewPromptBuilder(registry)
+	builder := NewPromptBuilder(registry, nil)
 	execCtx := &agent.ExecutionContext{
 		Config: &agent.ResolvedAgentConfig{
 			CustomInstructions: "CUSTOM_TIER3_MARKER",
@@ -378,7 +378,7 @@ func TestComposeInstructions_MemoryTier4(t *testing.T) {
 
 func TestComposeInstructions_MemoryTier4Ordering(t *testing.T) {
 	registry := newTestMCPRegistry(nil)
-	builder := NewPromptBuilder(registry)
+	builder := NewPromptBuilder(registry, nil)
 	execCtx := &agent.ExecutionContext{
 		Config: &agent.ResolvedAgentConfig{
 			CustomInstructions: "CUSTOM_TIER3_MARKER",
@@ -400,7 +400,7 @@ func TestComposeInstructions_MemoryTier4Ordering(t *testing.T) {
 
 func TestComposeInstructions_NoMemoryBriefing(t *testing.T) {
 	registry := newTestMCPRegistry(nil)
-	builder := NewPromptBuilder(registry)
+	builder := NewPromptBuilder(registry, nil)
 	execCtx := &agent.ExecutionContext{
 		Config: &agent.ResolvedAgentConfig{},
 	}
@@ -411,7 +411,7 @@ func TestComposeInstructions_NoMemoryBriefing(t *testing.T) {
 
 func TestComposeInstructions_EmptyMemoryBriefing(t *testing.T) {
 	registry := newTestMCPRegistry(nil)
-	builder := NewPromptBuilder(registry)
+	builder := NewPromptBuilder(registry, nil)
 	execCtx := &agent.ExecutionContext{
 		Config:         &agent.ResolvedAgentConfig{},
 		MemoryBriefing: &agent.MemoryBriefing{},
@@ -423,7 +423,7 @@ func TestComposeInstructions_EmptyMemoryBriefing(t *testing.T) {
 
 func TestComposeChatInstructions_NoMemoryInjection(t *testing.T) {
 	registry := newTestMCPRegistry(nil)
-	builder := NewPromptBuilder(registry)
+	builder := NewPromptBuilder(registry, nil)
 	execCtx := &agent.ExecutionContext{
 		Config: &agent.ResolvedAgentConfig{},
 		MemoryBriefing: &agent.MemoryBriefing{
@@ -443,7 +443,7 @@ func TestComposeInstructions_FullTierOrdering_WithMemory(t *testing.T) {
 	registry := newTestMCPRegistry(map[string]*config.MCPServerConfig{
 		"kubernetes-server": {Instructions: "MCP_TIER2_MARKER"},
 	})
-	builder := NewPromptBuilder(registry)
+	builder := NewPromptBuilder(registry, nil)
 	execCtx := &agent.ExecutionContext{
 		Config: &agent.ResolvedAgentConfig{
 			MCPServers:         []string{"kubernetes-server"},
@@ -483,7 +483,7 @@ func TestComposeInstructions_FullTierOrdering_WithMemory(t *testing.T) {
 
 func TestComposeInstructions_OnlyOnDemandSkills(t *testing.T) {
 	registry := newTestMCPRegistry(nil)
-	builder := NewPromptBuilder(registry)
+	builder := NewPromptBuilder(registry, nil)
 	execCtx := &agent.ExecutionContext{
 		Config: &agent.ResolvedAgentConfig{
 			OnDemandSkills: []agent.SkillCatalogEntry{

--- a/pkg/agent/prompt/testdata/function_calling_chat.golden
+++ b/pkg/agent/prompt/testdata/function_calling_chat.golden
@@ -2,6 +2,8 @@
 ## Context
 
 Current time: {CURRENT_TIME}
+Calendar context (UTC): {CALENDAR_CONTEXT}
+Staffing: {STAFFING}
 
 ## Chat Assistant Instructions
 

--- a/pkg/agent/prompt/testdata/function_calling_investigation.golden
+++ b/pkg/agent/prompt/testdata/function_calling_investigation.golden
@@ -2,6 +2,8 @@
 ## Context
 
 Current time: {CURRENT_TIME}
+Calendar context (UTC): {CALENDAR_CONTEXT}
+Staffing: {STAFFING}
 
 ## General SRE Agent Instructions
 

--- a/pkg/agent/prompt/testdata/function_calling_investigation_failed_servers.golden
+++ b/pkg/agent/prompt/testdata/function_calling_investigation_failed_servers.golden
@@ -2,6 +2,8 @@
 ## Context
 
 Current time: {CURRENT_TIME}
+Calendar context (UTC): {CALENDAR_CONTEXT}
+Staffing: {STAFFING}
 
 ## General SRE Agent Instructions
 

--- a/pkg/agent/prompt/testdata/function_calling_investigation_with_context.golden
+++ b/pkg/agent/prompt/testdata/function_calling_investigation_with_context.golden
@@ -2,6 +2,8 @@
 ## Context
 
 Current time: {CURRENT_TIME}
+Calendar context (UTC): {CALENDAR_CONTEXT}
+Staffing: {STAFFING}
 
 ## General SRE Agent Instructions
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -33,6 +33,9 @@ type Config struct {
 	// Additional WebSocket origin patterns beyond DashboardURL and localhost defaults
 	AllowedWSOrigins []string
 
+	// Global holidays for Tier 0 calendar / staffing context (resolved from system.holidays).
+	Holidays []Holiday
+
 	// Component registries
 	AgentRegistry       *AgentRegistry
 	ChainRegistry       *ChainRegistry

--- a/pkg/config/holidays.go
+++ b/pkg/config/holidays.go
@@ -1,0 +1,23 @@
+package config
+
+// Holiday is a year-agnostic global holiday matched by MM-DD (UTC).
+type Holiday struct {
+	Date string // MM-DD
+	Name string
+}
+
+// HolidayYAMLConfig is a single holiday entry from system.holidays in tarsy.yaml.
+type HolidayYAMLConfig struct {
+	Date string `yaml:"date"` // MM-DD
+	Name string `yaml:"name"`
+}
+
+// DefaultHolidays returns the built-in global holiday list used when
+// system.holidays is omitted or empty.
+func DefaultHolidays() []Holiday {
+	// Keep only broadly observed holidays across US, Canada, and much of Europe.
+	return []Holiday{
+		{Date: "01-01", Name: "New Year's Day"},
+		{Date: "12-25", Name: "Christmas"},
+	}
+}

--- a/pkg/config/holidays.go
+++ b/pkg/config/holidays.go
@@ -2,12 +2,6 @@ package config
 
 // Holiday is a year-agnostic global holiday matched by MM-DD (UTC).
 type Holiday struct {
-	Date string // MM-DD
-	Name string
-}
-
-// HolidayYAMLConfig is a single holiday entry from system.holidays in tarsy.yaml.
-type HolidayYAMLConfig struct {
 	Date string `yaml:"date"` // MM-DD
 	Name string `yaml:"name"`
 }

--- a/pkg/config/holidays_test.go
+++ b/pkg/config/holidays_test.go
@@ -1,0 +1,19 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultHolidays(t *testing.T) {
+	got := DefaultHolidays()
+	assert.Equal(t, []Holiday{
+		{Date: "01-01", Name: "New Year's Day"},
+		{Date: "12-25", Name: "Christmas"},
+	}, got)
+
+	// Callers must not observe shared mutable state if someone appends to the result.
+	got[0].Name = "mutated"
+	assert.Equal(t, "New Year's Day", DefaultHolidays()[0].Name)
+}

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -438,6 +438,11 @@ func resolveHolidays(sys *SystemYAMLConfig) []Holiday {
 				"date", h.Date, "name", h.Name)
 			continue
 		}
+		if _, err := time.Parse("01-02", h.Date); err != nil {
+			slog.Warn("Ignoring holiday entry with invalid date (want MM-DD)",
+				"date", h.Date, "name", h.Name, "error", err)
+			continue
+		}
 		out = append(out, h)
 	}
 	if len(out) == 0 {

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -32,6 +32,9 @@ type SystemYAMLConfig struct {
 	Slack            *SlackYAMLConfig          `yaml:"slack"`
 	CostEstimation   *CostEstimationYAMLConfig `yaml:"cost_estimation"`
 	Retention        *RetentionConfig          `yaml:"retention"`
+	// Holidays replaces the built-in global holiday list when non-empty.
+	// Each entry is year-agnostic MM-DD (UTC) used for Tier 0 calendar context.
+	Holidays []HolidayYAMLConfig `yaml:"holidays,omitempty"`
 }
 
 // CostEstimationYAMLConfig holds cost-estimation settings from YAML.
@@ -198,7 +201,7 @@ func load(_ context.Context, configDir string) (*Config, error) {
 		}
 	}
 
-	// Resolve system config (GitHub + Runbooks + Slack + CostEstimation + Retention + DashboardURL + WS Origins)
+	// Resolve system config (GitHub + Runbooks + Slack + CostEstimation + Retention + DashboardURL + WS Origins + Holidays)
 	githubCfg := resolveGitHubConfig(tarsyConfig.System)
 	runbooksCfg := resolveRunbooksConfig(tarsyConfig.System)
 	slackCfg := resolveSlackConfig(tarsyConfig.System)
@@ -206,6 +209,7 @@ func load(_ context.Context, configDir string) (*Config, error) {
 	retentionCfg := resolveRetentionConfig(tarsyConfig.System)
 	dashboardURL := resolveDashboardURL(tarsyConfig.System)
 	allowedWSOrigins := resolveAllowedWSOrigins(tarsyConfig.System)
+	holidays := resolveHolidays(tarsyConfig.System)
 
 	return &Config{
 		configDir:           configDir,
@@ -218,6 +222,7 @@ func load(_ context.Context, configDir string) (*Config, error) {
 		Retention:           retentionCfg,
 		DashboardURL:        dashboardURL,
 		AllowedWSOrigins:    allowedWSOrigins,
+		Holidays:            holidays,
 		AgentRegistry:       agentRegistry,
 		ChainRegistry:       chainRegistry,
 		MCPServerRegistry:   mcpServerRegistry,
@@ -418,4 +423,25 @@ func resolveAllowedWSOrigins(sys *SystemYAMLConfig) []string {
 		return sys.AllowedWSOrigins
 	}
 	return nil
+}
+
+// resolveHolidays returns system.holidays when non-empty (replacing defaults),
+// otherwise the built-in global holiday list.
+func resolveHolidays(sys *SystemYAMLConfig) []Holiday {
+	if sys == nil || len(sys.Holidays) == 0 {
+		return DefaultHolidays()
+	}
+	out := make([]Holiday, 0, len(sys.Holidays))
+	for _, h := range sys.Holidays {
+		if h.Date == "" || h.Name == "" {
+			slog.Warn("Ignoring holiday entry with empty date or name",
+				"date", h.Date, "name", h.Name)
+			continue
+		}
+		out = append(out, Holiday{Date: h.Date, Name: h.Name})
+	}
+	if len(out) == 0 {
+		return DefaultHolidays()
+	}
+	return out
 }

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -34,7 +34,7 @@ type SystemYAMLConfig struct {
 	Retention        *RetentionConfig          `yaml:"retention"`
 	// Holidays replaces the built-in global holiday list when non-empty.
 	// Each entry is year-agnostic MM-DD (UTC) used for Tier 0 calendar context.
-	Holidays []HolidayYAMLConfig `yaml:"holidays,omitempty"`
+	Holidays []Holiday `yaml:"holidays,omitempty"`
 }
 
 // CostEstimationYAMLConfig holds cost-estimation settings from YAML.
@@ -438,7 +438,7 @@ func resolveHolidays(sys *SystemYAMLConfig) []Holiday {
 				"date", h.Date, "name", h.Name)
 			continue
 		}
-		out = append(out, Holiday{Date: h.Date, Name: h.Name})
+		out = append(out, h)
 	}
 	if len(out) == 0 {
 		return DefaultHolidays()

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -887,6 +887,28 @@ func TestResolveHolidays(t *testing.T) {
 		})
 		assert.Equal(t, DefaultHolidays(), got)
 	})
+
+	t.Run("malformed and calendar-invalid dates are skipped", func(t *testing.T) {
+		got := resolveHolidays(&SystemYAMLConfig{
+			Holidays: []Holiday{
+				{Date: "7-04", Name: "Unpadded July 4"},
+				{Date: "02-30", Name: "Impossible day"},
+				{Date: "13-01", Name: "Invalid month"},
+				{Date: "07-04", Name: "Independence Day"},
+			},
+		})
+		assert.Equal(t, []Holiday{{Date: "07-04", Name: "Independence Day"}}, got)
+	})
+
+	t.Run("all malformed dates fall back to defaults", func(t *testing.T) {
+		got := resolveHolidays(&SystemYAMLConfig{
+			Holidays: []Holiday{
+				{Date: "7-04", Name: "Bad"},
+				{Date: "02-30", Name: "Also bad"},
+			},
+		})
+		assert.Equal(t, DefaultHolidays(), got)
+	})
 }
 
 func TestHolidaysYAMLLoading(t *testing.T) {

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -859,7 +859,7 @@ func TestResolveHolidays(t *testing.T) {
 
 	t.Run("non-empty holidays replace defaults", func(t *testing.T) {
 		got := resolveHolidays(&SystemYAMLConfig{
-			Holidays: []HolidayYAMLConfig{
+			Holidays: []Holiday{
 				{Date: "07-04", Name: "Independence Day"},
 				{Date: "12-25", Name: "Christmas"},
 			},
@@ -872,7 +872,7 @@ func TestResolveHolidays(t *testing.T) {
 
 	t.Run("entries with empty date or name are skipped", func(t *testing.T) {
 		got := resolveHolidays(&SystemYAMLConfig{
-			Holidays: []HolidayYAMLConfig{
+			Holidays: []Holiday{
 				{Date: "", Name: "Broken"},
 				{Date: "12-25", Name: ""},
 				{Date: "01-01", Name: "New Year's Day"},
@@ -883,7 +883,7 @@ func TestResolveHolidays(t *testing.T) {
 
 	t.Run("all invalid entries fall back to defaults", func(t *testing.T) {
 		got := resolveHolidays(&SystemYAMLConfig{
-			Holidays: []HolidayYAMLConfig{{Date: "", Name: ""}},
+			Holidays: []Holiday{{Date: "", Name: ""}},
 		})
 		assert.Equal(t, DefaultHolidays(), got)
 	})

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -846,6 +846,142 @@ func TestResolveRetentionConfig(t *testing.T) {
 	})
 }
 
+func TestResolveHolidays(t *testing.T) {
+	t.Run("nil system uses defaults", func(t *testing.T) {
+		got := resolveHolidays(nil)
+		assert.Equal(t, DefaultHolidays(), got)
+	})
+
+	t.Run("empty holidays uses defaults", func(t *testing.T) {
+		got := resolveHolidays(&SystemYAMLConfig{})
+		assert.Equal(t, DefaultHolidays(), got)
+	})
+
+	t.Run("non-empty holidays replace defaults", func(t *testing.T) {
+		got := resolveHolidays(&SystemYAMLConfig{
+			Holidays: []HolidayYAMLConfig{
+				{Date: "07-04", Name: "Independence Day"},
+				{Date: "12-25", Name: "Christmas"},
+			},
+		})
+		assert.Equal(t, []Holiday{
+			{Date: "07-04", Name: "Independence Day"},
+			{Date: "12-25", Name: "Christmas"},
+		}, got)
+	})
+
+	t.Run("entries with empty date or name are skipped", func(t *testing.T) {
+		got := resolveHolidays(&SystemYAMLConfig{
+			Holidays: []HolidayYAMLConfig{
+				{Date: "", Name: "Broken"},
+				{Date: "12-25", Name: ""},
+				{Date: "01-01", Name: "New Year's Day"},
+			},
+		})
+		assert.Equal(t, []Holiday{{Date: "01-01", Name: "New Year's Day"}}, got)
+	})
+
+	t.Run("all invalid entries fall back to defaults", func(t *testing.T) {
+		got := resolveHolidays(&SystemYAMLConfig{
+			Holidays: []HolidayYAMLConfig{{Date: "", Name: ""}},
+		})
+		assert.Equal(t, DefaultHolidays(), got)
+	})
+}
+
+func TestHolidaysYAMLLoading(t *testing.T) {
+	t.Run("explicit holidays replace defaults", func(t *testing.T) {
+		dir := t.TempDir()
+
+		tarsyYAML := `
+system:
+  holidays:
+    - date: "12-25"
+      name: "Christmas"
+    - date: "01-01"
+      name: "New Year's Day"
+defaults:
+  llm_provider: "google-default"
+  max_iterations: 20
+agents: {}
+mcp_servers: {}
+agent_chains: {}
+`
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "tarsy.yaml"), []byte(tarsyYAML), 0644))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "llm-providers.yaml"), []byte("llm_providers: {}\n"), 0644))
+
+		cfg, err := load(context.Background(), dir)
+		require.NoError(t, err)
+		assert.Equal(t, []Holiday{
+			{Date: "12-25", Name: "Christmas"},
+			{Date: "01-01", Name: "New Year's Day"},
+		}, cfg.Holidays)
+	})
+
+	t.Run("omitted holidays use defaults", func(t *testing.T) {
+		dir := t.TempDir()
+
+		tarsyYAML := `
+system:
+  dashboard_url: "https://tarsy.example.com"
+defaults:
+  llm_provider: "google-default"
+  max_iterations: 20
+agents: {}
+mcp_servers: {}
+agent_chains: {}
+`
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "tarsy.yaml"), []byte(tarsyYAML), 0644))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "llm-providers.yaml"), []byte("llm_providers: {}\n"), 0644))
+
+		cfg, err := load(context.Background(), dir)
+		require.NoError(t, err)
+		assert.Equal(t, DefaultHolidays(), cfg.Holidays)
+	})
+
+	t.Run("christmas break product list loads end to end", func(t *testing.T) {
+		dir := t.TempDir()
+
+		tarsyYAML := `
+system:
+  holidays:
+    - date: "12-24"
+      name: "Christmas Eve"
+    - date: "12-25"
+      name: "Christmas"
+    - date: "12-26"
+      name: "Christmas holiday"
+    - date: "12-27"
+      name: "Christmas holiday"
+    - date: "12-28"
+      name: "Christmas holiday"
+    - date: "12-29"
+      name: "Christmas holiday"
+    - date: "12-30"
+      name: "Christmas holiday"
+    - date: "12-31"
+      name: "New Year's Eve"
+    - date: "01-01"
+      name: "New Year's Day"
+defaults:
+  llm_provider: "google-default"
+  max_iterations: 20
+agents: {}
+mcp_servers: {}
+agent_chains: {}
+`
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "tarsy.yaml"), []byte(tarsyYAML), 0644))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "llm-providers.yaml"), []byte("llm_providers: {}\n"), 0644))
+
+		cfg, err := load(context.Background(), dir)
+		require.NoError(t, err)
+		require.Len(t, cfg.Holidays, 9)
+		assert.Equal(t, "12-24", cfg.Holidays[0].Date)
+		assert.Equal(t, "01-01", cfg.Holidays[8].Date)
+		assert.NotEqual(t, DefaultHolidays(), cfg.Holidays)
+	})
+}
+
 func TestSystemConfigYAMLLoading(t *testing.T) {
 	t.Run("system section parsed from YAML", func(t *testing.T) {
 		dir := t.TempDir()

--- a/pkg/queue/chat_executor.go
+++ b/pkg/queue/chat_executor.go
@@ -112,7 +112,7 @@ func NewChatMessageExecutor(
 		mcpFactory:         mcpFactory,
 		agentFactory:       agent.NewAgentFactory(controllerFactory),
 		eventPublisher:     eventPublisher,
-		promptBuilder:      prompt.NewPromptBuilder(cfg.MCPServerRegistry),
+		promptBuilder:      prompt.NewPromptBuilder(cfg.MCPServerRegistry, cfg.Holidays),
 		execConfig:         execConfig,
 		runbookService:     runbookService,
 		memoryService:      memoryService,

--- a/pkg/queue/executor.go
+++ b/pkg/queue/executor.go
@@ -55,7 +55,7 @@ func NewRealSessionExecutor(cfg *config.Config, dbClient *ent.Client, llmClient 
 		llmClient:        llmClient,
 		eventPublisher:   eventPublisher,
 		agentFactory:     agent.NewAgentFactory(controllerFactory),
-		promptBuilder:    prompt.NewPromptBuilder(cfg.MCPServerRegistry),
+		promptBuilder:    prompt.NewPromptBuilder(cfg.MCPServerRegistry, cfg.Holidays),
 		mcpFactory:       mcpFactory,
 		runbookService:   runbookService,
 		subAgentRegistry: config.BuildSubAgentRegistry(cfg.AgentRegistry.GetAll()),

--- a/pkg/queue/scoring_executor.go
+++ b/pkg/queue/scoring_executor.go
@@ -91,7 +91,7 @@ func NewScoringExecutor(
 		llmClient:          llmClient,
 		agentFactory:       agent.NewAgentFactory(controllerFactory),
 		eventPublisher:     eventPublisher,
-		promptBuilder:      prompt.NewPromptBuilder(cfg.MCPServerRegistry),
+		promptBuilder:      prompt.NewPromptBuilder(cfg.MCPServerRegistry, cfg.Holidays),
 		stageService:       stageService,
 		timelineService:    timelineService,
 		interactionService: services.NewInteractionService(dbClient, msgService, nil),

--- a/test/e2e/normalize.go
+++ b/test/e2e/normalize.go
@@ -37,9 +37,13 @@ var (
 	currentTimeLineRe     = regexp.MustCompile(`Current time: [^\n]+`)
 	calendarContextLineRe = regexp.MustCompile(`Calendar context \(UTC\): [^\n]+`)
 	staffingLineRe        = regexp.MustCompile(`Staffing: [^\n]+`)
-	memoryAgeRe           = regexp.MustCompile(`(learned|updated) (?:just now|\d+ \w+ ago)`)
-	memoryScoreRe         = regexp.MustCompile(`, score: -?\d+\.\d+`)
-	shortTimestampRe      = regexp.MustCompile(`\d{4}-\d{2}-\d{2} \d{2}:\d{2}`)
+	// Matches LLM-interaction golden bodies: system message content until the next
+	// message header (or EOF). Used so calendar/staffing placeholders do not rewrite
+	// user/assistant text that happens to mention those phrases.
+	systemMessageBodyRe = regexp.MustCompile(`(?s)(=== MESSAGE: system ===\n)(.*?)((?:\n=== MESSAGE: )|\z)`)
+	memoryAgeRe         = regexp.MustCompile(`(learned|updated) (?:just now|\d+ \w+ ago)`)
+	memoryScoreRe       = regexp.MustCompile(`, score: -?\d+\.\d+`)
+	shortTimestampRe    = regexp.MustCompile(`\d{4}-\d{2}-\d{2} \d{2}:\d{2}`)
 )
 
 // NewNormalizer creates a normalizer that knows the session ID to replace.
@@ -140,10 +144,15 @@ func (n *Normalizer) Normalize(data string) string {
 		data = strings.ReplaceAll(data, id, placeholder)
 	}
 
-	// 7. Replace Tier 0 calendar lines (vary every run / by weekday).
+	// 7. Replace Tier 0 lines that vary by wall-clock time.
+	// Current time stays global (same as before). Calendar/staffing are only
+	// rewritten inside system message bodies so user/assistant text is preserved.
 	data = currentTimeLineRe.ReplaceAllString(data, "Current time: {CURRENT_TIME}")
-	data = calendarContextLineRe.ReplaceAllString(data, "Calendar context (UTC): {CALENDAR_CONTEXT}")
-	data = staffingLineRe.ReplaceAllString(data, "Staffing: {STAFFING}")
+	data = replaceInSystemMessageBodies(data, func(body string) string {
+		body = calendarContextLineRe.ReplaceAllString(body, "Calendar context (UTC): {CALENDAR_CONTEXT}")
+		body = staffingLineRe.ReplaceAllString(body, "Staffing: {STAFFING}")
+		return body
+	})
 
 	// 8. Replace memory score values (vary based on ranking computation).
 	data = memoryScoreRe.ReplaceAllString(data, ", score: {SCORE}")
@@ -176,6 +185,18 @@ func (n *Normalizer) Normalize(data string) string {
 	data = durationMsRe.ReplaceAllString(data, `"duration_ms": {DURATION_MS}`)
 
 	return data
+}
+
+// replaceInSystemMessageBodies applies fn to each === MESSAGE: system === body
+// in AssertGoldenLLMInteraction output, leaving other roles unchanged.
+func replaceInSystemMessageBodies(data string, fn func(string) string) string {
+	return systemMessageBodyRe.ReplaceAllStringFunc(data, func(match string) string {
+		parts := systemMessageBodyRe.FindStringSubmatch(match)
+		if len(parts) != 4 {
+			return match
+		}
+		return parts[1] + fn(parts[2]) + parts[3]
+	})
 }
 
 // NormalizeBytes is a convenience wrapper for Normalize on byte slices.

--- a/test/e2e/normalize.go
+++ b/test/e2e/normalize.go
@@ -28,18 +28,18 @@ type Normalizer struct {
 
 // Regex patterns for dynamic values.
 var (
-	uuidRe            = regexp.MustCompile(`[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}`)
-	timestampRe       = regexp.MustCompile(`\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})`)
-	unixTSRe          = regexp.MustCompile(`"(created_at|updated_at|started_at|completed_at|timestamp)":\s*\d{10,13}`)
-	dbEventIDRe       = regexp.MustCompile(`"db_event_id":\s*\d+`)
-	connIDRe          = regexp.MustCompile(`"connection_id":\s*"[^"]*"`)
-	durationMsRe      = regexp.MustCompile(`"duration_ms":\s*\d+`)
-	currentTimeLineRe = regexp.MustCompile(`Current time: [^\n]+`)
+	uuidRe                = regexp.MustCompile(`[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}`)
+	timestampRe           = regexp.MustCompile(`\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})`)
+	unixTSRe              = regexp.MustCompile(`"(created_at|updated_at|started_at|completed_at|timestamp)":\s*\d{10,13}`)
+	dbEventIDRe           = regexp.MustCompile(`"db_event_id":\s*\d+`)
+	connIDRe              = regexp.MustCompile(`"connection_id":\s*"[^"]*"`)
+	durationMsRe          = regexp.MustCompile(`"duration_ms":\s*\d+`)
+	currentTimeLineRe     = regexp.MustCompile(`Current time: [^\n]+`)
 	calendarContextLineRe = regexp.MustCompile(`Calendar context \(UTC\): [^\n]+`)
-	staffingLineRe      = regexp.MustCompile(`Staffing: [^\n]+`)
-	memoryAgeRe       = regexp.MustCompile(`(learned|updated) (?:just now|\d+ \w+ ago)`)
-	memoryScoreRe     = regexp.MustCompile(`, score: -?\d+\.\d+`)
-	shortTimestampRe  = regexp.MustCompile(`\d{4}-\d{2}-\d{2} \d{2}:\d{2}`)
+	staffingLineRe        = regexp.MustCompile(`Staffing: [^\n]+`)
+	memoryAgeRe           = regexp.MustCompile(`(learned|updated) (?:just now|\d+ \w+ ago)`)
+	memoryScoreRe         = regexp.MustCompile(`, score: -?\d+\.\d+`)
+	shortTimestampRe      = regexp.MustCompile(`\d{4}-\d{2}-\d{2} \d{2}:\d{2}`)
 )
 
 // NewNormalizer creates a normalizer that knows the session ID to replace.

--- a/test/e2e/normalize.go
+++ b/test/e2e/normalize.go
@@ -35,6 +35,8 @@ var (
 	connIDRe          = regexp.MustCompile(`"connection_id":\s*"[^"]*"`)
 	durationMsRe      = regexp.MustCompile(`"duration_ms":\s*\d+`)
 	currentTimeLineRe = regexp.MustCompile(`Current time: [^\n]+`)
+	calendarContextLineRe = regexp.MustCompile(`Calendar context \(UTC\): [^\n]+`)
+	staffingLineRe      = regexp.MustCompile(`Staffing: [^\n]+`)
 	memoryAgeRe       = regexp.MustCompile(`(learned|updated) (?:just now|\d+ \w+ ago)`)
 	memoryScoreRe     = regexp.MustCompile(`, score: -?\d+\.\d+`)
 	shortTimestampRe  = regexp.MustCompile(`\d{4}-\d{2}-\d{2} \d{2}:\d{2}`)
@@ -138,8 +140,10 @@ func (n *Normalizer) Normalize(data string) string {
 		data = strings.ReplaceAll(data, id, placeholder)
 	}
 
-	// 7. Replace "Current time:" line (varies every run).
+	// 7. Replace Tier 0 calendar lines (vary every run / by weekday).
 	data = currentTimeLineRe.ReplaceAllString(data, "Current time: {CURRENT_TIME}")
+	data = calendarContextLineRe.ReplaceAllString(data, "Calendar context (UTC): {CALENDAR_CONTEXT}")
+	data = staffingLineRe.ReplaceAllString(data, "Staffing: {STAFFING}")
 
 	// 8. Replace memory score values (vary based on ranking computation).
 	data = memoryScoreRe.ReplaceAllString(data, ", score: {SCORE}")

--- a/test/e2e/normalize_test.go
+++ b/test/e2e/normalize_test.go
@@ -1,0 +1,39 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNormalize_CalendarStaffingOnlyInSystemMessages(t *testing.T) {
+	n := NewNormalizer("")
+	in := `{
+  "id": "meta"
+}
+
+=== MESSAGE: system ===
+## Context
+
+Current time: 2026-12-25T08:00:00Z (Friday)
+Calendar context (UTC): 2026-12-25 — Friday — GLOBAL_HOLIDAY (Christmas)
+Staffing: reduced (humans less likely to review promptly)
+
+## General SRE Agent Instructions
+
+=== MESSAGE: user ===
+Operator note: Calendar context (UTC): do not rewrite this line
+Staffing: keep user staffing mention
+
+=== MESSAGE: assistant ===
+I considered Calendar context (UTC): also leave this alone
+Staffing: keep assistant staffing mention
+`
+	got := n.Normalize(in)
+
+	assert.Contains(t, got, "=== MESSAGE: system ===\n## Context\n\nCurrent time: {CURRENT_TIME}\nCalendar context (UTC): {CALENDAR_CONTEXT}\nStaffing: {STAFFING}\n")
+	assert.Contains(t, got, "=== MESSAGE: user ===\nOperator note: Calendar context (UTC): do not rewrite this line\nStaffing: keep user staffing mention\n")
+	assert.Contains(t, got, "=== MESSAGE: assistant ===\nI considered Calendar context (UTC): also leave this alone\nStaffing: keep assistant staffing mention\n")
+	assert.NotContains(t, got, "GLOBAL_HOLIDAY (Christmas)")
+	assert.NotContains(t, got, "humans less likely to review promptly")
+}

--- a/test/e2e/testdata/golden/memory-feedback/trace_interactions/03_Investigator_llm_iteration_1.golden
+++ b/test/e2e/testdata/golden/memory-feedback/trace_interactions/03_Investigator_llm_iteration_1.golden
@@ -22,6 +22,8 @@
 ## Context
 
 Current time: {CURRENT_TIME}
+Calendar context (UTC): {CALENDAR_CONTEXT}
+Staffing: {STAFFING}
 
 ## General SRE Agent Instructions
 

--- a/test/e2e/testdata/golden/memory-feedback/trace_interactions/05_Investigator_llm_iteration_2.golden
+++ b/test/e2e/testdata/golden/memory-feedback/trace_interactions/05_Investigator_llm_iteration_2.golden
@@ -22,6 +22,8 @@
 ## Context
 
 Current time: {CURRENT_TIME}
+Calendar context (UTC): {CALENDAR_CONTEXT}
+Staffing: {STAFFING}
 
 ## General SRE Agent Instructions
 

--- a/test/e2e/testdata/golden/memory-session-search-no-match/trace_interactions/02_MemoryInvestigator_llm_iteration_1.golden
+++ b/test/e2e/testdata/golden/memory-session-search-no-match/trace_interactions/02_MemoryInvestigator_llm_iteration_1.golden
@@ -22,6 +22,8 @@
 ## Context
 
 Current time: {CURRENT_TIME}
+Calendar context (UTC): {CALENDAR_CONTEXT}
+Staffing: {STAFFING}
 
 ## General SRE Agent Instructions
 

--- a/test/e2e/testdata/golden/memory-session-search-no-match/trace_interactions/05_ChatAgent_llm_iteration_1.golden
+++ b/test/e2e/testdata/golden/memory-session-search-no-match/trace_interactions/05_ChatAgent_llm_iteration_1.golden
@@ -22,6 +22,8 @@
 ## Context
 
 Current time: {CURRENT_TIME}
+Calendar context (UTC): {CALENDAR_CONTEXT}
+Staffing: {STAFFING}
 
 ## Chat Assistant Instructions
 

--- a/test/e2e/testdata/golden/memory-session-search-no-match/trace_interactions/07_ChatAgent_llm_iteration_2.golden
+++ b/test/e2e/testdata/golden/memory-session-search-no-match/trace_interactions/07_ChatAgent_llm_iteration_2.golden
@@ -22,6 +22,8 @@
 ## Context
 
 Current time: {CURRENT_TIME}
+Calendar context (UTC): {CALENDAR_CONTEXT}
+Staffing: {STAFFING}
 
 ## Chat Assistant Instructions
 

--- a/test/e2e/testdata/golden/memory-session-search/trace_interactions/03_MemoryInvestigator_llm_iteration_1.golden
+++ b/test/e2e/testdata/golden/memory-session-search/trace_interactions/03_MemoryInvestigator_llm_iteration_1.golden
@@ -22,6 +22,8 @@
 ## Context
 
 Current time: {CURRENT_TIME}
+Calendar context (UTC): {CALENDAR_CONTEXT}
+Staffing: {STAFFING}
 
 ## General SRE Agent Instructions
 

--- a/test/e2e/testdata/golden/memory-session-search/trace_interactions/05_MemoryInvestigator_llm_iteration_2.golden
+++ b/test/e2e/testdata/golden/memory-session-search/trace_interactions/05_MemoryInvestigator_llm_iteration_2.golden
@@ -22,6 +22,8 @@
 ## Context
 
 Current time: {CURRENT_TIME}
+Calendar context (UTC): {CALENDAR_CONTEXT}
+Staffing: {STAFFING}
 
 ## General SRE Agent Instructions
 

--- a/test/e2e/testdata/golden/memory-session-search/trace_interactions/09_ChatAgent_llm_iteration_1.golden
+++ b/test/e2e/testdata/golden/memory-session-search/trace_interactions/09_ChatAgent_llm_iteration_1.golden
@@ -22,6 +22,8 @@
 ## Context
 
 Current time: {CURRENT_TIME}
+Calendar context (UTC): {CALENDAR_CONTEXT}
+Staffing: {STAFFING}
 
 ## Chat Assistant Instructions
 

--- a/test/e2e/testdata/golden/memory-session-search/trace_interactions/12_ChatAgent_llm_iteration_2.golden
+++ b/test/e2e/testdata/golden/memory-session-search/trace_interactions/12_ChatAgent_llm_iteration_2.golden
@@ -22,6 +22,8 @@
 ## Context
 
 Current time: {CURRENT_TIME}
+Calendar context (UTC): {CALENDAR_CONTEXT}
+Staffing: {STAFFING}
 
 ## Chat Assistant Instructions
 

--- a/test/e2e/testdata/golden/memory/trace_interactions/03_MemoryInvestigator_llm_iteration_1.golden
+++ b/test/e2e/testdata/golden/memory/trace_interactions/03_MemoryInvestigator_llm_iteration_1.golden
@@ -22,6 +22,8 @@
 ## Context
 
 Current time: {CURRENT_TIME}
+Calendar context (UTC): {CALENDAR_CONTEXT}
+Staffing: {STAFFING}
 
 ## General SRE Agent Instructions
 

--- a/test/e2e/testdata/golden/memory/trace_interactions/05_MemoryInvestigator_llm_iteration_2.golden
+++ b/test/e2e/testdata/golden/memory/trace_interactions/05_MemoryInvestigator_llm_iteration_2.golden
@@ -22,6 +22,8 @@
 ## Context
 
 Current time: {CURRENT_TIME}
+Calendar context (UTC): {CALENDAR_CONTEXT}
+Staffing: {STAFFING}
 
 ## General SRE Agent Instructions
 

--- a/test/e2e/testdata/golden/memory/trace_interactions/09_ChatAgent_llm_iteration_1.golden
+++ b/test/e2e/testdata/golden/memory/trace_interactions/09_ChatAgent_llm_iteration_1.golden
@@ -22,6 +22,8 @@
 ## Context
 
 Current time: {CURRENT_TIME}
+Calendar context (UTC): {CALENDAR_CONTEXT}
+Staffing: {STAFFING}
 
 ## Chat Assistant Instructions
 

--- a/test/e2e/testdata/golden/memory/trace_interactions/11_ChatAgent_llm_iteration_2.golden
+++ b/test/e2e/testdata/golden/memory/trace_interactions/11_ChatAgent_llm_iteration_2.golden
@@ -22,6 +22,8 @@
 ## Context
 
 Current time: {CURRENT_TIME}
+Calendar context (UTC): {CALENDAR_CONTEXT}
+Staffing: {STAFFING}
 
 ## Chat Assistant Instructions
 

--- a/test/e2e/testdata/golden/orchestrator/trace_interactions/02_SREOrchestrator_llm_iteration_1.golden
+++ b/test/e2e/testdata/golden/orchestrator/trace_interactions/02_SREOrchestrator_llm_iteration_1.golden
@@ -22,6 +22,8 @@
 ## Context
 
 Current time: {CURRENT_TIME}
+Calendar context (UTC): {CALENDAR_CONTEXT}
+Staffing: {STAFFING}
 
 ## General SRE Agent Instructions
 

--- a/test/e2e/testdata/golden/orchestrator/trace_interactions/04_SREOrchestrator_llm_iteration_2.golden
+++ b/test/e2e/testdata/golden/orchestrator/trace_interactions/04_SREOrchestrator_llm_iteration_2.golden
@@ -22,6 +22,8 @@
 ## Context
 
 Current time: {CURRENT_TIME}
+Calendar context (UTC): {CALENDAR_CONTEXT}
+Staffing: {STAFFING}
 
 ## General SRE Agent Instructions
 

--- a/test/e2e/testdata/golden/orchestrator/trace_interactions/05_SREOrchestrator_llm_iteration_3.golden
+++ b/test/e2e/testdata/golden/orchestrator/trace_interactions/05_SREOrchestrator_llm_iteration_3.golden
@@ -22,6 +22,8 @@
 ## Context
 
 Current time: {CURRENT_TIME}
+Calendar context (UTC): {CALENDAR_CONTEXT}
+Staffing: {STAFFING}
 
 ## General SRE Agent Instructions
 

--- a/test/e2e/testdata/golden/orchestrator/trace_interactions/07_LogAnalyzer_llm_iteration_1.golden
+++ b/test/e2e/testdata/golden/orchestrator/trace_interactions/07_LogAnalyzer_llm_iteration_1.golden
@@ -22,6 +22,8 @@
 ## Context
 
 Current time: {CURRENT_TIME}
+Calendar context (UTC): {CALENDAR_CONTEXT}
+Staffing: {STAFFING}
 
 ## General SRE Agent Instructions
 

--- a/test/e2e/testdata/golden/orchestrator/trace_interactions/09_LogAnalyzer_llm_iteration_2.golden
+++ b/test/e2e/testdata/golden/orchestrator/trace_interactions/09_LogAnalyzer_llm_iteration_2.golden
@@ -22,6 +22,8 @@
 ## Context
 
 Current time: {CURRENT_TIME}
+Calendar context (UTC): {CALENDAR_CONTEXT}
+Staffing: {STAFFING}
 
 ## General SRE Agent Instructions
 

--- a/test/e2e/testdata/golden/pipeline/trace_interactions/03_DataCollector_llm_iteration_1.golden
+++ b/test/e2e/testdata/golden/pipeline/trace_interactions/03_DataCollector_llm_iteration_1.golden
@@ -25,6 +25,8 @@
 ## Context
 
 Current time: {CURRENT_TIME}
+Calendar context (UTC): {CALENDAR_CONTEXT}
+Staffing: {STAFFING}
 
 ## General SRE Agent Instructions
 

--- a/test/e2e/testdata/golden/pipeline/trace_interactions/07_DataCollector_llm_iteration_2.golden
+++ b/test/e2e/testdata/golden/pipeline/trace_interactions/07_DataCollector_llm_iteration_2.golden
@@ -25,6 +25,8 @@
 ## Context
 
 Current time: {CURRENT_TIME}
+Calendar context (UTC): {CALENDAR_CONTEXT}
+Staffing: {STAFFING}
 
 ## General SRE Agent Instructions
 

--- a/test/e2e/testdata/golden/pipeline/trace_interactions/09_DataCollector_llm_iteration_3.golden
+++ b/test/e2e/testdata/golden/pipeline/trace_interactions/09_DataCollector_llm_iteration_3.golden
@@ -25,6 +25,8 @@
 ## Context
 
 Current time: {CURRENT_TIME}
+Calendar context (UTC): {CALENDAR_CONTEXT}
+Staffing: {STAFFING}
 
 ## General SRE Agent Instructions
 

--- a/test/e2e/testdata/golden/pipeline/trace_interactions/12_Remediator_llm_iteration_1.golden
+++ b/test/e2e/testdata/golden/pipeline/trace_interactions/12_Remediator_llm_iteration_1.golden
@@ -25,6 +25,8 @@
 ## Context
 
 Current time: {CURRENT_TIME}
+Calendar context (UTC): {CALENDAR_CONTEXT}
+Staffing: {STAFFING}
 
 ## General SRE Agent Instructions
 

--- a/test/e2e/testdata/golden/pipeline/trace_interactions/14_Remediator_llm_iteration_2.golden
+++ b/test/e2e/testdata/golden/pipeline/trace_interactions/14_Remediator_llm_iteration_2.golden
@@ -25,6 +25,8 @@
 ## Context
 
 Current time: {CURRENT_TIME}
+Calendar context (UTC): {CALENDAR_CONTEXT}
+Staffing: {STAFFING}
 
 ## General SRE Agent Instructions
 

--- a/test/e2e/testdata/golden/pipeline/trace_interactions/17_Remediator_llm_iteration_3.golden
+++ b/test/e2e/testdata/golden/pipeline/trace_interactions/17_Remediator_llm_iteration_3.golden
@@ -25,6 +25,8 @@
 ## Context
 
 Current time: {CURRENT_TIME}
+Calendar context (UTC): {CALENDAR_CONTEXT}
+Staffing: {STAFFING}
 
 ## General SRE Agent Instructions
 

--- a/test/e2e/testdata/golden/pipeline/trace_interactions/19_ConfigValidator_llm_iteration_1.golden
+++ b/test/e2e/testdata/golden/pipeline/trace_interactions/19_ConfigValidator_llm_iteration_1.golden
@@ -25,6 +25,8 @@
 ## Context
 
 Current time: {CURRENT_TIME}
+Calendar context (UTC): {CALENDAR_CONTEXT}
+Staffing: {STAFFING}
 
 ## General SRE Agent Instructions
 

--- a/test/e2e/testdata/golden/pipeline/trace_interactions/21_ConfigValidator_llm_iteration_2.golden
+++ b/test/e2e/testdata/golden/pipeline/trace_interactions/21_ConfigValidator_llm_iteration_2.golden
@@ -25,6 +25,8 @@
 ## Context
 
 Current time: {CURRENT_TIME}
+Calendar context (UTC): {CALENDAR_CONTEXT}
+Staffing: {STAFFING}
 
 ## General SRE Agent Instructions
 

--- a/test/e2e/testdata/golden/pipeline/trace_interactions/23_MetricsValidator_llm_iteration_1.golden
+++ b/test/e2e/testdata/golden/pipeline/trace_interactions/23_MetricsValidator_llm_iteration_1.golden
@@ -25,6 +25,8 @@
 ## Context
 
 Current time: {CURRENT_TIME}
+Calendar context (UTC): {CALENDAR_CONTEXT}
+Staffing: {STAFFING}
 
 ## General SRE Agent Instructions
 

--- a/test/e2e/testdata/golden/pipeline/trace_interactions/25_MetricsValidator_llm_forced_conclusion_1.golden
+++ b/test/e2e/testdata/golden/pipeline/trace_interactions/25_MetricsValidator_llm_forced_conclusion_1.golden
@@ -25,6 +25,8 @@
 ## Context
 
 Current time: {CURRENT_TIME}
+Calendar context (UTC): {CALENDAR_CONTEXT}
+Staffing: {STAFFING}
 
 ## General SRE Agent Instructions
 

--- a/test/e2e/testdata/golden/pipeline/trace_interactions/28_ScalingReviewer-1_llm_iteration_1.golden
+++ b/test/e2e/testdata/golden/pipeline/trace_interactions/28_ScalingReviewer-1_llm_iteration_1.golden
@@ -25,6 +25,8 @@
 ## Context
 
 Current time: {CURRENT_TIME}
+Calendar context (UTC): {CALENDAR_CONTEXT}
+Staffing: {STAFFING}
 
 ## General SRE Agent Instructions
 

--- a/test/e2e/testdata/golden/pipeline/trace_interactions/30_ScalingReviewer-2_llm_iteration_1.golden
+++ b/test/e2e/testdata/golden/pipeline/trace_interactions/30_ScalingReviewer-2_llm_iteration_1.golden
@@ -25,6 +25,8 @@
 ## Context
 
 Current time: {CURRENT_TIME}
+Calendar context (UTC): {CALENDAR_CONTEXT}
+Staffing: {STAFFING}
 
 ## General SRE Agent Instructions
 

--- a/test/e2e/testdata/golden/pipeline/trace_interactions/35_ChatAgent_llm_iteration_1.golden
+++ b/test/e2e/testdata/golden/pipeline/trace_interactions/35_ChatAgent_llm_iteration_1.golden
@@ -25,6 +25,8 @@
 ## Context
 
 Current time: {CURRENT_TIME}
+Calendar context (UTC): {CALENDAR_CONTEXT}
+Staffing: {STAFFING}
 
 ## Chat Assistant Instructions
 

--- a/test/e2e/testdata/golden/pipeline/trace_interactions/38_ChatAgent_llm_iteration_2.golden
+++ b/test/e2e/testdata/golden/pipeline/trace_interactions/38_ChatAgent_llm_iteration_2.golden
@@ -25,6 +25,8 @@
 ## Context
 
 Current time: {CURRENT_TIME}
+Calendar context (UTC): {CALENDAR_CONTEXT}
+Staffing: {STAFFING}
 
 ## Chat Assistant Instructions
 

--- a/test/e2e/testdata/golden/pipeline/trace_interactions/41_ChatAgent_llm_iteration_3.golden
+++ b/test/e2e/testdata/golden/pipeline/trace_interactions/41_ChatAgent_llm_iteration_3.golden
@@ -25,6 +25,8 @@
 ## Context
 
 Current time: {CURRENT_TIME}
+Calendar context (UTC): {CALENDAR_CONTEXT}
+Staffing: {STAFFING}
 
 ## Chat Assistant Instructions
 

--- a/test/e2e/testdata/golden/pipeline/trace_interactions/43_ChatAgent_llm_iteration_4.golden
+++ b/test/e2e/testdata/golden/pipeline/trace_interactions/43_ChatAgent_llm_iteration_4.golden
@@ -25,6 +25,8 @@
 ## Context
 
 Current time: {CURRENT_TIME}
+Calendar context (UTC): {CALENDAR_CONTEXT}
+Staffing: {STAFFING}
 
 ## Chat Assistant Instructions
 

--- a/test/e2e/testdata/golden/skills/trace_interactions/03_SkillInvestigator_llm_iteration_1.golden
+++ b/test/e2e/testdata/golden/skills/trace_interactions/03_SkillInvestigator_llm_iteration_1.golden
@@ -22,6 +22,8 @@
 ## Context
 
 Current time: {CURRENT_TIME}
+Calendar context (UTC): {CALENDAR_CONTEXT}
+Staffing: {STAFFING}
 
 ## General SRE Agent Instructions
 

--- a/test/e2e/testdata/golden/skills/trace_interactions/05_SkillInvestigator_llm_iteration_2.golden
+++ b/test/e2e/testdata/golden/skills/trace_interactions/05_SkillInvestigator_llm_iteration_2.golden
@@ -22,6 +22,8 @@
 ## Context
 
 Current time: {CURRENT_TIME}
+Calendar context (UTC): {CALENDAR_CONTEXT}
+Staffing: {STAFFING}
 
 ## General SRE Agent Instructions
 

--- a/test/e2e/testdata/golden/skills/trace_interactions/07_SkillInvestigator_llm_iteration_3.golden
+++ b/test/e2e/testdata/golden/skills/trace_interactions/07_SkillInvestigator_llm_iteration_3.golden
@@ -22,6 +22,8 @@
 ## Context
 
 Current time: {CURRENT_TIME}
+Calendar context (UTC): {CALENDAR_CONTEXT}
+Staffing: {STAFFING}
 
 ## General SRE Agent Instructions
 

--- a/test/e2e/testdata/golden/skills/trace_interactions/10_SkillRemediator_llm_iteration_1.golden
+++ b/test/e2e/testdata/golden/skills/trace_interactions/10_SkillRemediator_llm_iteration_1.golden
@@ -22,6 +22,8 @@
 ## Context
 
 Current time: {CURRENT_TIME}
+Calendar context (UTC): {CALENDAR_CONTEXT}
+Staffing: {STAFFING}
 
 ## General SRE Agent Instructions
 

--- a/test/e2e/testdata/golden/skills/trace_interactions/14_ChatAgent_llm_iteration_1.golden
+++ b/test/e2e/testdata/golden/skills/trace_interactions/14_ChatAgent_llm_iteration_1.golden
@@ -22,6 +22,8 @@
 ## Context
 
 Current time: {CURRENT_TIME}
+Calendar context (UTC): {CALENDAR_CONTEXT}
+Staffing: {STAFFING}
 
 ## Chat Assistant Instructions
 

--- a/test/e2e/testdata/golden/skills/trace_interactions/16_ChatAgent_llm_iteration_2.golden
+++ b/test/e2e/testdata/golden/skills/trace_interactions/16_ChatAgent_llm_iteration_2.golden
@@ -22,6 +22,8 @@
 ## Context
 
 Current time: {CURRENT_TIME}
+Calendar context (UTC): {CALENDAR_CONTEXT}
+Staffing: {STAFFING}
 
 ## Chat Assistant Instructions
 


### PR DESCRIPTION
### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

- Classify wall-clock UTC as WEEKEND / GLOBAL_HOLIDAY / WEEKDAY in prompts
- Add configurable system.holidays (replaces built-in New Year's and Christmas defaults)
- Wire holidays through PromptBuilder; cover compose, chat, and action paths in tests

### How did you verify your code works?

### Checklist

- [x] I tested locally (`make lint` / `make test` as relevant)
- [x] No unrelated changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable global holidays with built-in New Year’s Day and Christmas defaults.
  * Prompts now include UTC date, weekday/weekend or holiday classification, and staffing guidance.
  * Custom holiday settings can replace defaults and support optional names.
  * Invalid holiday entries are skipped, with defaults used when no valid entries remain.

* **Documentation**
  * Documented holiday configuration, calendar context, staffing guidance, and prompt behavior.

* **Tests**
  * Added coverage for default, custom, invalid, and multi-day holiday configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->