### PR TITLE
feat: add session count and average cost to Usage

### DIFF
--- a/docs/session-usage-cost.md
+++ b/docs/session-usage-cost.md
@@ -131,6 +131,8 @@ Rules:
 - Soft-deleted sessions are always excluded.
 - All `interaction_type` values count (same as session token SUMs).
 - Response sections: `totals`, `by_model`, `by_alert_type`, `by_chain`, and capped `top_sessions` (hardcoded top **20**; no `limit` param).
+- `totals.session_count` is the number of matching sessions in the window (same filters; includes sessions with no LLM rows). When estimation is enabled and `session_count > 0`, `totals.average_cost_usd` is `estimated_cost_usd / session_count`.
+- `by_model[]`, `by_alert_type[]`, and `by_chain[]` rows include `session_count` and (when estimation is enabled) `average_cost_usd`. For models, `session_count` is distinct sessions that used that model — a session that hits two models counts toward both.
 - `by_model[]` rows carry `priced` (bool: all token-bearing rows for that model are priced) and `unpriced_interaction_count` (count of token-bearing rows for that model with no resolved rate); the dashboard surfaces the count in the "Incomplete" chip's tooltip.
 - Unpriced top sessions are included with `$0` + `cost_completeness` (not dropped).
 - When estimation is disabled: `cost_estimation_enabled: false` and cost fields are omitted; token rollups remain.

