### PR TITLE
feat: show unpriced tokens on Usage cost card

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,9 @@ Also read `CLAUDE.md` and skills under `.cursor/skills/` (symlinked for Claude C
 
 ## Commits and PRs
 
+- Never commit, amend, or push unless the user explicitly asks in this turn
+- “Make the change”, “fix the tests”, or finishing a task is not permission to commit
+- If it is unclear, leave changes uncommitted and ask
 - Conventional commits: `feat|fix|docs|chore|refactor|test(scope): summary`
 - Prefer small, focused PRs
 - Fixes should reference an issue: `Fixes #123`

--- a/docs/adr/0020-session-usage-cost.md
+++ b/docs/adr/0020-session-usage-cost.md
@@ -219,7 +219,8 @@ Illustrative response shape:
     "total_tokens": 0,
     "estimated_cost_usd": 0.0,
     "cost_completeness": "partial",
-    "unpriced_interaction_count": 12
+    "unpriced_interaction_count": 12,
+    "unpriced_token_count": 1200000
   },
   "by_model": [],
   "by_alert_type": [],

--- a/docs/session-usage-cost.md
+++ b/docs/session-usage-cost.md
@@ -134,6 +134,7 @@ Rules:
 - `totals.session_count` is the number of matching sessions in the window (same filters; includes sessions with no LLM rows). When estimation is enabled and `session_count > 0`, `totals.average_cost_usd` is `estimated_cost_usd / session_count`.
 - `by_model[]`, `by_alert_type[]`, and `by_chain[]` rows include `session_count` and (when estimation is enabled) `average_cost_usd`. For models, `session_count` is distinct sessions that used that model — a session that hits two models counts toward both.
 - `by_model[]` rows carry `priced` (bool: all token-bearing rows for that model are priced) and `unpriced_interaction_count` (count of token-bearing rows for that model with no resolved rate); the dashboard surfaces the count in the "Incomplete" chip's tooltip.
+- `totals.unpriced_interaction_count` is that same row count across the window. `totals.unpriced_token_count` is `SUM(total_tokens)` of those unpriced rows; the Usage Est. cost caption shows it compactly (e.g. `1.2M unpriced`), with a tooltip of the form `1.2M tokens from 838 LLM interactions had no resolved rate`.
 - Unpriced top sessions are included with `$0` + `cost_completeness` (not dropped).
 - When estimation is disabled: `cost_estimation_enabled: false` and cost fields are omitted; token rollups remain.
 

--- a/pkg/models/session.go
+++ b/pkg/models/session.go
@@ -384,6 +384,7 @@ type UsageTotals struct {
 	AverageCostUsd           *float64         `json:"average_cost_usd,omitempty"` // estimated_cost_usd / session_count
 	CostCompleteness         CostCompleteness `json:"cost_completeness,omitempty"`
 	UnpricedInteractionCount *int             `json:"unpriced_interaction_count,omitempty"`
+	UnpricedTokenCount       *int64           `json:"unpriced_token_count,omitempty"` // SUM(total_tokens) of token-bearing unpriced rows
 }
 
 // UsageModelBreakdown is a per-model rollup within the window.

