### PR TITLE
chore: default Google provider to Gemini 3.7 Flash

### DIFF
--- a/pkg/config/builtin.go
+++ b/pkg/config/builtin.go
@@ -208,7 +208,7 @@ func initBuiltinLLMProviders() map[string]LLMProviderConfig {
 		// --- Google Gemini ---
 		"google-default": {
 			Type:                LLMProviderTypeGoogle,
-			Model:               "gemini-3.6-flash",
+			Model:               "gemini-3.7-flash",
 			APIKeyEnv:           "GOOGLE_API_KEY",
 			MaxToolResultTokens: 950000, // Conservative for 1M context
 			NativeTools:         geminiNativeTools(),
@@ -237,6 +237,13 @@ func initBuiltinLLMProviders() map[string]LLMProviderConfig {
 		"gemini-3.1-flash": {
 			Type:                LLMProviderTypeGoogle,
 			Model:               "gemini-3.1-flash-lite",
+			APIKeyEnv:           "GOOGLE_API_KEY",
+			MaxToolResultTokens: 950000, // Conservative for 1M context
+			NativeTools:         geminiNativeTools(),
+		},
+		"gemini-3.7-flash": {
+			Type:                LLMProviderTypeGoogle,
+			Model:               "gemini-3.7-flash",
 			APIKeyEnv:           "GOOGLE_API_KEY",
 			MaxToolResultTokens: 950000, // Conservative for 1M context
 			NativeTools:         geminiNativeTools(),

--- a/pkg/config/builtin_test.go
+++ b/pkg/config/builtin_test.go
@@ -216,7 +216,7 @@ func TestBuiltinImageProviderDisablesURLContext(t *testing.T) {
 	}
 
 	nonImageProviders := []string{
-		"google-default", "gemini-3.6-flash", "gemini-3.5-flash", "gemini-3-flash", "gemini-3.1-pro", "gemini-3.1-flash", "gemini-2.5-flash", "gemini-2.5-pro",
+		"google-default", "gemini-3.7-flash", "gemini-3.6-flash", "gemini-3.5-flash", "gemini-3-flash", "gemini-3.1-pro", "gemini-3.1-flash", "gemini-2.5-flash", "gemini-2.5-pro",
 	}
 	for _, name := range nonImageProviders {
 		t.Run(name+" has url_context", func(t *testing.T) {
@@ -302,6 +302,13 @@ func TestBuiltinLLMProviders(t *testing.T) {
 		{
 			name:          "gemini-3.1-flash",
 			providerID:    "gemini-3.1-flash",
+			wantType:      LLMProviderTypeGoogle,
+			wantMinTokens: 900000,
+			checkAPIKey:   true,
+		},
+		{
+			name:          "gemini-3.7-flash",
+			providerID:    "gemini-3.7-flash",
 			wantType:      LLMProviderTypeGoogle,
 			wantMinTokens: 900000,
 			checkAPIKey:   true,

--- a/pkg/config/builtin_test.go
+++ b/pkg/config/builtin_test.go
@@ -254,15 +254,18 @@ func TestBuiltinLLMProviders(t *testing.T) {
 		name          string
 		providerID    string
 		wantType      LLMProviderType
+		wantModel     string // if set, exact model ID (else only non-empty)
 		wantMinTokens int
+		wantTokens    int  // if set, exact MaxToolResultTokens (else wantMinTokens floor)
 		checkAPIKey   bool // VertexAI uses ProjectEnv/LocationEnv instead
 	}{
 		{
-			name:          "google-default",
-			providerID:    "google-default",
-			wantType:      LLMProviderTypeGoogle,
-			wantMinTokens: 900000,
-			checkAPIKey:   true,
+			name:        "google-default",
+			providerID:  "google-default",
+			wantType:    LLMProviderTypeGoogle,
+			wantModel:   "gemini-3.7-flash",
+			wantTokens:  950000,
+			checkAPIKey: true,
 		},
 		{
 			name:          "google-image-flash",
@@ -307,18 +310,20 @@ func TestBuiltinLLMProviders(t *testing.T) {
 			checkAPIKey:   true,
 		},
 		{
-			name:          "gemini-3.7-flash",
-			providerID:    "gemini-3.7-flash",
-			wantType:      LLMProviderTypeGoogle,
-			wantMinTokens: 900000,
-			checkAPIKey:   true,
+			name:        "gemini-3.7-flash",
+			providerID:  "gemini-3.7-flash",
+			wantType:    LLMProviderTypeGoogle,
+			wantModel:   "gemini-3.7-flash",
+			wantTokens:  950000,
+			checkAPIKey: true,
 		},
 		{
-			name:          "gemini-3.6-flash",
-			providerID:    "gemini-3.6-flash",
-			wantType:      LLMProviderTypeGoogle,
-			wantMinTokens: 900000,
-			checkAPIKey:   true,
+			name:        "gemini-3.6-flash",
+			providerID:  "gemini-3.6-flash",
+			wantType:    LLMProviderTypeGoogle,
+			wantModel:   "gemini-3.6-flash",
+			wantTokens:  950000,
+			checkAPIKey: true,
 		},
 		{
 			name:          "gemini-3.5-flash",
@@ -362,11 +367,19 @@ func TestBuiltinLLMProviders(t *testing.T) {
 			provider, exists := cfg.LLMProviders[tt.providerID]
 			require.True(t, exists, "Provider %s should exist", tt.providerID)
 			assert.Equal(t, tt.wantType, provider.Type)
-			assert.NotEmpty(t, provider.Model)
+			if tt.wantModel != "" {
+				assert.Equal(t, tt.wantModel, provider.Model)
+			} else {
+				assert.NotEmpty(t, provider.Model)
+			}
 			if tt.checkAPIKey {
 				assert.NotEmpty(t, provider.APIKeyEnv)
 			}
-			assert.GreaterOrEqual(t, provider.MaxToolResultTokens, tt.wantMinTokens)
+			if tt.wantTokens > 0 {
+				assert.Equal(t, tt.wantTokens, provider.MaxToolResultTokens)
+			} else {
+				assert.GreaterOrEqual(t, provider.MaxToolResultTokens, tt.wantMinTokens)
+			}
 		})
 	}
 }

--- a/pkg/cost/snapshot.json
+++ b/pkg/cost/snapshot.json
@@ -37,6 +37,24 @@
     "mode": "chat",
     "output_cost_per_token": 7.5e-06
   },
+  "gemini-3.7-flash": {
+    "input_cost_per_token": 7.5e-07,
+    "max_input_tokens": 1048576,
+    "litellm_provider": "vertex_ai-language-models",
+    "max_output_tokens": 65536,
+    "output_cost_per_reasoning_token": 3.75e-06,
+    "mode": "chat",
+    "output_cost_per_token": 3.75e-06
+  },
+  "gemini/gemini-3.7-flash": {
+    "input_cost_per_token": 7.5e-07,
+    "max_input_tokens": 1048576,
+    "litellm_provider": "gemini",
+    "max_output_tokens": 65536,
+    "output_cost_per_reasoning_token": 3.75e-06,
+    "mode": "chat",
+    "output_cost_per_token": 3.75e-06
+  },
   "gemini-2.5-pro": {
     "input_cost_per_token": 1.25e-06,
     "max_input_tokens": 1048576,


### PR DESCRIPTION
- Point google-default at gemini-3.7-flash
- Add builtin gemini-3.7-flash provider
- Keep gemini-3.6-flash for existing configs
- Add cost snapshot intro rates ($0.75/$3.75 per 1M)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the Gemini 3.7 Flash model with Google and Vertex AI configurations.
  * Updated the default Google provider to use Gemini 3.7 Flash.
  * Added support for native tools and a 950,000-token result limit.
  * Added corresponding pricing and token usage details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->