--- a/pkg/models/session.go
+++ b/pkg/models/session.go
@@ -376,10 +376,12 @@ type UsageWindow struct {
 
 // UsageTotals is the fleet-wide token/cost rollup for the window.
 type UsageTotals struct {
+	SessionCount             int64            `json:"session_count"`
 	InputTokens              int64            `json:"input_tokens"`
 	OutputTokens             int64            `json:"output_tokens"`
 	TotalTokens              int64            `json:"total_tokens"`
 	EstimatedCostUsd         *float64         `json:"estimated_cost_usd,omitempty"`
+	AverageCostUsd           *float64         `json:"average_cost_usd,omitempty"` // estimated_cost_usd / session_count
 	CostCompleteness         CostCompleteness `json:"cost_completeness,omitempty"`
 	UnpricedInteractionCount *int             `json:"unpriced_interaction_count,omitempty"`
 }
@@ -387,10 +389,12 @@ type UsageTotals struct {
 // UsageModelBreakdown is a per-model rollup within the window.
 type UsageModelBreakdown struct {
 	ModelName                string   `json:"model_name"`
+	SessionCount             int64    `json:"session_count"`
 	InputTokens              int64    `json:"input_tokens"`
 	OutputTokens             int64    `json:"output_tokens"`
 	TotalTokens              int64    `json:"total_tokens"`
 	EstimatedCostUsd         *float64 `json:"estimated_cost_usd,omitempty"`
+	AverageCostUsd           *float64 `json:"average_cost_usd,omitempty"`           // estimated_cost_usd / session_count
 	Priced                   *bool    `json:"priced,omitempty"`                     // true when all token-bearing rows for the model are priced
 	UnpricedInteractionCount *int     `json:"unpriced_interaction_count,omitempty"` // count of token-bearing interactions for this model with no resolved rate
 }
@@ -398,15 +402,19 @@ type UsageModelBreakdown struct {
 // UsageAlertBreakdown is a per-alert-type rollup within the window.
 type UsageAlertBreakdown struct {
 	AlertType        string   `json:"alert_type"`
+	SessionCount     int64    `json:"session_count"`
 	TotalTokens      int64    `json:"total_tokens"`
 	EstimatedCostUsd *float64 `json:"estimated_cost_usd,omitempty"`
+	AverageCostUsd   *float64 `json:"average_cost_usd,omitempty"` // estimated_cost_usd / session_count
 }
 
 // UsageChainBreakdown is a per-chain rollup within the window.
 type UsageChainBreakdown struct {
 	ChainID          string   `json:"chain_id"`
+	SessionCount     int64    `json:"session_count"`
 	TotalTokens      int64    `json:"total_tokens"`
 	EstimatedCostUsd *float64 `json:"estimated_cost_usd,omitempty"`
+	AverageCostUsd   *float64 `json:"average_cost_usd,omitempty"` // estimated_cost_usd / session_count
 }
 
 // UsageTopSession is one of the capped top sessions in the window.

--- a/pkg/models/session_test.go
+++ b/pkg/models/session_test.go
@@ -132,7 +132,9 @@ func TestUsageSummaryResponseJSON(t *testing.T) {
 			CostEstimationEnabled: true,
 			RankBy:                UsageRankByCost,
 			Totals: UsageTotals{
+				SessionCount:     1,
 				EstimatedCostUsd: &zero,
+				AverageCostUsd:   &zero,
 				CostCompleteness: CostCompletenessNone,
 			},
 			ByModel: []UsageModelBreakdown{{
@@ -143,7 +145,9 @@ func TestUsageSummaryResponseJSON(t *testing.T) {
 		}
 		raw, err := json.Marshal(resp)
 		require.NoError(t, err)
+		assert.Contains(t, string(raw), `"session_count":1`)
 		assert.Contains(t, string(raw), `"estimated_cost_usd":0`)
+		assert.Contains(t, string(raw), `"average_cost_usd":0`)
 		assert.Contains(t, string(raw), `"cost_completeness":"none"`)
 		assert.Contains(t, string(raw), `"priced":false`)
 	})
@@ -158,6 +162,8 @@ func TestUsageSummaryResponseJSON(t *testing.T) {
 		}
 		raw, err := json.Marshal(resp)
 		require.NoError(t, err)
+		assert.Contains(t, string(raw), `"session_count":0`)
+		assert.NotContains(t, string(raw), "average_cost_usd")
 		assert.NotContains(t, string(raw), "estimated_cost_usd")
 		assert.NotContains(t, string(raw), "cost_completeness")
 		assert.NotContains(t, string(raw), `"priced"`)

--- a/pkg/models/session_test.go
+++ b/pkg/models/session_test.go
@@ -139,13 +139,22 @@ func TestUsageSummaryResponseJSON(t *testing.T) {
 			},
 			ByModel: []UsageModelBreakdown{{
 				ModelName:        "m",
+				SessionCount:     2,
 				EstimatedCostUsd: &zero,
+				AverageCostUsd:   &zero,
 				Priced:           &priced,
+			}},
+			ByAlertType: []UsageAlertBreakdown{{
+				AlertType:        "oom",
+				SessionCount:     2,
+				EstimatedCostUsd: &zero,
+				AverageCostUsd:   &zero,
 			}},
 		}
 		raw, err := json.Marshal(resp)
 		require.NoError(t, err)
 		assert.Contains(t, string(raw), `"session_count":1`)
+		assert.Contains(t, string(raw), `"session_count":2`)
 		assert.Contains(t, string(raw), `"estimated_cost_usd":0`)
 		assert.Contains(t, string(raw), `"average_cost_usd":0`)
 		assert.Contains(t, string(raw), `"cost_completeness":"none"`)

--- a/pkg/services/session_service_usage.go
+++ b/pkg/services/session_service_usage.go
@@ -35,6 +35,14 @@ func (s *SessionService) GetUsageSummary(ctx context.Context, params models.Usag
 	if err != nil {
 		return nil, err
 	}
+	sessionCount, err := s.client.AlertSession.Query().
+		Where(sessionPreds...).
+		Count(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to count usage sessions: %w", err)
+	}
+	totals.SessionCount = int64(sessionCount)
+	totals.AverageCostUsd = usageAverageCostUSD(totals.EstimatedCostUsd, totals.SessionCount)
 	byModel, err := s.usageByModel(ctx, interactionPred)
 	if err != nil {
 		return nil, err
@@ -139,6 +147,7 @@ func (s *SessionService) usageTotals(ctx context.Context, interactionPred predic
 func (s *SessionService) usageByModel(ctx context.Context, interactionPred predicate.LLMInteraction) ([]models.UsageModelBreakdown, error) {
 	var rows []struct {
 		ModelName    string             `json:"model_name"`
+		SessionCount stdsql.NullInt64   `json:"session_count"`
 		InputSum     stdsql.NullInt64   `json:"input_sum"`
 		OutputSum    stdsql.NullInt64   `json:"output_sum"`
 		TotalSum     stdsql.NullInt64   `json:"total_sum"`
@@ -148,6 +157,9 @@ func (s *SessionService) usageByModel(ctx context.Context, interactionPred predi
 	}
 
 	aggs := []ent.AggregateFunc{
+		ent.As(func(_ *sql.Selector) string {
+			return "COUNT(DISTINCT " + llminteraction.FieldSessionID + ")"
+		}, "session_count"),
 		ent.As(ent.Sum(llminteraction.FieldInputTokens), "input_sum"),
 		ent.As(ent.Sum(llminteraction.FieldOutputTokens), "output_sum"),
 		ent.As(ent.Sum(llminteraction.FieldTotalTokens), "total_sum"),
@@ -177,6 +189,7 @@ func (s *SessionService) usageByModel(ctx context.Context, interactionPred predi
 	for _, row := range rows {
 		item := models.UsageModelBreakdown{
 			ModelName:    row.ModelName,
+			SessionCount: row.SessionCount.Int64,
 			InputTokens:  row.InputSum.Int64,
 			OutputTokens: row.OutputSum.Int64,
 			TotalTokens:  row.TotalSum.Int64,
@@ -184,6 +197,7 @@ func (s *SessionService) usageByModel(ctx context.Context, interactionPred predi
 		if s.costEstimationEnabled {
 			cost := row.CostSum.Float64
 			item.EstimatedCostUsd = &cost
+			item.AverageCostUsd = usageAverageCostUSD(item.EstimatedCostUsd, item.SessionCount)
 			priced := row.TokenBearing > 0 && row.Priced == row.TokenBearing
 			item.Priced = &priced
 			unpriced := row.TokenBearing - row.Priced
@@ -196,9 +210,10 @@ func (s *SessionService) usageByModel(ctx context.Context, interactionPred predi
 
 func (s *SessionService) usageByAlertType(ctx context.Context, sessionPreds []predicate.AlertSession) ([]models.UsageAlertBreakdown, error) {
 	var rows []struct {
-		AlertType stdsql.NullString  `json:"alert_type"`
-		TotalSum  stdsql.NullInt64   `json:"total_sum"`
-		CostSum   stdsql.NullFloat64 `json:"cost_sum"`
+		AlertType    stdsql.NullString  `json:"alert_type"`
+		SessionCount stdsql.NullInt64   `json:"session_count"`
+		TotalSum     stdsql.NullInt64   `json:"total_sum"`
+		CostSum      stdsql.NullFloat64 `json:"cost_sum"`
 	}
 
 	err := s.client.AlertSession.Query().
@@ -207,6 +222,10 @@ func (s *SessionService) usageByAlertType(ctx context.Context, sessionPreds []pr
 			li := sql.Table(llminteraction.Table).As("li")
 			sel.LeftJoin(li).On(sel.C(alertsession.FieldID), li.C(llminteraction.FieldSessionID))
 			sel.Select(sql.As(sel.C(alertsession.FieldAlertType), "alert_type"))
+			sel.AppendSelectAs(
+				fmt.Sprintf("COUNT(DISTINCT %s)", sel.C(alertsession.FieldID)),
+				"session_count",
+			)
 			sel.AppendSelectAs(
 				fmt.Sprintf("COALESCE(SUM(%s), 0)", li.C(llminteraction.FieldTotalTokens)),
 				"total_sum",
@@ -227,12 +246,14 @@ func (s *SessionService) usageByAlertType(ctx context.Context, sessionPreds []pr
 	out := make([]models.UsageAlertBreakdown, 0, len(rows))
 	for _, row := range rows {
 		item := models.UsageAlertBreakdown{
-			AlertType:   row.AlertType.String,
-			TotalTokens: row.TotalSum.Int64,
+			AlertType:    row.AlertType.String,
+			SessionCount: row.SessionCount.Int64,
+			TotalTokens:  row.TotalSum.Int64,
 		}
 		if s.costEstimationEnabled {
 			cost := row.CostSum.Float64
 			item.EstimatedCostUsd = &cost
+			item.AverageCostUsd = usageAverageCostUSD(item.EstimatedCostUsd, item.SessionCount)
 		}
 		out = append(out, item)
 	}
@@ -241,9 +262,10 @@ func (s *SessionService) usageByAlertType(ctx context.Context, sessionPreds []pr
 
 func (s *SessionService) usageByChain(ctx context.Context, sessionPreds []predicate.AlertSession) ([]models.UsageChainBreakdown, error) {
 	var rows []struct {
-		ChainID  string             `json:"chain_id"`
-		TotalSum stdsql.NullInt64   `json:"total_sum"`
-		CostSum  stdsql.NullFloat64 `json:"cost_sum"`
+		ChainID      string             `json:"chain_id"`
+		SessionCount stdsql.NullInt64   `json:"session_count"`
+		TotalSum     stdsql.NullInt64   `json:"total_sum"`
+		CostSum      stdsql.NullFloat64 `json:"cost_sum"`
 	}
 
 	err := s.client.AlertSession.Query().
@@ -252,6 +274,10 @@ func (s *SessionService) usageByChain(ctx context.Context, sessionPreds []predic
 			li := sql.Table(llminteraction.Table).As("li")
 			sel.LeftJoin(li).On(sel.C(alertsession.FieldID), li.C(llminteraction.FieldSessionID))
 			sel.Select(sql.As(sel.C(alertsession.FieldChainID), "chain_id"))
+			sel.AppendSelectAs(
+				fmt.Sprintf("COUNT(DISTINCT %s)", sel.C(alertsession.FieldID)),
+				"session_count",
+			)
 			sel.AppendSelectAs(
 				fmt.Sprintf("COALESCE(SUM(%s), 0)", li.C(llminteraction.FieldTotalTokens)),
 				"total_sum",
@@ -272,12 +298,14 @@ func (s *SessionService) usageByChain(ctx context.Context, sessionPreds []predic
 	out := make([]models.UsageChainBreakdown, 0, len(rows))
 	for _, row := range rows {
 		item := models.UsageChainBreakdown{
-			ChainID:     row.ChainID,
-			TotalTokens: row.TotalSum.Int64,
+			ChainID:      row.ChainID,
+			SessionCount: row.SessionCount.Int64,
+			TotalTokens:  row.TotalSum.Int64,
 		}
 		if s.costEstimationEnabled {
 			cost := row.CostSum.Float64
 			item.EstimatedCostUsd = &cost
+			item.AverageCostUsd = usageAverageCostUSD(item.EstimatedCostUsd, item.SessionCount)
 		}
 		out = append(out, item)
 	}
@@ -377,4 +405,11 @@ func (s *SessionService) usageTopSessions(
 		out = append(out, item)
 	}
 	return out, nil
+}
+
+func usageAverageCostUSD(cost *float64, sessionCount int64) *float64 {
+	if cost == nil || sessionCount <= 0 {
+		return nil
+	}
+	return new(*cost / float64(sessionCount))
 }

--- a/pkg/services/session_service_usage_test.go
+++ b/pkg/services/session_service_usage_test.go
@@ -146,6 +146,54 @@ func TestSessionService_GetUsageSummary(t *testing.T) {
 		assert.InDelta(t, 0.012, *summary.TopSessions[0].EstimatedCostUsd, 1e-9)
 	})
 
+	t.Run("model average counts distinct sessions that used that model", func(t *testing.T) {
+		oc := testdb.NewTestClient(t)
+		svc := setupTestSessionService(t, oc.Client)
+		ctx := t.Context()
+
+		aID, aStage, aExec := seedUsageSession(t, oc.Client, usageSeed{
+			AlertData: "shared-a",
+			AlertType: "pod-crash",
+			ChainID:   "k8s-analysis",
+			CreatedAt: inWindow,
+		})
+		seedLLMInteraction(t, oc.Client, aID, aStage, aExec, "shared-model", 10, 10, 20, floatPtr(0.10), 0)
+		seedLLMInteraction(t, oc.Client, aID, aStage, aExec, "solo-model", 20, 20, 40, floatPtr(0.40), 0)
+
+		bID, bStage, bExec := seedUsageSession(t, oc.Client, usageSeed{
+			AlertData: "shared-b",
+			AlertType: "pod-crash",
+			ChainID:   "k8s-analysis",
+			CreatedAt: inWindow.Add(time.Minute),
+		})
+		seedLLMInteraction(t, oc.Client, bID, bStage, bExec, "shared-model", 30, 30, 60, floatPtr(0.30), 0)
+
+		summary, err := svc.GetUsageSummary(ctx, params)
+		require.NoError(t, err)
+		assert.Equal(t, int64(2), summary.Totals.SessionCount)
+		require.NotNil(t, summary.Totals.AverageCostUsd)
+		assert.InDelta(t, 0.40, *summary.Totals.AverageCostUsd, 1e-9)
+
+		byModel := map[string]models.UsageModelBreakdown{}
+		for _, m := range summary.ByModel {
+			byModel[m.ModelName] = m
+		}
+		require.Contains(t, byModel, "shared-model")
+		require.Contains(t, byModel, "solo-model")
+
+		assert.Equal(t, int64(2), byModel["shared-model"].SessionCount)
+		require.NotNil(t, byModel["shared-model"].EstimatedCostUsd)
+		assert.InDelta(t, 0.40, *byModel["shared-model"].EstimatedCostUsd, 1e-9)
+		require.NotNil(t, byModel["shared-model"].AverageCostUsd)
+		assert.InDelta(t, 0.20, *byModel["shared-model"].AverageCostUsd, 1e-9)
+
+		assert.Equal(t, int64(1), byModel["solo-model"].SessionCount)
+		require.NotNil(t, byModel["solo-model"].EstimatedCostUsd)
+		assert.InDelta(t, 0.40, *byModel["solo-model"].EstimatedCostUsd, 1e-9)
+		require.NotNil(t, byModel["solo-model"].AverageCostUsd)
+		assert.InDelta(t, 0.40, *byModel["solo-model"].AverageCostUsd, 1e-9)
+	})
+
 	t.Run("null costs treated as zero with none completeness", func(t *testing.T) {
 		nc := testdb.NewTestClient(t)
 		svc := setupTestSessionService(t, nc.Client)
@@ -581,4 +629,34 @@ func seedUsageLLMInteractionType(
 		create = create.SetEstimatedCostUsd(*costUSD)
 	}
 	create.SaveX(context.Background())
+}
+
+func TestUsageAverageCostUSD(t *testing.T) {
+	t.Parallel()
+	cost := 1.5
+	zero := 0.0
+	tests := []struct {
+		name         string
+		cost         *float64
+		sessionCount int64
+		wantNil      bool
+		want         float64
+	}{
+		{name: "nil cost", cost: nil, sessionCount: 3, wantNil: true},
+		{name: "zero sessions", cost: &cost, sessionCount: 0, wantNil: true},
+		{name: "divides cost by count", cost: &cost, sessionCount: 3, want: 0.5},
+		{name: "zero cost with sessions", cost: &zero, sessionCount: 2, want: 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := usageAverageCostUSD(tt.cost, tt.sessionCount)
+			if tt.wantNil {
+				assert.Nil(t, got)
+				return
+			}
+			require.NotNil(t, got)
+			assert.InDelta(t, tt.want, *got, 1e-9)
+		})
+	}
 }

--- a/pkg/services/session_service_usage_test.go
+++ b/pkg/services/session_service_usage_test.go
@@ -60,9 +60,12 @@ func TestSessionService_GetUsageSummary(t *testing.T) {
 
 		summary, err := service.GetUsageSummary(ctx, params)
 		require.NoError(t, err)
+		assert.Equal(t, int64(1), summary.Totals.SessionCount)
 		assert.Equal(t, int64(150), summary.Totals.TotalTokens)
 		require.NotNil(t, summary.Totals.EstimatedCostUsd)
 		assert.InDelta(t, 0.01, *summary.Totals.EstimatedCostUsd, 1e-9)
+		require.NotNil(t, summary.Totals.AverageCostUsd)
+		assert.InDelta(t, 0.01, *summary.Totals.AverageCostUsd, 1e-9)
 		assert.Equal(t, models.UsageRankByCost, summary.RankBy)
 		assert.Equal(t, windowStart, summary.Window.Start)
 		assert.Equal(t, windowEnd, summary.Window.End)
@@ -86,6 +89,8 @@ func TestSessionService_GetUsageSummary(t *testing.T) {
 
 		summary, err := delSvc.GetUsageSummary(ctx, params)
 		require.NoError(t, err)
+		assert.Equal(t, int64(0), summary.Totals.SessionCount)
+		assert.Nil(t, summary.Totals.AverageCostUsd)
 		assert.Equal(t, int64(0), summary.Totals.TotalTokens)
 		assert.Empty(t, summary.TopSessions)
 		assert.Empty(t, summary.ByModel)
@@ -120,6 +125,12 @@ func TestSessionService_GetUsageSummary(t *testing.T) {
 		}
 		require.Contains(t, byModel, "priced-model")
 		require.Contains(t, byModel, "unpriced-model")
+		assert.Equal(t, int64(1), byModel["priced-model"].SessionCount)
+		require.NotNil(t, byModel["priced-model"].AverageCostUsd)
+		assert.InDelta(t, 0.012, *byModel["priced-model"].AverageCostUsd, 1e-9)
+		assert.Equal(t, int64(1), byModel["unpriced-model"].SessionCount)
+		require.NotNil(t, byModel["unpriced-model"].AverageCostUsd)
+		assert.InDelta(t, 0.0, *byModel["unpriced-model"].AverageCostUsd, 1e-9)
 		require.NotNil(t, byModel["priced-model"].Priced)
 		assert.True(t, *byModel["priced-model"].Priced)
 		require.NotNil(t, byModel["priced-model"].UnpricedInteractionCount)
@@ -186,6 +197,10 @@ func TestSessionService_GetUsageSummary(t *testing.T) {
 		assert.Equal(t, models.UsageRankByCost, byCost.RankBy)
 		assert.Equal(t, priceyID, byCost.TopSessions[0].SessionID)
 		assert.Equal(t, cheapID, byCost.TopSessions[1].SessionID)
+		require.Len(t, byCost.ByModel, 1)
+		assert.Equal(t, int64(2), byCost.ByModel[0].SessionCount)
+		require.NotNil(t, byCost.ByModel[0].AverageCostUsd)
+		assert.InDelta(t, (0.001+5.0)/2, *byCost.ByModel[0].AverageCostUsd, 1e-9)
 
 		byTokens, err := svc.GetUsageSummary(ctx, models.UsageSummaryParams{
 			StartDate: windowStart,
@@ -226,7 +241,10 @@ func TestSessionService_GetUsageSummary(t *testing.T) {
 			ChainID:   "chain-a",
 		})
 		require.NoError(t, err)
+		assert.Equal(t, int64(1), filtered.Totals.SessionCount)
 		assert.Equal(t, int64(100), filtered.Totals.TotalTokens)
+		require.NotNil(t, filtered.Totals.AverageCostUsd)
+		assert.InDelta(t, 0.1, *filtered.Totals.AverageCostUsd, 1e-9)
 		require.Len(t, filtered.ByAlertType, 1)
 		assert.Equal(t, "type-a", filtered.ByAlertType[0].AlertType)
 		require.Len(t, filtered.ByChain, 1)
@@ -266,25 +284,38 @@ func TestSessionService_GetUsageSummary(t *testing.T) {
 
 		summary, err := svc.GetUsageSummary(ctx, params)
 		require.NoError(t, err)
+		assert.Equal(t, int64(3), summary.Totals.SessionCount)
+		require.NotNil(t, summary.Totals.AverageCostUsd)
+		assert.InDelta(t, 0.25, *summary.Totals.AverageCostUsd, 1e-9)
 
 		alertMap := map[string]models.UsageAlertBreakdown{}
 		for _, row := range summary.ByAlertType {
 			alertMap[row.AlertType] = row
 		}
 		require.Contains(t, alertMap, "oom")
+		assert.Equal(t, int64(2), alertMap["oom"].SessionCount)
 		assert.Equal(t, int64(150), alertMap["oom"].TotalTokens)
 		require.NotNil(t, alertMap["oom"].EstimatedCostUsd)
 		assert.InDelta(t, 0.75, *alertMap["oom"].EstimatedCostUsd, 1e-9)
+		require.NotNil(t, alertMap["oom"].AverageCostUsd)
+		assert.InDelta(t, 0.375, *alertMap["oom"].AverageCostUsd, 1e-9)
 		require.Contains(t, alertMap, "idle")
+		assert.Equal(t, int64(1), alertMap["idle"].SessionCount)
 		assert.Equal(t, int64(0), alertMap["idle"].TotalTokens)
+		require.NotNil(t, alertMap["idle"].AverageCostUsd)
+		assert.InDelta(t, 0.0, *alertMap["idle"].AverageCostUsd, 1e-9)
 
 		chainMap := map[string]models.UsageChainBreakdown{}
 		for _, row := range summary.ByChain {
 			chainMap[row.ChainID] = row
 		}
 		require.Contains(t, chainMap, "chain-x")
+		assert.Equal(t, int64(1), chainMap["chain-x"].SessionCount)
 		assert.Equal(t, int64(100), chainMap["chain-x"].TotalTokens)
+		require.NotNil(t, chainMap["chain-x"].AverageCostUsd)
+		assert.InDelta(t, 0.5, *chainMap["chain-x"].AverageCostUsd, 1e-9)
 		require.Contains(t, chainMap, "chain-z")
+		assert.Equal(t, int64(1), chainMap["chain-z"].SessionCount)
 		assert.Equal(t, int64(0), chainMap["chain-z"].TotalTokens)
 	})
 
@@ -306,13 +337,23 @@ func TestSessionService_GetUsageSummary(t *testing.T) {
 		assert.False(t, summary.CostEstimationEnabled)
 		assert.Equal(t, models.UsageRankByTokens, summary.RankBy)
 		assert.Nil(t, summary.Totals.EstimatedCostUsd)
+		assert.Nil(t, summary.Totals.AverageCostUsd)
 		assert.Empty(t, summary.Totals.CostCompleteness)
 		assert.Nil(t, summary.Totals.UnpricedInteractionCount)
+		assert.Equal(t, int64(1), summary.Totals.SessionCount)
 		assert.Equal(t, int64(150), summary.Totals.TotalTokens)
 
 		require.Len(t, summary.ByModel, 1)
+		assert.Equal(t, int64(1), summary.ByModel[0].SessionCount)
 		assert.Nil(t, summary.ByModel[0].EstimatedCostUsd)
+		assert.Nil(t, summary.ByModel[0].AverageCostUsd)
 		assert.Nil(t, summary.ByModel[0].Priced)
+		require.Len(t, summary.ByAlertType, 1)
+		assert.Equal(t, int64(1), summary.ByAlertType[0].SessionCount)
+		assert.Nil(t, summary.ByAlertType[0].AverageCostUsd)
+		require.Len(t, summary.ByChain, 1)
+		assert.Equal(t, int64(1), summary.ByChain[0].SessionCount)
+		assert.Nil(t, summary.ByChain[0].AverageCostUsd)
 
 		require.Len(t, summary.TopSessions, 1)
 		assert.Nil(t, summary.TopSessions[0].EstimatedCostUsd)
@@ -325,6 +366,8 @@ func TestSessionService_GetUsageSummary(t *testing.T) {
 
 		summary, err := svc.GetUsageSummary(ctx, params)
 		require.NoError(t, err)
+		assert.Equal(t, int64(0), summary.Totals.SessionCount)
+		assert.Nil(t, summary.Totals.AverageCostUsd)
 		assert.Equal(t, int64(0), summary.Totals.TotalTokens)
 		require.NotNil(t, summary.Totals.EstimatedCostUsd)
 		assert.InDelta(t, 0.0, *summary.Totals.EstimatedCostUsd, 1e-9)
@@ -399,6 +442,12 @@ func TestSessionService_GetUsageSummary(t *testing.T) {
 		assert.Equal(t, int64(80), summary.Totals.TotalTokens)
 		require.NotNil(t, summary.Totals.EstimatedCostUsd)
 		assert.InDelta(t, 0.35, *summary.Totals.EstimatedCostUsd, 1e-9)
+		require.Len(t, summary.ByModel, 1)
+		assert.Equal(t, int64(1), summary.ByModel[0].SessionCount)
+		require.NotNil(t, summary.ByModel[0].AverageCostUsd)
+		assert.InDelta(t, 0.35, *summary.ByModel[0].AverageCostUsd, 1e-9)
+		require.Len(t, summary.ByAlertType, 1)
+		assert.Equal(t, int64(1), summary.ByAlertType[0].SessionCount)
 	})
 
 	t.Run("empty alert_type normalized to nil in top_sessions", func(t *testing.T) {
@@ -445,6 +494,7 @@ func TestSessionService_GetUsageSummary(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Len(t, summary.TopSessions, 20)
+		assert.Equal(t, int64(21), summary.Totals.SessionCount)
 		assert.Equal(t, int64(210), summary.TopSessions[0].TotalTokens)
 		assert.Equal(t, int64(20), summary.TopSessions[19].TotalTokens)
 		for _, item := range summary.TopSessions {

--- a/test/e2e/usage_cost_test.go
+++ b/test/e2e/usage_cost_test.go
@@ -177,7 +177,9 @@ func TestUsageCost_PipelinePersistsAndExposesCost(t *testing.T) {
 		assert.Equal(t, totalIn, toInt(totals["input_tokens"]))
 		assert.Equal(t, totalOut, toInt(totals["output_tokens"]))
 		assert.Equal(t, totalTok, toInt(totals["total_tokens"]))
+		assert.Equal(t, 2, toInt(totals["session_count"]))
 		assert.InDelta(t, totalCost, toFloat(totals["estimated_cost_usd"]), 1e-12)
+		assert.InDelta(t, totalCost/2, toFloat(totals["average_cost_usd"]), 1e-12)
 		assert.Equal(t, "complete", totals["cost_completeness"])
 
 		byModel, ok := usage["by_model"].([]interface{})
@@ -187,17 +189,25 @@ func TestUsageCost_PipelinePersistsAndExposesCost(t *testing.T) {
 		assert.Equal(t, "test-model", model["model_name"])
 		assert.Equal(t, true, model["priced"])
 		assert.Equal(t, 0, toInt(model["unpriced_interaction_count"]))
+		assert.Equal(t, 2, toInt(model["session_count"]))
 		assert.InDelta(t, totalCost, toFloat(model["estimated_cost_usd"]), 1e-12)
+		assert.InDelta(t, totalCost/2, toFloat(model["average_cost_usd"]), 1e-12)
 
 		byAlert, ok := usage["by_alert_type"].([]interface{})
 		require.True(t, ok)
 		require.Len(t, byAlert, 1)
-		assert.Equal(t, "test-usage-cost", byAlert[0].(map[string]interface{})["alert_type"])
+		alertRow := byAlert[0].(map[string]interface{})
+		assert.Equal(t, "test-usage-cost", alertRow["alert_type"])
+		assert.Equal(t, 2, toInt(alertRow["session_count"]))
+		assert.InDelta(t, totalCost/2, toFloat(alertRow["average_cost_usd"]), 1e-12)
 
 		byChain, ok := usage["by_chain"].([]interface{})
 		require.True(t, ok)
 		require.Len(t, byChain, 1)
-		assert.Equal(t, "usage-cost-chain", byChain[0].(map[string]interface{})["chain_id"])
+		chainRow := byChain[0].(map[string]interface{})
+		assert.Equal(t, "usage-cost-chain", chainRow["chain_id"])
+		assert.Equal(t, 2, toInt(chainRow["session_count"]))
+		assert.InDelta(t, totalCost/2, toFloat(chainRow["average_cost_usd"]), 1e-12)
 
 		top, ok := usage["top_sessions"].([]interface{})
 		require.True(t, ok)
@@ -298,8 +308,11 @@ func TestUsageCost_EstimationDisabled(t *testing.T) {
 	assert.Equal(t, false, usage["cost_estimation_enabled"])
 	totals := usage["totals"].(map[string]interface{})
 	assert.Equal(t, 150, toInt(totals["total_tokens"]))
+	assert.Equal(t, 1, toInt(totals["session_count"]))
 	_, hasUsageCost := totals["estimated_cost_usd"]
 	assert.False(t, hasUsageCost)
+	_, hasAvgCost := totals["average_cost_usd"]
+	assert.False(t, hasAvgCost)
 
 	// rank_by=cost is rejected when estimation is disabled.
 	app.getJSON(t, fmt.Sprintf(

--- a/web/dashboard/src/pages/UsagePage.tsx
+++ b/web/dashboard/src/pages/UsagePage.tsx
@@ -65,12 +65,6 @@ function defaultThirtyDayRange(): { start: Date; end: Date; preset: string } {
   return { start: range.start, end: range.end, preset: '30d' };
 }
 
-/** "~$X" for the Usage page's large, colored cost displays — tilde reads clearly at this size/weight. */
-function approxCostUsd(usd: number | null | undefined): string {
-  const formatted = formatEstimatedCostUsd(usd);
-  return formatted === '—' ? formatted : `~${formatted}`;
-}
-
 /** Explains exactly what "Incomplete" means for a model's priced status. */
 function incompletePricingTooltip(unpricedCount: number | undefined): string {
   const suffix = 'so its total cost likely undercounts.';
@@ -293,22 +287,33 @@ export function UsagePage() {
                     gap: 2,
                   }}
                 >
+                  <StatCard
+                    label="Sessions"
+                    value={summary.totals.session_count.toLocaleString()}
+                  />
                   <StatCard label="Total tokens" value={formatTokens(summary.totals.total_tokens)} />
                   <StatCard label="Input tokens" value={formatTokens(summary.totals.input_tokens)} />
                   <StatCard label="Output tokens" value={formatTokens(summary.totals.output_tokens)} />
                   {costEnabled && (
-                    <StatCard
-                      label="Est. cost"
-                      value={approxCostUsd(summary.totals.estimated_cost_usd)}
-                      warning={summary.totals.cost_completeness === 'partial'}
-                      caption={
-                        summary.totals.cost_completeness === 'partial' &&
-                        summary.totals.unpriced_interaction_count != null &&
-                        summary.totals.unpriced_interaction_count > 0
-                          ? `${summary.totals.unpriced_interaction_count} unpriced`
-                          : undefined
-                      }
-                    />
+                    <>
+                      <StatCard
+                        label="Est. cost"
+                        value={formatEstimatedCostUsd(summary.totals.estimated_cost_usd)}
+                        warning={summary.totals.cost_completeness === 'partial'}
+                        caption={
+                          summary.totals.cost_completeness === 'partial' &&
+                          summary.totals.unpriced_interaction_count != null &&
+                          summary.totals.unpriced_interaction_count > 0
+                            ? `${summary.totals.unpriced_interaction_count} unpriced`
+                            : undefined
+                        }
+                      />
+                      <StatCard
+                        label="Avg. cost / session"
+                        value={formatEstimatedCostUsd(summary.totals.average_cost_usd)}
+                        warning={summary.totals.cost_completeness === 'partial'}
+                      />
+                    </>
                   )}
                 </Box>
               </Paper>
@@ -324,6 +329,7 @@ export function UsagePage() {
                         { label: 'In', align: 'right' },
                         { label: 'Out', align: 'right' },
                         { label: 'Est. cost', align: 'right' },
+                        { label: 'Avg. / session', align: 'right' },
                         { label: 'Priced', align: 'center' },
                       ]
                     : [
@@ -343,7 +349,8 @@ export function UsagePage() {
                     <TableCell align="right">{formatTokens(row.output_tokens)}</TableCell>
                     {costEnabled && (
                       <>
-                        <TableCell align="right">{approxCostUsd(row.estimated_cost_usd)}</TableCell>
+                        <TableCell align="right">{formatEstimatedCostUsd(row.estimated_cost_usd)}</TableCell>
+                        <TableCell align="right">{formatEstimatedCostUsd(row.average_cost_usd)}</TableCell>
                         <TableCell align="center">
                           {row.priced === false ? (
                             <Tooltip title={incompletePricingTooltip(row.unpriced_interaction_count)} arrow>
@@ -377,7 +384,12 @@ export function UsagePage() {
                   title="By alert type"
                   columns={
                     costEnabled
-                      ? [{ label: 'Alert type' }, { label: 'Tokens', align: 'right' }, { label: 'Est. cost', align: 'right' }]
+                      ? [
+                          { label: 'Alert type' },
+                          { label: 'Tokens', align: 'right' },
+                          { label: 'Est. cost', align: 'right' },
+                          { label: 'Avg. / session', align: 'right' },
+                        ]
                       : [{ label: 'Alert type' }, { label: 'Tokens', align: 'right' }]
                   }
                   empty={summary.by_alert_type.length === 0}
@@ -387,7 +399,10 @@ export function UsagePage() {
                       <TableCell>{row.alert_type || '—'}</TableCell>
                       <TableCell align="right">{formatTokens(row.total_tokens)}</TableCell>
                       {costEnabled && (
-                        <TableCell align="right">{approxCostUsd(row.estimated_cost_usd)}</TableCell>
+                        <>
+                          <TableCell align="right">{formatEstimatedCostUsd(row.estimated_cost_usd)}</TableCell>
+                          <TableCell align="right">{formatEstimatedCostUsd(row.average_cost_usd)}</TableCell>
+                        </>
                       )}
                     </TableRow>
                   ))}
@@ -397,7 +412,12 @@ export function UsagePage() {
                   title="By chain"
                   columns={
                     costEnabled
-                      ? [{ label: 'Chain' }, { label: 'Tokens', align: 'right' }, { label: 'Est. cost', align: 'right' }]
+                      ? [
+                          { label: 'Chain' },
+                          { label: 'Tokens', align: 'right' },
+                          { label: 'Est. cost', align: 'right' },
+                          { label: 'Avg. / session', align: 'right' },
+                        ]
                       : [{ label: 'Chain' }, { label: 'Tokens', align: 'right' }]
                   }
                   empty={summary.by_chain.length === 0}
@@ -407,7 +427,10 @@ export function UsagePage() {
                       <TableCell>{row.chain_id}</TableCell>
                       <TableCell align="right">{formatTokens(row.total_tokens)}</TableCell>
                       {costEnabled && (
-                        <TableCell align="right">{approxCostUsd(row.estimated_cost_usd)}</TableCell>
+                        <>
+                          <TableCell align="right">{formatEstimatedCostUsd(row.estimated_cost_usd)}</TableCell>
+                          <TableCell align="right">{formatEstimatedCostUsd(row.average_cost_usd)}</TableCell>
+                        </>
                       )}
                     </TableRow>
                   ))}

--- a/web/dashboard/src/test/pages/UsagePage.test.tsx
+++ b/web/dashboard/src/test/pages/UsagePage.test.tsx
@@ -66,25 +66,45 @@ function makeSummary(overrides: Partial<UsageSummaryResponse> = {}): UsageSummar
     },
     rank_by: 'cost',
     totals: {
+      session_count: 2,
       input_tokens: 100,
       output_tokens: 50,
       total_tokens: 150,
       estimated_cost_usd: 1.23,
+      average_cost_usd: 0.615,
       cost_completeness: 'complete',
       unpriced_interaction_count: 0,
     },
     by_model: [
       {
         model_name: 'gemini-flash',
+        session_count: 2,
         input_tokens: 100,
         output_tokens: 50,
         total_tokens: 150,
         estimated_cost_usd: 1.23,
+        average_cost_usd: 0.615,
         priced: true,
       },
     ],
-    by_alert_type: [{ alert_type: 'kubernetes', total_tokens: 150, estimated_cost_usd: 1.23 }],
-    by_chain: [{ chain_id: 'default', total_tokens: 150, estimated_cost_usd: 1.23 }],
+    by_alert_type: [
+      {
+        alert_type: 'kubernetes',
+        session_count: 2,
+        total_tokens: 150,
+        estimated_cost_usd: 1.23,
+        average_cost_usd: 0.615,
+      },
+    ],
+    by_chain: [
+      {
+        chain_id: 'default',
+        session_count: 2,
+        total_tokens: 150,
+        estimated_cost_usd: 1.23,
+        average_cost_usd: 0.615,
+      },
+    ],
     top_sessions: [
       {
         session_id: 'abcdef12-3456-7890-abcd-ef1234567890',
@@ -141,7 +161,12 @@ describe('UsagePage', () => {
     expect(end - start).toBeLessThan(31 * dayMs);
 
     expect(await screen.findByText('Totals')).toBeInTheDocument();
-    expect(screen.getAllByText('~$1.23').length).toBeGreaterThan(0);
+    expect(screen.getByText('Sessions')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+    expect(screen.getByText('Avg. cost / session')).toBeInTheDocument();
+    expect(screen.getAllByText('Avg. / session').length).toBe(3);
+    expect(screen.getAllByText('$0.615').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('$1.23').length).toBeGreaterThan(0);
     expect(screen.getByRole('button', { name: 'Select time range' })).toHaveTextContent(
       'Last 30 days',
     );
@@ -216,6 +241,7 @@ describe('UsagePage', () => {
         by_model: [
           {
             model_name: 'gemini-flash',
+            session_count: 2,
             input_tokens: 100,
             output_tokens: 50,
             total_tokens: 150,
@@ -243,6 +269,7 @@ describe('UsagePage', () => {
         cost_estimation_enabled: false,
         rank_by: 'tokens',
         totals: {
+          session_count: 1,
           input_tokens: 100,
           output_tokens: 50,
           total_tokens: 150,
@@ -250,13 +277,14 @@ describe('UsagePage', () => {
         by_model: [
           {
             model_name: 'gemini-flash',
+            session_count: 1,
             input_tokens: 100,
             output_tokens: 50,
             total_tokens: 150,
           },
         ],
-        by_alert_type: [{ alert_type: 'kubernetes', total_tokens: 150 }],
-        by_chain: [{ chain_id: 'default', total_tokens: 150 }],
+        by_alert_type: [{ alert_type: 'kubernetes', session_count: 1, total_tokens: 150 }],
+        by_chain: [{ chain_id: 'default', session_count: 1, total_tokens: 150 }],
         top_sessions: [
           {
             session_id: 'abcdef12-3456-7890-abcd-ef1234567890',
@@ -274,10 +302,14 @@ describe('UsagePage', () => {
 
     expect(screen.queryByText(/[~≈]\$/)).not.toBeInTheDocument();
     expect(screen.queryByLabelText('Rank top sessions')).not.toBeInTheDocument();
+    expect(screen.getByText('Sessions')).toBeInTheDocument();
+    expect(screen.queryByText('Avg. cost / session')).not.toBeInTheDocument();
+    expect(screen.queryByText('Avg. / session')).not.toBeInTheDocument();
 
     const modelSection = screen.getByText('By model').closest('.MuiPaper-root');
     expect(modelSection).toBeInstanceOf(HTMLElement);
     expect(within(modelSection as HTMLElement).queryByText('Est. cost')).not.toBeInTheDocument();
+    expect(within(modelSection as HTMLElement).queryByText('Avg. / session')).not.toBeInTheDocument();
     expect(within(modelSection as HTMLElement).getByText('Tokens')).toBeInTheDocument();
   });
 });

--- a/web/dashboard/src/types/api.ts
+++ b/web/dashboard/src/types/api.ts
@@ -40,10 +40,13 @@ export interface UsageWindow {
 
 /** Fleet-wide token/cost rollup for a usage window. */
 export interface UsageTotals {
+  session_count: number;
   input_tokens: number;
   output_tokens: number;
   total_tokens: number;
   estimated_cost_usd?: number | null;
+  /** estimated_cost_usd / session_count; omitted when count is 0 or estimation is disabled */
+  average_cost_usd?: number | null;
   cost_completeness?: CostCompleteness;
   unpriced_interaction_count?: number;
 }
@@ -51,10 +54,12 @@ export interface UsageTotals {
 /** Per-model rollup within a usage window. */
 export interface UsageModelBreakdown {
   model_name: string;
+  session_count: number;
   input_tokens: number;
   output_tokens: number;
   total_tokens: number;
   estimated_cost_usd?: number | null;
+  average_cost_usd?: number | null;
   priced?: boolean;
   unpriced_interaction_count?: number;
 }
@@ -62,15 +67,19 @@ export interface UsageModelBreakdown {
 /** Per-alert-type rollup within a usage window. */
 export interface UsageAlertBreakdown {
   alert_type: string;
+  session_count: number;
   total_tokens: number;
   estimated_cost_usd?: number | null;
+  average_cost_usd?: number | null;
 }
 
 /** Per-chain rollup within a usage window. */
 export interface UsageChainBreakdown {
   chain_id: string;
+  session_count: number;
   total_tokens: number;
   estimated_cost_usd?: number | null;
+  average_cost_usd?: number | null;
 }
 
 /** One of the capped top sessions in a usage window. */


### PR DESCRIPTION
- Count matching sessions in the selected window so totals show volume, not just tokens
- Average cost is estimated_cost / session_count when estimation is enabled
- Show the same average on model, alert type, and chain breakdowns
- Drop the redundant ~ prefix on Usage cost figures; labels already say Est.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Usage summaries now show total session counts and average cost per session.
  * Session counts and average costs are available for model, alert-type, and chain breakdowns.
  * Cost breakdowns now display estimated and average costs with standard currency formatting.
  * Session counts remain visible when cost estimation is disabled, while cost metrics are hidden.
* **Documentation**
  * Usage API documentation now describes session counts and average-cost metrics for totals and breakdowns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->