--- a/pkg/models/session_test.go
+++ b/pkg/models/session_test.go
@@ -132,10 +132,12 @@ func TestUsageSummaryResponseJSON(t *testing.T) {
 			CostEstimationEnabled: true,
 			RankBy:                UsageRankByCost,
 			Totals: UsageTotals{
-				SessionCount:     1,
-				EstimatedCostUsd: &zero,
-				AverageCostUsd:   &zero,
-				CostCompleteness: CostCompletenessNone,
+				SessionCount:             1,
+				EstimatedCostUsd:         &zero,
+				AverageCostUsd:           &zero,
+				CostCompleteness:         CostCompletenessNone,
+				UnpricedInteractionCount: new(0),
+				UnpricedTokenCount:       new(int64(0)),
 			},
 			ByModel: []UsageModelBreakdown{{
 				ModelName:        "m",
@@ -159,6 +161,8 @@ func TestUsageSummaryResponseJSON(t *testing.T) {
 		assert.Contains(t, string(raw), `"average_cost_usd":0`)
 		assert.Contains(t, string(raw), `"cost_completeness":"none"`)
 		assert.Contains(t, string(raw), `"priced":false`)
+		assert.Contains(t, string(raw), `"unpriced_interaction_count":0`)
+		assert.Contains(t, string(raw), `"unpriced_token_count":0`)
 	})
 
 	t.Run("nil cost fields omitted when estimation disabled shape", func(t *testing.T) {

--- a/pkg/models/session_test.go
+++ b/pkg/models/session_test.go
@@ -177,5 +177,6 @@ func TestUsageSummaryResponseJSON(t *testing.T) {
 		assert.NotContains(t, string(raw), "cost_completeness")
 		assert.NotContains(t, string(raw), `"priced"`)
 		assert.NotContains(t, string(raw), "unpriced_interaction_count")
+		assert.NotContains(t, string(raw), "unpriced_token_count")
 	})
 }

--- a/pkg/services/session_service_usage.go
+++ b/pkg/services/session_service_usage.go
@@ -93,12 +93,13 @@ func usageSessionPreds(params models.UsageSummaryParams) []predicate.AlertSessio
 
 func (s *SessionService) usageTotals(ctx context.Context, interactionPred predicate.LLMInteraction) (models.UsageTotals, error) {
 	var results []struct {
-		InputSum     stdsql.NullInt64   `json:"input_sum"`
-		OutputSum    stdsql.NullInt64   `json:"output_sum"`
-		TotalSum     stdsql.NullInt64   `json:"total_sum"`
-		CostSum      stdsql.NullFloat64 `json:"cost_sum"`
-		TokenBearing int                `json:"token_bearing"`
-		Priced       int                `json:"priced"`
+		InputSum       stdsql.NullInt64   `json:"input_sum"`
+		OutputSum      stdsql.NullInt64   `json:"output_sum"`
+		TotalSum       stdsql.NullInt64   `json:"total_sum"`
+		CostSum        stdsql.NullFloat64 `json:"cost_sum"`
+		TokenBearing   int                `json:"token_bearing"`
+		Priced         int                `json:"priced"`
+		UnpricedTokens stdsql.NullInt64   `json:"unpriced_tokens"`
 	}
 
 	aggs := []ent.AggregateFunc{
@@ -115,6 +116,10 @@ func (s *SessionService) usageTotals(ctx context.Context, interactionPred predic
 			ent.As(func(_ *sql.Selector) string {
 				return "COUNT(*) FILTER (WHERE " + tokenBearingPredicateSQL + " AND estimated_cost_usd IS NOT NULL)"
 			}, "priced"),
+			ent.As(func(_ *sql.Selector) string {
+				return "COALESCE(SUM(COALESCE(" + llminteraction.FieldTotalTokens + ", 0)) FILTER (WHERE " +
+					tokenBearingPredicateSQL + " AND estimated_cost_usd IS NULL), 0)"
+			}, "unpriced_tokens"),
 		)
 	}
 
@@ -140,6 +145,8 @@ func (s *SessionService) usageTotals(ctx context.Context, interactionPred predic
 		totals.CostCompleteness = models.DeriveCostCompleteness(r.TokenBearing, r.Priced)
 		unpriced := r.TokenBearing - r.Priced
 		totals.UnpricedInteractionCount = &unpriced
+		unpricedTokens := r.UnpricedTokens.Int64
+		totals.UnpricedTokenCount = &unpricedTokens
 	}
 	return totals, nil
 }

--- a/pkg/services/session_service_usage_test.go
+++ b/pkg/services/session_service_usage_test.go
@@ -148,6 +148,31 @@ func TestSessionService_GetUsageSummary(t *testing.T) {
 		assert.InDelta(t, 0.012, *summary.TopSessions[0].EstimatedCostUsd, 1e-9)
 	})
 
+	t.Run("unpriced_token_count sums unpriced token-bearing rows only", func(t *testing.T) {
+		uc := testdb.NewTestClient(t)
+		svc := setupTestSessionService(t, uc.Client)
+		ctx := t.Context()
+
+		sid, stageID, execID := seedUsageSession(t, uc.Client, usageSeed{
+			AlertData: "unpriced-token-sum",
+			AlertType: "pod-crash",
+			ChainID:   "k8s-analysis",
+			CreatedAt: inWindow,
+		})
+		seedLLMInteraction(t, uc.Client, sid, stageID, execID, "priced-model", 100, 50, 150, floatPtr(0.01), 0)
+		seedLLMInteraction(t, uc.Client, sid, stageID, execID, "unpriced-a", 80, 20, 100, nil, 0)
+		seedLLMInteraction(t, uc.Client, sid, stageID, execID, "unpriced-b", 150, 50, 200, nil, 0)
+		seedLLMInteraction(t, uc.Client, sid, stageID, execID, "zero-token", 0, 0, 0, nil, 0)
+
+		summary, err := svc.GetUsageSummary(ctx, params)
+		require.NoError(t, err)
+		assert.Equal(t, int64(450), summary.Totals.TotalTokens)
+		require.NotNil(t, summary.Totals.UnpricedInteractionCount)
+		assert.Equal(t, 2, *summary.Totals.UnpricedInteractionCount)
+		require.NotNil(t, summary.Totals.UnpricedTokenCount)
+		assert.Equal(t, int64(300), *summary.Totals.UnpricedTokenCount)
+	})
+
 	t.Run("model average counts distinct sessions that used that model", func(t *testing.T) {
 		oc := testdb.NewTestClient(t)
 		svc := setupTestSessionService(t, oc.Client)
@@ -425,6 +450,10 @@ func TestSessionService_GetUsageSummary(t *testing.T) {
 		require.NotNil(t, summary.Totals.EstimatedCostUsd)
 		assert.InDelta(t, 0.0, *summary.Totals.EstimatedCostUsd, 1e-9)
 		assert.Equal(t, models.CostCompletenessNone, summary.Totals.CostCompleteness)
+		require.NotNil(t, summary.Totals.UnpricedInteractionCount)
+		assert.Equal(t, 0, *summary.Totals.UnpricedInteractionCount)
+		require.NotNil(t, summary.Totals.UnpricedTokenCount)
+		assert.Equal(t, int64(0), *summary.Totals.UnpricedTokenCount)
 		assert.Empty(t, summary.ByModel)
 		assert.Empty(t, summary.ByAlertType)
 		assert.Empty(t, summary.ByChain)

--- a/pkg/services/session_service_usage_test.go
+++ b/pkg/services/session_service_usage_test.go
@@ -118,6 +118,8 @@ func TestSessionService_GetUsageSummary(t *testing.T) {
 		assert.Equal(t, models.CostCompletenessPartial, summary.Totals.CostCompleteness)
 		require.NotNil(t, summary.Totals.UnpricedInteractionCount)
 		assert.Equal(t, 1, *summary.Totals.UnpricedInteractionCount)
+		require.NotNil(t, summary.Totals.UnpricedTokenCount)
+		assert.Equal(t, int64(300), *summary.Totals.UnpricedTokenCount)
 
 		byModel := map[string]models.UsageModelBreakdown{}
 		for _, m := range summary.ByModel {
@@ -213,6 +215,8 @@ func TestSessionService_GetUsageSummary(t *testing.T) {
 		assert.Equal(t, models.CostCompletenessNone, summary.Totals.CostCompleteness)
 		require.NotNil(t, summary.Totals.UnpricedInteractionCount)
 		assert.Equal(t, 1, *summary.Totals.UnpricedInteractionCount)
+		require.NotNil(t, summary.Totals.UnpricedTokenCount)
+		assert.Equal(t, int64(15), *summary.Totals.UnpricedTokenCount)
 	})
 
 	t.Run("rank_by cost vs tokens", func(t *testing.T) {
@@ -388,6 +392,7 @@ func TestSessionService_GetUsageSummary(t *testing.T) {
 		assert.Nil(t, summary.Totals.AverageCostUsd)
 		assert.Empty(t, summary.Totals.CostCompleteness)
 		assert.Nil(t, summary.Totals.UnpricedInteractionCount)
+		assert.Nil(t, summary.Totals.UnpricedTokenCount)
 		assert.Equal(t, int64(1), summary.Totals.SessionCount)
 		assert.Equal(t, int64(150), summary.Totals.TotalTokens)
 
@@ -464,6 +469,8 @@ func TestSessionService_GetUsageSummary(t *testing.T) {
 		assert.Equal(t, models.CostCompletenessComplete, summary.Totals.CostCompleteness)
 		require.NotNil(t, summary.Totals.UnpricedInteractionCount)
 		assert.Equal(t, 0, *summary.Totals.UnpricedInteractionCount)
+		require.NotNil(t, summary.Totals.UnpricedTokenCount)
+		assert.Equal(t, int64(0), *summary.Totals.UnpricedTokenCount)
 		require.Len(t, summary.ByModel, 1)
 		require.NotNil(t, summary.ByModel[0].Priced)
 		assert.True(t, *summary.ByModel[0].Priced)

--- a/test/e2e/usage_cost_test.go
+++ b/test/e2e/usage_cost_test.go
@@ -181,6 +181,8 @@ func TestUsageCost_PipelinePersistsAndExposesCost(t *testing.T) {
 		assert.InDelta(t, totalCost, toFloat(totals["estimated_cost_usd"]), 1e-12)
 		assert.InDelta(t, totalCost/2, toFloat(totals["average_cost_usd"]), 1e-12)
 		assert.Equal(t, "complete", totals["cost_completeness"])
+		assert.Equal(t, 0, toInt(totals["unpriced_interaction_count"]))
+		assert.Equal(t, 0, toInt(totals["unpriced_token_count"]))
 
 		byModel, ok := usage["by_model"].([]interface{})
 		require.True(t, ok)

--- a/test/e2e/usage_cost_test.go
+++ b/test/e2e/usage_cost_test.go
@@ -315,6 +315,10 @@ func TestUsageCost_EstimationDisabled(t *testing.T) {
 	assert.False(t, hasUsageCost)
 	_, hasAvgCost := totals["average_cost_usd"]
 	assert.False(t, hasAvgCost)
+	_, hasUnpricedTokens := totals["unpriced_token_count"]
+	assert.False(t, hasUnpricedTokens, "unpriced_token_count must be omitted when estimation is disabled")
+	_, hasUnpricedInteractions := totals["unpriced_interaction_count"]
+	assert.False(t, hasUnpricedInteractions, "unpriced_interaction_count must be omitted when estimation is disabled")
 
 	// rank_by=cost is rejected when estimation is disabled.
 	app.getJSON(t, fmt.Sprintf(

--- a/web/dashboard/src/pages/UsagePage.tsx
+++ b/web/dashboard/src/pages/UsagePage.tsx
@@ -51,7 +51,7 @@ import { getFilterOptions, getUsageSummary, handleAPIError } from '../services/a
 import { websocketService } from '../services/websocket.ts';
 import { EVENT_SESSION_STATUS } from '../constants/eventTypes.ts';
 import { isTerminalStatus, type SessionStatus } from '../constants/sessionStatus.ts';
-import { formatEstimatedCostUsd, formatTimestamp, formatTokens } from '../utils/format.ts';
+import { formatEstimatedCostUsd, formatTimestamp, formatTokens, formatTokensCompact } from '../utils/format.ts';
 import { sessionDetailPath } from '../constants/routes.ts';
 import type { UsageRankBy, UsageSummaryResponse } from '../types/api.ts';
 import type { SessionStatusPayload } from '../types/events.ts';
@@ -71,6 +71,20 @@ function incompletePricingTooltip(unpricedCount: number | undefined): string {
   return unpricedCount != null && unpricedCount > 0
     ? `${unpricedCount} token-bearing interaction${unpricedCount === 1 ? '' : 's'} for this model had no resolved rate (missing from the price catalog/overrides), ${suffix}`
     : `Some token-bearing interactions for this model had no resolved rate (missing from the price catalog/overrides), ${suffix}`;
+}
+
+function unpricedCostCaption(tokenCount: number | undefined): string | undefined {
+  if (tokenCount == null || tokenCount <= 0) {
+    return undefined;
+  }
+  return `${formatTokensCompact(tokenCount)} unpriced`;
+}
+
+function unpricedCostTooltip(tokenCount: number | undefined, interactionCount: number | undefined): string {
+  const tokens = formatTokensCompact(tokenCount ?? 0);
+  const n = interactionCount ?? 0;
+  const interactionWord = n === 1 ? 'interaction' : 'interactions';
+  return `${tokens} tokens from ${n.toLocaleString()} LLM ${interactionWord} had no resolved rate`;
 }
 
 export function UsagePage() {
@@ -301,10 +315,16 @@ export function UsagePage() {
                         value={formatEstimatedCostUsd(summary.totals.estimated_cost_usd)}
                         warning={summary.totals.cost_completeness === 'partial'}
                         caption={
-                          summary.totals.cost_completeness === 'partial' &&
-                          summary.totals.unpriced_interaction_count != null &&
-                          summary.totals.unpriced_interaction_count > 0
-                            ? `${summary.totals.unpriced_interaction_count} unpriced`
+                          summary.totals.cost_completeness === 'partial'
+                            ? unpricedCostCaption(summary.totals.unpriced_token_count)
+                            : undefined
+                        }
+                        captionTooltip={
+                          summary.totals.cost_completeness === 'partial'
+                            ? unpricedCostTooltip(
+                                summary.totals.unpriced_token_count,
+                                summary.totals.unpriced_interaction_count,
+                              )
                             : undefined
                         }
                       />
@@ -612,11 +632,13 @@ function StatCard({
   value,
   warning,
   caption,
+  captionTooltip,
 }: {
   label: string;
   value: string;
   warning?: boolean;
   caption?: string;
+  captionTooltip?: string;
 }) {
   return (
     <Box sx={{ p: 1.5, borderRadius: 1, bgcolor: 'action.hover' }}>
@@ -636,14 +658,16 @@ function StatCard({
         {value}
       </Typography>
       {caption && (
-        <Typography
-          variant="caption"
-          color="warning.main"
-          sx={{ display: 'flex', alignItems: 'center', gap: 0.25, mt: 0.25 }}
-        >
-          <WarningAmberRounded sx={{ fontSize: '0.9rem' }} />
-          {caption}
-        </Typography>
+        <Tooltip title={captionTooltip ?? ''} disableHoverListener={!captionTooltip} arrow>
+          <Typography
+            variant="caption"
+            color="warning.main"
+            sx={{ display: 'flex', alignItems: 'center', gap: 0.25, mt: 0.25 }}
+          >
+            <WarningAmberRounded sx={{ fontSize: '0.9rem' }} />
+            {caption}
+          </Typography>
+        </Tooltip>
       )}
     </Box>
   );

--- a/web/dashboard/src/test/pages/UsagePage.test.tsx
+++ b/web/dashboard/src/test/pages/UsagePage.test.tsx
@@ -74,6 +74,7 @@ function makeSummary(overrides: Partial<UsageSummaryResponse> = {}): UsageSummar
       average_cost_usd: 0.615,
       cost_completeness: 'complete',
       unpriced_interaction_count: 0,
+      unpriced_token_count: 0,
     },
     by_model: [
       {
@@ -232,6 +233,37 @@ describe('UsagePage', () => {
     await new Promise((resolve) => setTimeout(resolve, 2200));
     expect(mockGetUsageSummary).toHaveBeenCalledTimes(1);
     expect(screen.queryByText('Updated — new session data available')).not.toBeInTheDocument();
+  });
+
+  it('shows unpriced token volume on the Est. cost card with an interaction-count tooltip', async () => {
+    const user = userEvent.setup();
+    mockGetUsageSummary.mockResolvedValue(
+      makeSummary({
+        totals: {
+          session_count: 2,
+          input_tokens: 100,
+          output_tokens: 50,
+          total_tokens: 1_200_150,
+          estimated_cost_usd: 1.23,
+          average_cost_usd: 0.615,
+          cost_completeness: 'partial',
+          unpriced_interaction_count: 838,
+          unpriced_token_count: 1_200_000,
+        },
+      }),
+    );
+
+    renderUsagePage();
+    await screen.findByText('Totals');
+
+    const caption = await screen.findByText('1.2M unpriced');
+    expect(caption).toBeInTheDocument();
+
+    await user.hover(caption);
+
+    expect(
+      await screen.findByText('1.2M tokens from 838 LLM interactions had no resolved rate'),
+    ).toBeInTheDocument();
   });
 
   it('shows a tooltip on the Incomplete chip explaining exactly what is unpriced', async () => {

--- a/web/dashboard/src/types/api.ts
+++ b/web/dashboard/src/types/api.ts
@@ -49,6 +49,8 @@ export interface UsageTotals {
   average_cost_usd?: number | null;
   cost_completeness?: CostCompleteness;
   unpriced_interaction_count?: number;
+  /** SUM(total_tokens) of token-bearing interactions with no resolved rate */
+  unpriced_token_count?: number;
 }
 
 /** Per-model rollup within a usage window. */


### PR DESCRIPTION
- Add unpriced_token_count to usage totals (SUM of unpriced token-bearing rows)
- Caption uses compact token format (e.g. 1.2M unpriced)
- Tooltip includes token volume and LLM interaction count

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Usage summaries now report tokens from interactions without resolved pricing.
  * The dashboard displays compact unpriced-token counts and provides details about affected tokens and interactions in a tooltip.

* **Bug Fixes**
  * Improved usage-cost reporting for partial, complete, disabled, and zero-cost estimation scenarios.
  * Ensured unpriced token and interaction totals are accurately included or omitted as appropriate.

* **Documentation**
  * Updated usage API documentation to describe unpriced interaction and token totals and dashboard messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->