### PR TITLE
docs: make AGENTS.md the shared always-on agent contract

### DIFF
--- a/.cursor/skills/karpathy-modified-guidelines/SKILL.md
+++ b/.cursor/skills/karpathy-modified-guidelines/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: karpathy-modified-guidelines
-description: Behavioral guidelines to reduce common LLM coding mistakes by emphasizing thinking before coding, simplicity, surgical changes, and goal-driven execution. Use when implementing features, fixing bugs, refactoring code, or performing any coding task.
+description: Behavioral guidelines to reduce common LLM coding mistakes (think before coding, simplicity, surgical changes, goal-driven execution). Use when implementing features, fixing bugs, refactoring, reviewing code, or any other coding task.
 ---
 
 # Karpathy Guidelines

--- a/.cursor/skills/use-modern-go/SKILL.md
+++ b/.cursor/skills/use-modern-go/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: use-modern-go
-description: Apply modern Go syntax guidelines based on project's Go version. Use when user ask for modern Go code guidelines.
+description: Apply modern Go syntax based on this repository's Go version. Use when writing, editing, or reviewing Go code, or when the user asks for modern Go guidelines.
 ---
 
 # Modern Go Guidelines

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,22 +1,34 @@
 # TARSy - agent guide
 
-Default branch: `master`.
+TARSy is a hybrid Go + Python SRE system: Go orchestrator (alerts, sessions, MCP tools), a stateless Python LLM service over gRPC, and a React dashboard.
+
+Default branch: `master`. Architecture and package map: `CLAUDE.md`.
 
 ## Commands
 
-- Lint: `make lint`
-- Test: `make test`
+Never invent alternate package-manager commands if these work.
+
 - Full local gate: `make check-all`
-- Never invent alternate package-manager commands if the above work.
-
-Stack notes (do not invent substitutes):
-
-- Go backend: `make test-unit`, `make test-go`, `make build`
+- Lint: `make lint` (`make lint-fix` to auto-fix)
+- Test: `make test`
+- Format: `make fmt`
+- Dev: `make doctor`, `make setup`, `make dev`, `make dev-stop`
+- Go: `make test-unit`, `make test-go`, `make build`
 - Python LLM service: `make test-llm`
 - Dashboard: `make test-dashboard`
-- Format: `make fmt`
+- Codegen: `make ent-generate`, `make proto-generate`
+- Migrations: `make migrate-create NAME=add_feature` — then apply the `db-migration-review` skill
 
-Also read `CLAUDE.md` and skills under `.cursor/skills/` (symlinked for Claude Code) before substantive edits.
+## Skills
+
+Project skills live in `.cursor/skills/` (symlinked as `.claude/skills/`). Load a skill when its description matches the task. Do not preload all of them.
+
+## How we work
+
+- Don't assume; surface tradeoffs and ask when unclear
+- Minimum code that solves the problem; no speculative features or abstractions
+- Touch only what you must; no drive-by refactors
+- Define success criteria and verify before finishing
 
 ## Commits and PRs
 
@@ -32,7 +44,6 @@ Also read `CLAUDE.md` and skills under `.cursor/skills/` (symlinked for Claude C
 - Match existing code; do not reformat unrelated files
 - Prefer clear names over clever abstractions
 - No AI walls of text in PR descriptions
-- Avoid drive-by refactors
 
 ## Safety
 
@@ -42,4 +53,4 @@ Also read `CLAUDE.md` and skills under `.cursor/skills/` (symlinked for Claude C
 
 ## Learnings
 
-When using `/learn`, append **non-obvious** discoveries to the nearest relevant `AGENTS.md` (package-level preferred over root).
+When using `/learn`, append **non-obvious** discoveries to the nearest relevant `AGENTS.md` (package-level preferred over root). Do not create empty nested files.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,54 +1,10 @@
-# CLAUDE.md
+@AGENTS.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Shared always-on rules are imported from `AGENTS.md`. This file is the architecture map.
 
 ## Project Overview
 
 TARSy (Thoughtful Alert Response System) is an intelligent SRE system that processes alerts through parallel agent chains using MCP servers for multi-stage incident analysis and automated remediation. Hybrid Go + Python architecture: Go orchestrator handles business logic, session management, and real-time streaming; a stateless Python service manages LLM interactions over gRPC.
-
-## Build & Development Commands
-
-```bash
-make doctor          # Verify prerequisites (Go 1.26+, Python 3.13+, Node 24+, uv, Podman)
-make setup           # Install all deps + bootstrap config files
-make dev             # Start full dev environment (DB + LLM service + backend + dashboard)
-make dev-stop        # Stop all dev services
-make build           # Build Go binary
-```
-
-## Testing Commands
-
-```bash
-make test            # Run all tests (Go + Python + Dashboard)
-make test-unit       # Go unit tests only (pkg/...)
-make test-go         # All Go tests (unit + e2e) with coverage and race detector
-make test-llm        # Python LLM service tests (via uv/pytest)
-make test-dashboard  # Dashboard tests + TypeScript check
-
-# Single Go test
-go test -v -race ./pkg/config/ -run TestSkillRegistry
-go test -v -race ./pkg/config/ -run TestSkillRegistry/subtest_name
-
-# E2E tests (require Docker/Podman for PostgreSQL via Testcontainers)
-go test -v -race -timeout 300s ./test/e2e/ -run TestE2E_Pipeline
-```
-
-## Lint & Format
-
-```bash
-make fmt             # Format Go code (goimports + gofmt)
-make lint            # Run golangci-lint
-make lint-fix        # Lint with auto-fix
-make check-all       # Format + build + lint + all tests
-```
-
-## Code Generation
-
-```bash
-make ent-generate    # Regenerate Ent ORM code after schema changes in ent/schema/
-make proto-generate  # Regenerate Go + Python gRPC code from proto/llm_service.proto
-make migrate-create NAME=add_feature  # Create new DB migration (MUST run db-migration-review skill after)
-```
 
 ## Architecture
 
@@ -99,13 +55,3 @@ Config files in `deploy/config/`: `tarsy.yaml` (agents, chains, MCP servers), `l
 ### E2E test infrastructure
 
 Tests in `test/e2e/` use a `TestApp` harness that boots a complete TARSy instance with Testcontainers PostgreSQL, a `ScriptedLLMClient` for deterministic LLM responses, and in-memory MCP servers. Test configs in `test/e2e/testdata/configs/`.
-
-## Coding Standards
-
-**MANDATORY**: Before writing, editing, or reviewing code, read and apply:
-
-1. `.cursor/skills/karpathy-modified-guidelines/SKILL.md` (always first -- think before coding, simplicity, surgical changes, goal-driven execution)
-2. All `.cursor/skills/<language>-*/SKILL.md` matching the language you're working in (e.g., `golang-*` for Go)
-3. `.cursor/skills/db-migration-review/SKILL.md` after every `make migrate-create`
-
-Current Go skills: `golang-context-patterns`, `golang-error-handling`, `golang-testing-patterns`, `golang-type-safety`, `use-modern-go`. Scan `.cursor/skills/` for the latest set.


### PR DESCRIPTION
- Import AGENTS.md from CLAUDE.md and drop duplicated make/skill mandates
- Load project skills by description instead of preloading all of them
- Trigger use-modern-go on Go edits, not only when asked for guidelines


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated repository guidance with clearer architecture references, development commands, workflow principles, and skill-loading instructions.
  * Clarified when to record project discoveries and reinforced guidance against unnecessary refactoring.
  * Streamlined coding-skill descriptions, including modern Go syntax guidance based on the repository’s Go version.
  * Consolidated architecture and always-on project rules into the primary development guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->