### PR TITLE
feat: add dormant compose agent plumbing

### DIFF
--- a/deploy/config/tarsy.yaml.example
+++ b/deploy/config/tarsy.yaml.example
@@ -140,6 +140,9 @@ system:
 defaults:
   # Default LLM provider for all agents/chains
   llm_provider: "google-default"
+
+  # Mid-tier provider for compose (amended-report) generation
+  compose_provider: "google-default"
   
   # Default max iterations (forces conclusion when reached, no pause/resume)
   max_iterations: 20

--- a/deploy/config/tarsy.yaml.quickstart
+++ b/deploy/config/tarsy.yaml.quickstart
@@ -20,6 +20,7 @@
 
 defaults:
   llm_provider: "google-default"
+  compose_provider: "google-default"
   max_iterations: 20
   llm_backend: "langchain"
   scoring:

--- a/docs/adr/0004-stage-types.md
+++ b/docs/adr/0004-stage-types.md
@@ -28,8 +28,6 @@ Additionally, executive summary generation is refactored from a special-cased di
 
 ### Stage Type Enum
 
-Five values:
-
 | Value | Description | Created by |
 |-------|-------------|------------|
 | `investigation` | From chain config stage | Session executor (default) |
@@ -37,6 +35,7 @@ Five values:
 | `chat` | User follow-up chat message | Chat path |
 | `exec_summary` | Executive summary of the investigation | Session executor (after refactor) |
 | `scoring` | Quality evaluation | Scoring path (reserved) |
+| `compose` | Amended report after an action stage | Session executor (reserved until PR 2) |
 
 All values exist in the schema from the initial rollout; `exec_summary` and `scoring` gain creation paths when their features are wired. Stage creation remains internal — executors call the stage service; the enum provides schema-level validation.
 

--- a/docs/adr/0005-referenced-stage-id.md
+++ b/docs/adr/0005-referenced-stage-id.md
@@ -36,6 +36,7 @@ Add an optional `referenced_stage_id` column to the `stages` table as a self-ref
 | `chat` | NULL | Chats are session-scoped, not stage-scoped |
 | `exec_summary` | NULL | Summarizes entire session |
 | `scoring` | NULL | Evaluates entire session |
+| `compose` | Points to the triggering action stage | Amended-report sibling |
 
 The field is modeled in the ORM with a self-referential relationship consistent with other stage FKs. A reverse “referencing stages” relation may be generated even if rarely queried — acceptable for consistency.
 

--- a/docs/proposals/action-report-compose-design.md
+++ b/docs/proposals/action-report-compose-design.md
@@ -1,0 +1,310 @@
+# Action Report Compose Pass
+
+**Status:** Final — decisions from [action-report-compose-questions.md](action-report-compose-questions.md)
+
+## Overview
+
+When a chain ends with an action/remediation stage, session `final_analysis` is taken from that last stage. The action agent is currently prompted to **copy the investigation report and amend it**. Claude 4.6 followed that contract. Claude 5 often does not: it writes a short action memo (or a stub "preserved above verbatim") and that memo becomes the session's final analysis.
+
+Mechanical concatenation of synthesis + action output is ugly: duplicated sections, stale "recommended actions" next to "already done", two summaries.
+
+This design adds a **dedicated compose stage** after each successful action stage. The action agent only decides and acts (short memo). A single-shot LLM call then produces the session report: investigation text as the body, action outcome as an amendment. The copy-the-report instruction is removed from the action prompt.
+
+## Design Principles
+
+1. **Split jobs.** The action agent evaluates and executes. It does not author the canonical session report.
+2. **Investigation-first document.** The composed report is the investigation/synthesis with an actions amendment — not an action memo with a nod to the investigation.
+3. **Copy-edit, not rewrite.** Keep the upstream document's own structure and wording (whatever format that agent or skill used). Fold in the action result. Do not re-author the investigation into a canonical template.
+4. **Fail-open.** A failed compose LLM must not fail the session. Action tools already ran. Stage status is still `failed`; the card uses mechanical concat.
+5. **Visible.** Compose is its own collapsible stage (`{actionStage} - Amended Report`), distinct from the action RESULT memo.
+6. **Cheap.** One shot, no tools, two `final_analysis` documents in, one document out.
+
+## Architecture / How It Works
+
+Today:
+
+```
+investigation → [synthesis] → action → extractFinalAnalysis(last stage) → exec_summary
+                     ↑                         ↑
+              canonical report         supposed to copy+amend; often doesn't
+```
+
+Proposed:
+
+```
+investigation → [synthesis] → action (memo only) → compose stage → extractFinalAnalysis(compose) → exec_summary
+                                                     ↑
+                         automatic sibling: two final_analysis docs → amended report
+```
+
+Synthesis is optional: TARSy inserts it only after parallel/replica **investigation**. Upstream report = synthesis `final_analysis` if that stage ran, otherwise the investigation agent's `final_analysis`.
+
+```mermaid
+sequenceDiagram
+    participant Exec as Session executor
+    participant Action as Action agent (iterating)
+    participant Compose as Compose stage (single-shot)
+    participant TL as Timeline
+    participant Sess as Session
+
+    Exec->>Action: prev stage context (investigation/synthesis)
+    Action->>Action: tools / decide / act
+    Action->>TL: RESULT (action memo)
+    Exec->>Compose: create compose stage (referenced_stage_id = action)
+    Exec->>Compose: upstream final_analysis + action memo
+    Compose->>TL: stage final_analysis (streamed)
+    Exec->>Sess: final_analysis = composed text
+    Exec->>Exec: exec_summary summarizes composed text
+```
+
+### Trigger
+
+After **each successful action stage** (and that stage's synthesis sibling, if parallel agents ran), the executor inserts an automatic compose sibling. Not YAML, not buried in the action stage.
+
+**Skip** only when there is no upstream investigation/synthesis (or prior compose) report. Do **not** skip when the remediator took no action — that is the common path where today's card is wrong.
+
+Action-only chains (no investigation/synthesis before the action) skip compose. Session `final_analysis` stays the action memo.
+
+### Inputs
+
+Exactly two stage `final_analysis` strings, as already stored — no extra parsing:
+
+1. **Upstream report** — last investigation / investigation-synthesis / **prior compose** `final_analysis`, snapshotted **before** this action stage (and its synthesis, if any) is appended.
+2. **Action memo** — the result of this action work: the action stage `final_analysis` when a single agent ran, or the **synthesis** `final_analysis` when parallel action agents ran.
+
+Send both to the compose model as-is and ask it to copy-edit them into one report. Compose does not re-read tool traces or per-agent transcripts.
+
+(The action agent still ends with a YES/NO line for `actions_executed`. The executor already strips that before writing the action stage's `final_analysis`. Compose never sees it.)
+
+### Outputs
+
+One markdown document. The compose prompt is **format-agnostic**: the upstream report's structure is defined by that chain's investigation/synthesis agent or skill, not by TARSy.
+
+The prompt should tell the model to:
+
+- Emit the upstream report as the body. Keep its headings, tables, lists, and wording.
+- Fold the action memo into that document (new section if there is no natural place; or fill an existing actions/status area if the upstream already has one).
+- Patch only upstream text the memo makes stale (e.g. a "do X" recommendation that was already done or declined). Do not invent a TARSy-standard template, improve prose, drop sections, or add facts that are in neither document.
+
+### Token cost
+
+| Call | Tools | Typical in | Typical out |
+|------|-------|------------|-------------|
+| Action agent today (4.6, copying) | yes, many | large | full report (2–6k) on the expensive action model |
+| Action agent with this design | yes, many | large | short memo (~0.5–2k) |
+| Compose pass | no | two docs (~3–10k) + short prompt | one report (~2–6k) |
+
+Net vs 4.6: action **output** shrinks; compose adds one modest call on `defaults.compose_provider` (mid-tier). Do not send the action agent's iteration history into compose.
+
+### Failure and cancellation
+
+If compose **LLM** errors, times out, or returns empty (after the existing single-shot empty retry):
+
+- Session still completes (**fail-open**, like exec summary — not fail-closed like synthesis).
+- Compose **stage status is `failed`** (honest timeline).
+- Executor writes mechanical concat to the compose stage's `final_analysis` **and** still **appends** that stage to `completedStages`. Concat format: upstream report + `\n\n## Action result\n\n` + raw memo. Generic heading on purpose — fail-open concat must not assume an investigation template.
+- `extractFinalAnalysis` includes `compose` and does not check stage status. Concat is non-empty, so the last compose wins. Do **not** omit a failed compose from `completedStages` — that would land on the action memo (today's bug).
+- Chain **continues** (further YAML stages, then exec summary). Do not `return` the way a failed investigation/synthesis does.
+
+Session **cancel / session timeout** during compose: honour it. Do not concat-and-complete a cancelled session. Fail-open is for the compose LLM call, not for operator cancel.
+
+### Session `final_analysis` and exec summary
+
+Action stage analysis stays the memo. Compose stage analysis is the composed report (or concat on failure).
+
+`extractFinalAnalysis` runs **once at the end** of the chain loop (today's `worker` persists `ExecutionResult.FinalAnalysis`). Do not write `alert_sessions.final_analysis` incrementally during compose; the stage timeline still streams.
+
+`extractFinalAnalysis` allowlist today: `investigation`, `synthesis`, `action`. Add `compose`. Last non-empty wins, so the last compose wins over the action memo. `exec_summary`, `scoring`, and `chat` stay excluded.
+
+Executive summary already takes `extractFinalAnalysis(...)` as `prevContext`. After this change it summarizes the composed document automatically.
+
+### Context for later YAML stages
+
+`buildStageContext` uses the same type allowlist as `extractFinalAnalysis`. Add `compose`.
+
+If a later YAML stage runs after action+compose, it would otherwise see **both** the action memo and the composed report. Treat compose like synthesis does for parallel investigation: the composed report **supersedes** that action memo for downstream context.
+
+- `completedStages` keeps the action row, its synthesis sibling if any, and compose.
+- `buildStageContext` **omits** that action stage (and a synthesis whose `referenced_stage_id` points at it) when a later compose points at the action.
+- A later compose's upstream report is the previous compose `final_analysis`.
+
+### Parallel action agents (existing synthesis)
+
+Today the executor inserts synthesis whenever `len(agentResults) > 1`, with no stage-type check. That is **fine for compose**. Parallel action memos are merged into one synthesis document; that document **is** the action-side input. Compose should not read per-agent transcripts.
+
+Order:
+
+```
+… → action (N agents) → [synthesis of those memos, if N>1] → compose
+```
+
+- **Upstream report** is snapshotted **before** this action stage is appended (last investigation / investigation-synthesis / prior compose). Do not pick the action's own synthesis as upstream — that would send the same blob twice.
+- **Action memo** is whatever was just appended for this action: the action stage `final_analysis` when N=1, or the synthesis `final_analysis` when N>1.
+
+Keep auto-synthesis as it is. Do not special-case it off for action stages.
+
+(The builtin synthesis prompt is investigation-flavored. That is a pre-existing mismatch if someone actually runs parallel remediator agents; it is not a compose problem. Compose still wants the one merged document.)
+
+### Progress count
+
+`countExpectedStages` is computed once from chain YAML (stages + synthesis for multi-agent/replica investigation + 1 exec summary).
+
+Add **+1 per action stage that has an earlier investigation stage in the same chain** (static approximation of the skip rule). Action-only chains do not pre-count compose. If investigation produced an empty report and compose is skipped at runtime, `TotalStages` may be 1 high — acceptable.
+
+## Core Concepts
+
+### Action memo
+
+The action agent's final text. Short, structured, about the decision and tool outcomes. Shown on the action stage as **RESULT**.
+
+### Composed report
+
+Single-shot copy-edit: upstream document preserved, action result folded in. This is session `final_analysis` (Final Analysis card, Slack, memory extraction).
+
+### Compose stage
+
+- `stage_type`: `compose` (new enum value on `ent/schema/stage.go`; Atlas migration)
+- Stage name / UI label: `{actionStage.Name} - Amended Report` (same pattern as `{parent} - Synthesis`)
+- Builtin agent `ComposeAgent`, type `compose`, `SingleShotController`, no MCP
+- Native Gemini tools **explicitly off** (`google_search`, `url_context`, `code_execution` all false). Omitting MCP is not enough: `SingleShotController` still allows provider-native tools when the backend is Google-native.
+- Executor-created; `referenced_stage_id` → the action stage (trigger). Upstream report is prompt context, not a second FK.
+- Collapsed by default (`COLLAPSIBLE_STAGE_TYPES`)
+- LLM interaction type: `composition` (new enum on `LLMInteraction`, same rollout as `synthesis` / `executive_summary`)
+- `ThinkingFallback: false` — empty model text is failure → concat, not a thinking dump
+
+## Timeline visibility
+
+| Artifact | Where | What |
+|----------|--------|------|
+| Investigation / synthesis conclusion | that stage | canonical findings |
+| Action RESULT | action stage | memo: decided / acted / skipped |
+| Composed report | `{action} - Amended Report` | session-facing document |
+
+## Implementation Plan
+
+Three stacked PRs. Merge in order. Each PR must leave **existing** TARSy green: investigation, action, exec summary, scoring, chat, Slack/memory still complete sessions the way they do today. Compose may be unused or imperfect until the last PR.
+
+**Hard ordering:** do not merge PR 3 before PR 2. Stripping the action prompt without compose writing `session.final_analysis` turns today's Claude 5 bug into guaranteed behavior for every model.
+
+```
+PR 1  plumbing (dormant)     →  compose type/agent/config exist; executor never creates a compose stage
+PR 2  turn it on             →  compose runs; session card is the composed (or concat) document
+PR 3  action is memo-only    →  stop asking the remediator to copy the investigation
+```
+
+Do not split further (schema-only, dashboard-only, scoring-only). Do not combine PR 2+3: if compose wiring is wrong, revert PR 2 and the action agent still copies — existing safety net.
+
+### PR 1 — Compose plumbing (dormant) - DONE
+
+**Goal:** Compose is a real agent type with a prompt, provider knobs, and a DB enum. The executor does not call it.
+
+**Existing TARSy after merge:** Unchanged. Same stages, same `final_analysis`, same action prompt, same e2e stage counts (`test/e2e/action_test.go` still expects 3 stages / 5 LLM calls).
+
+**New (ok if unused):** `ComposeAgent` constructs in unit tests; `defaults.compose_provider` shows up in YAML and system-config JSON; Postgres accepts `stage_type=compose`.
+
+**In:**
+
+- Schema: `stage_type` += `compose`; `llm_interactions.interaction_type` += `composition`. Atlas migration for both. Run the `db-migration-review` skill on the generated `.up.sql`.
+- `pkg/config.AgentType` += `compose`. Validator: YAML chain agents must not use `type: compose` (executor-only, like `exec_summary`).
+- Builtin `ComposeAgent` in `pkg/config/builtin.go`: type `compose`, no MCP, native tools all false (`google_search`, `url_context`, `code_execution`).
+- Factory: `AgentTypeCompose` → `SingleShotController` with a compose message builder.
+- Prompt (`pkg/agent/prompt/compose.go` + golden): two fenced docs (`UPSTREAM REPORT`, `ACTION MEMO`) + format-agnostic copy-edit rules. `ThinkingFallback: false`.
+- Knobs (each set value must exist in the LLM provider registry):
+  - `Defaults.ComposeProvider` (`defaults.compose_provider`) — set in `deploy/config/tarsy.yaml` and the sandbox config to a Flash/Sonnet ID that exists in that file.
+  - `ChainConfig.ComposeProvider` (`compose_provider`) — same YAML/JSON shape as `executive_summary_provider`.
+- Resolver (`ResolveComposeConfig` — do **not** copy exec-summary's `defaults.llm_provider → chain.llm_provider → override` order):
+  1. `chain.compose_provider` if set
+  2. else `defaults.compose_provider` if set
+  3. else `chain.llm_provider` → `defaults.llm_provider`
+- `chain.llm_provider` must **not** win over `defaults.compose_provider`.
+- System-config JSON (`DefaultsView` + chain view) and dashboard `system.ts` types for the two new fields.
+- ADR-0004: add `compose` to the enum table. ADR-0005: `referenced_stage_id` is also compose → action.
+
+**Tests in this PR:** config / resolver / factory / compose-prompt golden / validator rejects YAML `type: compose`. No executor tests that insert a compose stage.
+
+**Must not:** touch `executor.go`, `extractFinalAnalysis`, `buildStageContext`, `countExpectedStages`, the action prompt, e2e expected stage counts, or goldens that encode stage lists.
+
+### PR 2 — Run compose after action
+
+**Goal:** After each successful action stage (and its synthesis sibling if N>1), insert the compose sibling. Session `final_analysis` becomes that document. Dashboard renders it. Scoring and chat see the output.
+
+**Existing TARSy after merge:**
+
+- Chains with no action stage: identical.
+- Action-only chains: compose skipped (no upstream report); card stays the action memo.
+- Investigation + action: session still completes; action prompt **unchanged** (still asked to copy+amend). The Final Analysis card is now the compose output instead of the raw action blob — that is the product fix, not a regression.
+- Compose LLM failure: session still completes (fail-open); compose stage is `failed`; card is mechanical concat.
+
+**New (ok if imperfect):** Compose copy-edits whatever the action agent currently emits (full report on 4.6, memo on 5). Token-wasteful until PR 3, but the card is a full report either way.
+
+**In:**
+
+Executor (`pkg/queue/executor.go` + new `executor_compose.go`, same shape as `executor_exec_summary.go`):
+
+1. Snapshot **upstream report** from `completedStages` **before** this action (and its synthesis) is appended — last investigation / investigation-synthesis / prior compose with non-empty analysis. If empty → skip.
+2. Run the action stage as today (including auto-synthesis when `len(agentResults) > 1`). Do **not** disable auto-synthesis for action.
+3. Action memo = the blob just appended: action `final_analysis` when N=1, synthesis `final_analysis` when N>1.
+4. Create compose stage (`referenced_stage_id` = the action stage, next `dbStageIndex`). Name `{actionStage} - Amended Report`. Publish status + progress ("Amending report...").
+5. Run `ComposeAgent` with the two blobs.
+6. On success: compose `final_analysis` = model text; status completed; append to `completedStages`.
+7. On LLM failure: status `failed`; `final_analysis` = mechanical concat (`upstream + \n\n## Action result\n\n + memo`); **still append**; **do not return**.
+8. Session cancel / session timeout during compose: honour it. Do not concat-and-complete.
+9. `extractFinalAnalysis` / `buildStageContext`: add `compose`. Omit superseded action (and a synthesis whose `referenced_stage_id` points at it) from `buildStageContext` when a later compose points at that action.
+10. `countExpectedStages`: +1 per action stage that has an earlier investigation stage in the same chain.
+
+Follow `executeSynthesisStage` for DB/progress/events; follow `executeExecSummaryStage` for fail-open. Do not copy synthesis fail-closed returns.
+
+Dashboard (ship with the stages so operators never see an unknown type):
+
+- `STAGE_TYPE.COMPOSE`, `COLLAPSIBLE_STAGE_TYPES`, separator icon, `getFinalAnalysisPresentation` → **AMENDED REPORT** (action RESULT stays the memo), trace label for `composition`. Final Analysis card still reads `session.final_analysis`. Failed compose: red stage chrome; card still shows concat.
+
+Downstream (small, same PR — not worth a follow-up):
+
+| Consumer | Behavior |
+|----------|----------|
+| Exec summary | Unchanged path; `prevContext` is already `extractFinalAnalysis` |
+| Slack / notifications / memory | Session `final_analysis` (automatic). Do **not** add compose to `InvestigationContextBuilder`'s stage loop |
+| Scoring timeline | Keep skipping compose in `InvestigationContextBuilder` (default `continue`) |
+| Scoring inputs | `ScoringExecutor` appends compose stage `final_analysis` as one extra document after the timeline |
+| Chat | Add compose as a document stage (`final_analysis` only). Action memo stays on the action stage in the UI |
+
+**Tests in this PR:**
+
+- Unit: `extractFinalAnalysis` prefers compose including failed+concat; `buildStageContext` includes compose and omits superseded action/synthesis; `countExpectedStages` +1 per action-after-investigation.
+- Executor: action success → compose with two docs; skip when no upstream; still compose on "no action"; LLM failure → failed stage + concat, chain continues, exec summary still runs; cancel during compose does not concat-complete; parallel action → compose uses the synthesis blob (upstream snapshotted before that synthesis).
+- Dashboard: stage type, `{name} - Amended Report`, AMENDED REPORT vs RESULT, failed chrome vs card.
+- Scoring: investigation + action + compose **output**; no compose prompt as "work".
+- Chat: compose FA in follow-up context.
+- E2E **must be updated in this PR or CI is red.** `test/e2e/action_test.go` today asserts `Len(stages, 3)` and `CallCount() == 5`. Insert a scripted compose response between action and exec summary; expect 4 stages / 6 LLM calls; assert `session.final_analysis` is the compose text; update `ActionChainExpectedEvents`, trace goldens, and the exec-summary context assertion (it will see the composed doc, not the raw action memo). Same for any other action-chain e2e that hard-codes stage counts.
+
+**Must not:** change `actionBehavioralInstructions` / `actionTaskFocus` / `actionTask`.
+
+### PR 3 — Action agent emits a memo only
+
+**Goal:** The remediator stops reprinting the investigation. Compose (already the session card after PR 2) is the only author of the combined document.
+
+**Existing TARSy after merge:** Compose already writes `final_analysis`. This only changes the action stage's RESULT from "try to copy the investigation" to a short memo. Investigation, tools, YES/NO marker, fail-open compose, dashboard — unchanged.
+
+**In:**
+
+- `pkg/agent/prompt/action.go` and `templates.go`: drop preserve/copy / "final report becomes finalAnalysis" / "amended report that preserves investigation findings". Keep safety (evidence, no re-investigation, prefer inaction, explain before tools, YES/NO marker). Instruct a short action memo (decision, evidence, tools, outcome).
+- Update action prompt goldens.
+- ADR-0007: preserving the investigation report moves **off** the action agent and **onto** compose.
+
+**Tests in this PR:** action prompt goldens; e2e that the action agent's captured system prompt no longer contains the copy/preserve sentences (the existing safety-preamble assertion in `action_test.go` stays). Do not require a new e2e that pattern-matches "memo vs report" on model output.
+
+**Must not ship before PR 2.**
+
+## Decisions
+
+| # | Topic | Decision |
+|---|--------|----------|
+| Q1 | Placement | Automatic sibling stage after each successful action stage |
+| Q2 | Prompt | Strict copy-edit of whatever format the upstream report already has; fold in the action result; no rewrite and no TARSy-imposed template |
+| Q3 | Model | Builtin compose agent. Default: `defaults.compose_provider` (mid-tier, set in tarsy.yaml). Override: `chain.compose_provider`. Last resort: `chain.llm_provider` → `defaults.llm_provider`. `chain.llm_provider` does not override the defaults compose knob. |
+| Q4 | LLM failure | Stage `failed`; append concat; session `final_analysis` via `extractFinalAnalysis` |
+| Q5 | Skip | Only when there is no upstream report; still compose if no tools ran |
+| Q6 | Naming | `stage_type: compose`; UI `{actionStage} - Amended Report` |
+| Q7 | Action prompt | Memo only; strip preserve/copy language |
+| Q8 | Inputs | Two `final_analysis` docs (upstream report + action memo) |
+| Q9 | Scoring / memory / chat | Memory/chat/Slack/exec summary use compose output; scoring skips compose process, includes compose output |

--- a/docs/proposals/action-report-compose-questions.md
+++ b/docs/proposals/action-report-compose-questions.md
@@ -1,0 +1,150 @@
+# Action Report Compose Pass — Questions
+
+**Status:** All decisions made
+**Related:** [Design document](action-report-compose-design.md)
+
+Each question has options with trade-offs and a recommendation. Go through them one by one to form the design, then update the design document.
+
+---
+
+## Q1: Where does the compose pass live?
+
+This is the main structural choice. It decides schema, executor flow, fail-open behavior, and how visible the step is in the dashboard.
+
+### Option B: Automatic sibling stage after each action stage (like synthesis)
+- **Pro:** Same pattern as synthesis and exec summary: work stage, then a single-shot document stage.
+- **Pro:** Best timeline/stage-list visibility (named collapsible stage, e.g. `{actionStage} - Amended Report`).
+- **Pro:** Fail-open is clean — action stage stays completed; compose stage can fail without rewriting action status.
+- **Pro:** Independent provider, `referenced_stage_id` to the action stage, own LLM interaction type.
+- **Con:** More surface area: `stage_type` enum, agent type, factory, progress count, dashboard chrome.
+- **Con:** Slightly less "inside the remediator" — it is attached to action, not a YAML chain stage.
+
+**Decision:** Option B — compose is a first-class document (session `final_analysis`), not a helper nested on the remediator. Same automatic-stage pattern as synthesis. Lightweight via no YAML and collapsed-by-default chrome, not by hiding the step.
+
+_Considered and rejected: Option A (in-stage extra call — tool-summarization analogy does not hold; compose combines two stages and becomes the session report), Option C (chain YAML — product invariant, too easy to omit)._
+
+---
+
+## Q2: How strict is the compose prompt?
+
+4.6 succeeded because it copied the synthesis and patched a few sections. 4.5/5 rewrote or stubbed. Mechanical concat is ugly because it does not patch stale "recommended actions." Compose has both documents in one prompt and must not re-author the investigation.
+
+### Option A: Strict copy-edit (format-agnostic)
+Instructions: emit the upstream report with its own wording and structure preserved (whatever format that agent or skill used); fold in the action result; patch only text the memo makes stale. Do not impose a TARSy report template, improve prose, drop sections, or invent facts.
+- **Pro:** Closest to the 4.6 document operators liked, without assuming one investigation layout.
+- **Pro:** Constrains even a "helpful" model; cheaper models are less dangerous.
+- **Con:** A model that still ignores instructions (the original bug) could ignore this too — but the task is narrower and has both documents in one prompt.
+
+**Decision:** Option A — the compose stage copy-edits the upstream document as it is; it does not rewrite it into a canonical template. The only upstream text it may change is whatever the action memo makes stale.
+
+_Considered and rejected: Option B (light rewrite — that is how 5 already replaces the investigation)._
+
+---
+
+## Q3: Which model runs the compose stage?
+
+Sibling stage means an independent provider — not “whatever the action agent used.” Token count is still one shot (two docs in, one doc out). Dollar cost and instruction-following differ.
+
+**Constraint:** Synthesis is not always in the chain. TARSy inserts a synthesis stage only after parallel/replica investigation. A single-agent investigation has no synthesis agent and no synthesis provider block. The upstream report is synthesis output if that stage ran, otherwise the investigation agent’s final analysis.
+
+### Option C: Dedicated builtin compose agent with optional chain override, defaulting to a mid-tier model (e.g. Sonnet / Flash)
+- **Pro:** Cost control; copy-edit does not need tools or Opus.
+- **Pro:** Same default on every chain, whether or not synthesis ran.
+- **Pro:** Override if a cheap default starts dropping sections (same shape as `executive_summary_provider`).
+- **Con:** One more config knob.
+
+**Decision:** Option C — builtin compose agent, mid-tier default, optional chain override. Same default whether or not synthesis ran.
+
+Mid-tier default is `defaults.compose_provider` (set in tarsy.yaml to a Flash/Sonnet provider ID that exists in that deployment). Chain `compose_provider` overrides it. Neither field inherits `chain.llm_provider` — that is often Opus and would undo the cost control. If both compose knobs are unset, fall through to `chain.llm_provider` → `defaults.llm_provider` so compose still runs.
+
+_Considered and rejected: Option A (provider of whoever wrote the upstream report — chain-shape dependent; frontier-priced copy-edit), Option B (exec summary provider — that prompt is trained to compress)._
+
+---
+
+## Q4: What happens when the compose LLM fails?
+
+Action tools may already have mutated the cluster. The session must still complete (**fail-open**, like exec summary — not fail-closed like synthesis).
+
+### Option C: Compose stage **failed**; session `final_analysis` is mechanical concat (upstream report + fixed heading + raw memo)
+- **Pro:** Timeline is honest — operators see that the compose LLM failed.
+- **Pro:** The Final Analysis card is still complete (findings + actions). Ugly is acceptable on a rare error path.
+- **Con:** Red compose stage next to a usable card. Acceptable if the card is clearly fallback concat, not a silent walk-back to the memo.
+
+**Decision:** Option C — stage status `failed`; executor sets session `final_analysis` (and the failed stage’s analysis) to mechanical concat. Do **not** let `extractFinalAnalysis` skip the failed compose stage and land on the action memo.
+
+_Considered and rejected: Option A (walk back to action memo — recreates today’s bug), Option B (completed stage + warning — hides LLM failure as a successful stage)._
+
+---
+
+## Q5: When do we skip creating a compose stage?
+
+Compose runs after **each** successful action stage. Remaining policy is skip vs always insert.
+
+### Option A: Skip only when there is no upstream investigation/synthesis (or prior compose) report
+- **Pro:** Avoids a no-op stage on action-only chains.
+- **Pro:** Still composes when the remediator took **no action** — "no action" is an amendment operators should see on the card, not a reason to leave the memo as the session report.
+- **Con:** None significant.
+
+**Decision:** Option A — skip only when there is no upstream report. Still compose when no tools ran.
+
+_Considered and rejected: Option B (skip when no tools ran — recreates today’s bug on the common “NO ACTION” path), Option C (always insert — pointless copy-edit on action-only chains)._
+
+---
+
+## Q6: What is the compose stage called (schema + UI)?
+
+`stage_type` / agent type in API and DB, plus the label in the stage list. Synthesis uses `stage_type: synthesis` and `{parent} - Synthesis`. Type string and display name do not have to match.
+
+### Option C: schema `compose` / UI `{actionStage} - Amended Report`
+- **Pro:** `compose` sits with `synthesis` / `exec_summary` as a document-producing stage; matches how we name the pass.
+- **Pro:** List label is unambiguous (session-facing document), not a vague “Report” or legal “Amendment.”
+- **Con:** Longer label than `{stage} - Synthesis`.
+
+**Decision:** Schema `compose`; UI `{actionStage} - Amended Report`. Collapsed by default like synthesis / exec summary / action. `referenced_stage_id` → the action stage (trigger). Upstream report is prompt context, not a second FK.
+
+_Considered and rejected: Option A (schema `amendment` — weaker type name, easy to confuse with action edits), Option B (UI `Report` — vague next to Final Analysis / Exec Summary)._
+
+---
+
+## Q7: How much do we strip from the action prompt?
+
+Today (`action.go` / `templates.go`): "Your final report becomes finalAnalysis… Preserve the investigation report… produce an amended report that preserves the investigation findings." That contract moves to the compose stage.
+
+### Option A: Remove all preserve/copy language; require a short structured memo only
+- **Pro:** Stops wasting action-model output tokens on a reprint compose will not trust.
+- **Pro:** Clear job split; 4.5/5 already write memos — we align the prompt with that.
+- **Con:** 4.6-style action agents that currently emit a full report will stop (compose takes over — intended).
+
+**Decision:** Option A — action agent emits a short memo only. Preserve/copy contract moves entirely to compose.
+
+_Considered and rejected: Option B (keep “you may copy the report” — models oscillate; compose input becomes inconsistent)._
+
+---
+
+## Q8: What is fed into the compose stage?
+
+### Option A: Two blobs — upstream report + action memo
+Upstream report = last investigation/synthesis, or the **previous compose result** if this is a later action stage in the same chain.
+- **Pro:** Smallest, cheapest, clearest prompt.
+- **Pro:** Avoids dumping tool traces (expensive, noisy).
+- **Con:** If the memo omits a tool outcome, compose cannot recover it from traces.
+
+**Decision:** Option A — two `final_analysis` documents only. Compose does not re-evaluate the investigation or read tool traces.
+
+_Considered and rejected: Option B (add compact tool-call summary — second interpretation of tools; add later only if memos are too thin), Option C (full action conversation — not a cheap pass)._
+
+---
+
+## Q9: Do scoring, memory, and chat see the compose stage?
+
+Scoring today does **not** receive `alert_sessions.final_analysis` as its own blob. It gets alert + runbook + tools + a timeline of `investigation` / `exec_summary` / `action`. Stage `final_analysis` events appear only for those types. After compose, the card text is no longer the same as the last investigation/action event.
+
+### Option A: Session field + chat + memory use compose output. Scoring timeline skips compose *internals*, but still includes compose **output** (the stage’s `final_analysis` / session card).
+- **Pro:** Memory, Slack, exec summary, and chat see what operators read.
+- **Pro:** Scoring still judges investigation + action *work*; it can also see if the delivered card is garbage relative to those inputs.
+- **Pro:** Output is one extra document (~2–6k tokens), not the compose LLM trace.
+- **Con:** Scoring is not asked to grade copy-edit craft as a process (we do not need it to).
+
+**Decision:** Option A (refined) — exclude compose process from the scoring timeline; still feed compose **output** into the judge. Chat includes compose as the latest report. Memory uses session `final_analysis` (compose).
+
+_Considered and rejected: Option B (full compose stage in scoring — grades a copy-edit pass as investigation quality), Option C (memory uses action memo — drops the investigation body)._

--- a/ent/llminteraction/llminteraction.go
+++ b/ent/llminteraction/llminteraction.go
@@ -162,6 +162,7 @@ const (
 	InteractionTypeForcedConclusion InteractionType = "forced_conclusion"
 	InteractionTypeScoring          InteractionType = "scoring"
 	InteractionTypeMemoryExtraction InteractionType = "memory_extraction"
+	InteractionTypeComposition      InteractionType = "composition"
 )
 
 func (it InteractionType) String() string {
@@ -171,7 +172,7 @@ func (it InteractionType) String() string {
 // InteractionTypeValidator is a validator for the "interaction_type" field enum values. It is called by the builders before save.
 func InteractionTypeValidator(it InteractionType) error {
 	switch it {
-	case InteractionTypeIteration, InteractionTypeFinalAnalysis, InteractionTypeExecutiveSummary, InteractionTypeChatResponse, InteractionTypeSummarization, InteractionTypeSynthesis, InteractionTypeForcedConclusion, InteractionTypeScoring, InteractionTypeMemoryExtraction:
+	case InteractionTypeIteration, InteractionTypeFinalAnalysis, InteractionTypeExecutiveSummary, InteractionTypeChatResponse, InteractionTypeSummarization, InteractionTypeSynthesis, InteractionTypeForcedConclusion, InteractionTypeScoring, InteractionTypeMemoryExtraction, InteractionTypeComposition:
 		return nil
 	default:
 		return fmt.Errorf("llminteraction: invalid enum value for interaction_type field: %q", it)

--- a/ent/migrate/schema.go
+++ b/ent/migrate/schema.go
@@ -343,7 +343,7 @@ var (
 	LlmInteractionsColumns = []*schema.Column{
 		{Name: "interaction_id", Type: field.TypeString, Unique: true},
 		{Name: "created_at", Type: field.TypeTime},
-		{Name: "interaction_type", Type: field.TypeEnum, Enums: []string{"iteration", "final_analysis", "executive_summary", "chat_response", "summarization", "synthesis", "forced_conclusion", "scoring", "memory_extraction"}},
+		{Name: "interaction_type", Type: field.TypeEnum, Enums: []string{"iteration", "final_analysis", "executive_summary", "chat_response", "summarization", "synthesis", "forced_conclusion", "scoring", "memory_extraction", "composition"}},
 		{Name: "model_name", Type: field.TypeString},
 		{Name: "llm_request", Type: field.TypeJSON},
 		{Name: "llm_response", Type: field.TypeJSON},
@@ -644,7 +644,7 @@ var (
 		{Name: "expected_agent_count", Type: field.TypeInt},
 		{Name: "parallel_type", Type: field.TypeEnum, Nullable: true, Enums: []string{"multi_agent", "replica"}},
 		{Name: "success_policy", Type: field.TypeEnum, Nullable: true, Enums: []string{"all", "any"}},
-		{Name: "stage_type", Type: field.TypeEnum, Enums: []string{"investigation", "synthesis", "chat", "exec_summary", "scoring", "action"}, Default: "investigation"},
+		{Name: "stage_type", Type: field.TypeEnum, Enums: []string{"investigation", "synthesis", "chat", "exec_summary", "scoring", "action", "compose"}, Default: "investigation"},
 		{Name: "status", Type: field.TypeEnum, Enums: []string{"pending", "active", "completed", "failed", "timed_out", "cancelled"}, Default: "pending"},
 		{Name: "started_at", Type: field.TypeTime, Nullable: true},
 		{Name: "completed_at", Type: field.TypeTime, Nullable: true},

--- a/ent/schema/llminteraction.go
+++ b/ent/schema/llminteraction.go
@@ -42,7 +42,7 @@ func (LLMInteraction) Fields() []ent.Field {
 
 		// Interaction Details
 		field.Enum("interaction_type").
-			Values("iteration", "final_analysis", "executive_summary", "chat_response", "summarization", "synthesis", "forced_conclusion", "scoring", "memory_extraction"),
+			Values("iteration", "final_analysis", "executive_summary", "chat_response", "summarization", "synthesis", "forced_conclusion", "scoring", "memory_extraction", "composition"),
 		field.String("model_name").
 			Comment("e.g., 'gemini-2.0-flash-thinking-exp'"),
 

--- a/ent/schema/stage.go
+++ b/ent/schema/stage.go
@@ -46,9 +46,9 @@ func (Stage) Fields() []ent.Field {
 
 		// Stage Type
 		field.Enum("stage_type").
-			Values("investigation", "synthesis", "chat", "exec_summary", "scoring", "action").
+			Values("investigation", "synthesis", "chat", "exec_summary", "scoring", "action", "compose").
 			Default("investigation").
-			Comment("Kind of stage: investigation (from chain), synthesis (auto-generated), chat (user message), exec_summary (executive summary), scoring (quality evaluation), action (automated remediation)"),
+			Comment("Kind of stage: investigation (from chain), synthesis (auto-generated), chat (user message), exec_summary (executive summary), scoring (quality evaluation), action (automated remediation), compose (amended report after action)"),
 
 		// Stage-Level Status & Timing (aggregated from agent executions)
 		field.Enum("status").
@@ -83,7 +83,7 @@ func (Stage) Fields() []ent.Field {
 		field.String("referenced_stage_id").
 			Optional().
 			Nillable().
-			Comment("FK to another stage in the same session (e.g. synthesis -> investigation)"),
+			Comment("FK to another stage in the same session (e.g. synthesis -> investigation, compose -> action)"),
 
 		// Action stage outcome
 		field.Bool("actions_executed").

--- a/ent/stage.go
+++ b/ent/stage.go
@@ -32,7 +32,7 @@ type Stage struct {
 	ParallelType *stage.ParallelType `json:"parallel_type,omitempty"`
 	// null if count=1, 'all'/'any' if count>1
 	SuccessPolicy *stage.SuccessPolicy `json:"success_policy,omitempty"`
-	// Kind of stage: investigation (from chain), synthesis (auto-generated), chat (user message), exec_summary (executive summary), scoring (quality evaluation), action (automated remediation)
+	// Kind of stage: investigation (from chain), synthesis (auto-generated), chat (user message), exec_summary (executive summary), scoring (quality evaluation), action (automated remediation), compose (amended report after action)
 	StageType stage.StageType `json:"stage_type,omitempty"`
 	// Status holds the value of the "status" field.
 	Status stage.Status `json:"status,omitempty"`
@@ -48,7 +48,7 @@ type Stage struct {
 	ChatID *string `json:"chat_id,omitempty"`
 	// ChatUserMessageID holds the value of the "chat_user_message_id" field.
 	ChatUserMessageID *string `json:"chat_user_message_id,omitempty"`
-	// FK to another stage in the same session (e.g. synthesis -> investigation)
+	// FK to another stage in the same session (e.g. synthesis -> investigation, compose -> action)
 	ReferencedStageID *string `json:"referenced_stage_id,omitempty"`
 	// Whether the action agent executed any remediation tools (null for non-action stages)
 	ActionsExecuted *bool `json:"actions_executed,omitempty"`

--- a/ent/stage/stage.go
+++ b/ent/stage/stage.go
@@ -252,6 +252,7 @@ const (
 	StageTypeExecSummary   StageType = "exec_summary"
 	StageTypeScoring       StageType = "scoring"
 	StageTypeAction        StageType = "action"
+	StageTypeCompose       StageType = "compose"
 )
 
 func (st StageType) String() string {
@@ -261,7 +262,7 @@ func (st StageType) String() string {
 // StageTypeValidator is a validator for the "stage_type" field enum values. It is called by the builders before save.
 func StageTypeValidator(st StageType) error {
 	switch st {
-	case StageTypeInvestigation, StageTypeSynthesis, StageTypeChat, StageTypeExecSummary, StageTypeScoring, StageTypeAction:
+	case StageTypeInvestigation, StageTypeSynthesis, StageTypeChat, StageTypeExecSummary, StageTypeScoring, StageTypeAction, StageTypeCompose:
 		return nil
 	default:
 		return fmt.Errorf("stage: invalid enum value for stage_type field: %q", st)

--- a/pkg/agent/config_resolver.go
+++ b/pkg/agent/config_resolver.go
@@ -457,6 +457,70 @@ func ResolveExecSummaryConfig(
 	}, nil
 }
 
+// ResolveComposeConfig builds the agent configuration for a compose execution.
+// Provider order (last non-empty wins): defaults.llm_provider → chain.llm_provider
+// → defaults.compose_provider → chain.compose_provider.
+// defaults.compose_provider beats chain.llm_provider so a mid-tier compose default
+// is not overridden by a chain's investigation model.
+func ResolveComposeConfig(
+	cfg *config.Config,
+	chain *config.ChainConfig,
+) (*ResolvedAgentConfig, error) {
+	if chain == nil {
+		return nil, fmt.Errorf("chain configuration cannot be nil")
+	}
+
+	var defaults config.Defaults
+	if cfg.Defaults != nil {
+		defaults = *cfg.Defaults
+	}
+
+	agentDef, err := cfg.GetAgent(config.AgentNameCompose)
+	if err != nil {
+		return nil, fmt.Errorf("agent %q not found: %w", config.AgentNameCompose, err)
+	}
+
+	backend := resolveLLMBackend(
+		defaults.LLMBackend, agentDef.LLMBackend, chain.LLMBackend,
+	)
+
+	provider, providerName, err := resolveLLMProvider(cfg,
+		defaults.LLMProvider, chain.LLMProvider, defaults.ComposeProvider, chain.ComposeProvider,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	maxIter := resolveMaxIterations(
+		defaults.MaxIterations, agentDef.MaxIterations, chain.MaxIterations, nil,
+	)
+
+	fallbackProviders := resolveFallbackProviders(
+		defaults.FallbackProviders, chain.FallbackProviders,
+	)
+
+	resolvedProvider := applyAgentNativeTools(provider, agentDef.NativeTools)
+	resolvedFallback := resolveFullFallbackEntries(cfg, fallbackProviders, agentDef.NativeTools)
+
+	return &ResolvedAgentConfig{
+		AgentName:                 config.AgentNameCompose,
+		Type:                      config.AgentTypeCompose,
+		LLMBackend:                backend,
+		LLMProvider:               resolvedProvider,
+		LLMProviderName:           providerName,
+		MaxIterations:             maxIter,
+		IterationTimeout:          DefaultIterationTimeout,
+		LLMCallTimeout:            DefaultLLMCallTimeout,
+		ToolCallTimeout:           DefaultToolCallTimeout,
+		CustomInstructions:        agentDef.CustomInstructions,
+		FallbackProviders:         fallbackProviders,
+		ResolvedFallbackProviders: resolvedFallback,
+		InitialResponseTimeout:    DefaultInitialResponseTimeout,
+		StallTimeout:              DefaultStallTimeout,
+		RequiresNativeTools:       requiresNativeTools(agentDef.NativeTools),
+	}, nil
+}
+
 // requiresNativeTools returns true when the agent definition declares at least
 // one enabled native tool. Used to set RequiresNativeTools on ResolvedAgentConfig.
 func requiresNativeTools(agentTools map[config.GoogleNativeTool]bool) bool {

--- a/pkg/agent/config_resolver_test.go
+++ b/pkg/agent/config_resolver_test.go
@@ -1726,6 +1726,141 @@ func TestResolveExecSummaryConfig(t *testing.T) {
 	})
 }
 
+func TestResolveComposeConfig(t *testing.T) {
+	defaults := &config.Defaults{
+		LLMProvider:     "google-default",
+		ComposeProvider: "anthropic-default",
+		LLMBackend:      config.LLMBackendLangChain,
+	}
+
+	googleProvider := &config.LLMProviderConfig{
+		Type:      config.LLMProviderTypeGoogle,
+		Model:     "gemini-2.5-pro",
+		APIKeyEnv: "GOOGLE_API_KEY",
+	}
+	openaiProvider := &config.LLMProviderConfig{
+		Type:      config.LLMProviderTypeOpenAI,
+		Model:     "gpt-5",
+		APIKeyEnv: "OPENAI_API_KEY",
+	}
+	anthropicProvider := &config.LLMProviderConfig{
+		Type:      config.LLMProviderTypeAnthropic,
+		Model:     "claude-sonnet",
+		APIKeyEnv: "ANTHROPIC_API_KEY",
+	}
+
+	cfg := &config.Config{
+		Defaults: defaults,
+		AgentRegistry: config.NewAgentRegistry(map[string]*config.AgentConfig{
+			config.AgentNameCompose: {Type: config.AgentTypeCompose, LLMBackend: config.LLMBackendLangChain},
+		}),
+		LLMProviderRegistry: config.NewLLMProviderRegistry(map[string]*config.LLMProviderConfig{
+			"google-default":    googleProvider,
+			"openai-default":    openaiProvider,
+			"anthropic-default": anthropicProvider,
+		}),
+	}
+
+	t.Run("uses ComposeAgent type", func(t *testing.T) {
+		resolved, err := ResolveComposeConfig(cfg, &config.ChainConfig{})
+		require.NoError(t, err)
+		assert.Equal(t, config.AgentNameCompose, resolved.AgentName)
+		assert.Equal(t, config.AgentTypeCompose, resolved.Type)
+	})
+
+	t.Run("defaults.compose_provider beats chain.llm_provider", func(t *testing.T) {
+		chain := &config.ChainConfig{LLMProvider: "openai-default"}
+		resolved, err := ResolveComposeConfig(cfg, chain)
+		require.NoError(t, err)
+		assert.Equal(t, anthropicProvider, resolved.LLMProvider)
+		assert.Equal(t, "anthropic-default", resolved.LLMProviderName)
+	})
+
+	t.Run("chain.compose_provider beats defaults.compose_provider", func(t *testing.T) {
+		chain := &config.ChainConfig{
+			LLMProvider:     "openai-default",
+			ComposeProvider: "google-default",
+		}
+		resolved, err := ResolveComposeConfig(cfg, chain)
+		require.NoError(t, err)
+		assert.Equal(t, googleProvider, resolved.LLMProvider)
+		assert.Equal(t, "google-default", resolved.LLMProviderName)
+	})
+
+	t.Run("falls back to chain.llm_provider when compose knobs unset", func(t *testing.T) {
+		cfgNoComposeDefault := &config.Config{
+			Defaults: &config.Defaults{LLMProvider: "google-default"},
+			AgentRegistry: config.NewAgentRegistry(map[string]*config.AgentConfig{
+				config.AgentNameCompose: {Type: config.AgentTypeCompose},
+			}),
+			LLMProviderRegistry: cfg.LLMProviderRegistry,
+		}
+		chain := &config.ChainConfig{LLMProvider: "openai-default"}
+		resolved, err := ResolveComposeConfig(cfgNoComposeDefault, chain)
+		require.NoError(t, err)
+		assert.Equal(t, "openai-default", resolved.LLMProviderName)
+	})
+
+	t.Run("nil chain returns error", func(t *testing.T) {
+		_, err := ResolveComposeConfig(cfg, nil)
+		assert.Error(t, err)
+	})
+
+	t.Run("unknown provider returns error", func(t *testing.T) {
+		chain := &config.ChainConfig{ComposeProvider: "nonexistent-provider"}
+		_, err := ResolveComposeConfig(cfg, chain)
+		assert.Error(t, err)
+	})
+
+	t.Run("missing ComposeAgent returns error", func(t *testing.T) {
+		cfgNoAgent := &config.Config{
+			Defaults:            defaults,
+			AgentRegistry:       config.NewAgentRegistry(map[string]*config.AgentConfig{}),
+			LLMProviderRegistry: cfg.LLMProviderRegistry,
+		}
+		_, err := ResolveComposeConfig(cfgNoAgent, &config.ChainConfig{})
+		assert.Error(t, err)
+	})
+
+	t.Run("all-false native tools strip inherited Gemini tools", func(t *testing.T) {
+		googleWithNative := &config.LLMProviderConfig{
+			Type:      config.LLMProviderTypeGoogle,
+			Model:     "gemini-2.5-pro",
+			APIKeyEnv: "GOOGLE_API_KEY",
+			NativeTools: map[config.GoogleNativeTool]bool{
+				config.GoogleNativeToolGoogleSearch: true,
+				config.GoogleNativeToolURLContext:   true,
+			},
+		}
+		nativeCfg := &config.Config{
+			Defaults: &config.Defaults{LLMProvider: "google-default"},
+			AgentRegistry: config.NewAgentRegistry(map[string]*config.AgentConfig{
+				config.AgentNameCompose: {
+					Type: config.AgentTypeCompose,
+					NativeTools: map[config.GoogleNativeTool]bool{
+						config.GoogleNativeToolGoogleSearch:  false,
+						config.GoogleNativeToolURLContext:    false,
+						config.GoogleNativeToolCodeExecution: false,
+					},
+				},
+			}),
+			LLMProviderRegistry: config.NewLLMProviderRegistry(map[string]*config.LLMProviderConfig{
+				"google-default": googleWithNative,
+			}),
+		}
+
+		resolved, err := ResolveComposeConfig(nativeCfg, &config.ChainConfig{})
+		require.NoError(t, err)
+		assert.False(t, resolved.RequiresNativeTools)
+		require.NotNil(t, resolved.LLMProvider)
+		assert.False(t, resolved.LLMProvider.NativeTools[config.GoogleNativeToolGoogleSearch])
+		assert.False(t, resolved.LLMProvider.NativeTools[config.GoogleNativeToolURLContext])
+		assert.False(t, resolved.LLMProvider.NativeTools[config.GoogleNativeToolCodeExecution])
+		assert.True(t, googleWithNative.NativeTools[config.GoogleNativeToolGoogleSearch],
+			"original provider must not be mutated")
+	})
+}
+
 func TestResolveSkills(t *testing.T) {
 	registry := config.NewSkillRegistry(map[string]*config.SkillConfig{
 		"kubernetes-basics": {

--- a/pkg/agent/context.go
+++ b/pkg/agent/context.go
@@ -46,6 +46,10 @@ type ExecutionContext struct {
 	// Implemented by prompt.PromptBuilder; interface avoids agent↔prompt import cycle.
 	PromptBuilder PromptBuilder
 
+	// Compose inputs (set by the executor for compose stages; empty otherwise).
+	ComposeUpstreamReport string
+	ComposeActionMemo     string
+
 	// Chat context (nil for non-chat sessions)
 	ChatContext *ChatContext
 
@@ -198,6 +202,8 @@ type PromptBuilder interface {
 	BuildMCPSummarizationUserPrompt(conversationContext, serverName, toolName, resultText string) string
 	BuildExecutiveSummarySystemPrompt() string
 	BuildExecutiveSummaryUserPrompt(finalAnalysis string) string
+	BuildComposeSystemPrompt() string
+	BuildComposeUserPrompt(upstreamReport, actionMemo string) string
 	BuildScoringSystemPrompt() string
 	BuildScoringInitialPrompt(sessionInvestigationContext, outputSchema string) string
 	BuildScoringOutputSchemaReminderPrompt(outputSchema string) string

--- a/pkg/agent/controller/factory.go
+++ b/pkg/agent/controller/factory.go
@@ -30,6 +30,8 @@ func (f *Factory) CreateController(agentType config.AgentType, execCtx *agent.Ex
 		return NewScoringController(), nil
 	case config.AgentTypeAction:
 		return NewIteratingController(), nil
+	case config.AgentTypeCompose:
+		return NewComposeController(execCtx.PromptBuilder), nil
 	default:
 		return nil, fmt.Errorf("unknown agent type: %q", agentType)
 	}

--- a/pkg/agent/controller/factory_test.go
+++ b/pkg/agent/controller/factory_test.go
@@ -81,6 +81,23 @@ func TestFactory_CreateController(t *testing.T) {
 		assert.True(t, ok, "expected SingleShotController")
 	})
 
+	t.Run("compose type returns SingleShotController", func(t *testing.T) {
+		pb := prompt.NewPromptBuilder(config.NewMCPServerRegistry(map[string]*config.MCPServerConfig{}), nil)
+		composeExecCtx := &agent.ExecutionContext{
+			SessionID:     "test-session",
+			StageID:       "test-stage",
+			AgentName:     "test-agent",
+			AgentIndex:    1,
+			PromptBuilder: pb,
+		}
+		controller, err := factory.CreateController(config.AgentTypeCompose, composeExecCtx)
+		require.NoError(t, err)
+		require.NotNil(t, controller)
+
+		_, ok := controller.(*SingleShotController)
+		assert.True(t, ok, "expected SingleShotController")
+	})
+
 	t.Run("action type returns IteratingController", func(t *testing.T) {
 		controller, err := factory.CreateController(config.AgentTypeAction, execCtx)
 		require.NoError(t, err)

--- a/pkg/agent/controller/scoring_test.go
+++ b/pkg/agent/controller/scoring_test.go
@@ -44,6 +44,14 @@ func (m *mockScoringPromptBuilder) BuildExecutiveSummaryUserPrompt(_ string) str
 	panic("unexpected call")
 }
 
+func (m *mockScoringPromptBuilder) BuildComposeSystemPrompt() string {
+	panic("unexpected call")
+}
+
+func (m *mockScoringPromptBuilder) BuildComposeUserPrompt(_, _ string) string {
+	panic("unexpected call")
+}
+
 func (m *mockScoringPromptBuilder) MCPServerRegistry() *config.MCPServerRegistry {
 	panic("unexpected call")
 }

--- a/pkg/agent/controller/single_shot.go
+++ b/pkg/agent/controller/single_shot.go
@@ -65,6 +65,21 @@ func NewExecSummaryController(pb agent.PromptBuilder) *SingleShotController {
 	})
 }
 
+// NewComposeController creates a SingleShotController configured for compose.
+// Upstream report and action memo are read from ExecutionContext (not prevStageContext).
+func NewComposeController(pb agent.PromptBuilder) *SingleShotController {
+	return NewSingleShotController(SingleShotConfig{
+		BuildMessages: func(execCtx *agent.ExecutionContext, _ string) []agent.ConversationMessage {
+			return []agent.ConversationMessage{
+				{Role: agent.RoleSystem, Content: pb.BuildComposeSystemPrompt()},
+				{Role: agent.RoleUser, Content: pb.BuildComposeUserPrompt(execCtx.ComposeUpstreamReport, execCtx.ComposeActionMemo)},
+			}
+		},
+		ThinkingFallback: false,
+		InteractionLabel: llminteraction.InteractionTypeComposition,
+	})
+}
+
 // Run executes a single LLM call and returns the result.
 func (c *SingleShotController) Run(
 	ctx context.Context,

--- a/pkg/agent/controller/single_shot_test.go
+++ b/pkg/agent/controller/single_shot_test.go
@@ -386,6 +386,65 @@ func TestExecSummaryController_NoThinkingFallback(t *testing.T) {
 	require.Equal(t, maxEmptyResponseRetries+1, llm.callCount, "should exhaust empty retries")
 }
 
+func TestComposeController_NoThinkingFallback(t *testing.T) {
+	responses := make([]mockLLMResponse, maxEmptyResponseRetries+1)
+	for i := range responses {
+		responses[i] = mockLLMResponse{chunks: []agent.Chunk{
+			&agent.ThinkingChunk{Content: "Let me think about this..."},
+		}}
+	}
+
+	llm := &mockLLMClient{responses: responses}
+	execCtx := newTestExecCtx(t, llm, &mockToolExecutor{})
+	execCtx.ComposeUpstreamReport = "Investigation findings."
+	execCtx.ComposeActionMemo = "No action taken."
+	ctrl := NewComposeController(execCtx.PromptBuilder)
+
+	result, err := ctrl.Run(t.Context(), execCtx, "")
+	require.NoError(t, err)
+	require.Empty(t, result.FinalAnalysis)
+	require.Equal(t, maxEmptyResponseRetries+1, llm.callCount, "should exhaust empty retries")
+}
+
+func TestComposeController_HappyPath(t *testing.T) {
+	llm := &mockLLMClient{
+		responses: []mockLLMResponse{
+			{chunks: []agent.Chunk{
+				&agent.TextChunk{Content: "Amended report with action outcome folded in."},
+				&agent.UsageChunk{InputTokens: 80, OutputTokens: 20, TotalTokens: 100},
+			}},
+		},
+	}
+
+	execCtx := newTestExecCtx(t, llm, &mockToolExecutor{})
+	execCtx.ComposeUpstreamReport = "Root cause: OOM in web-1."
+	execCtx.ComposeActionMemo = "No action taken. Memory change needs a CR."
+	ctrl := NewComposeController(execCtx.PromptBuilder)
+
+	prevStageContext := "this previous-stage blob must not appear in compose prompts"
+	result, err := ctrl.Run(t.Context(), execCtx, prevStageContext)
+	require.NoError(t, err)
+	require.Equal(t, agent.ExecutionStatusCompleted, result.Status)
+	require.Contains(t, result.FinalAnalysis, "Amended report")
+	require.Equal(t, 100, result.TokensUsed.TotalTokens)
+	require.Equal(t, 1, llm.callCount)
+
+	require.NotNil(t, llm.lastInput)
+	require.GreaterOrEqual(t, len(llm.lastInput.Messages), 2)
+	require.Nil(t, llm.lastInput.Tools)
+
+	systemMsg := llm.lastInput.Messages[0]
+	userMsg := llm.lastInput.Messages[1]
+	require.Equal(t, agent.RoleSystem, systemMsg.Role)
+	require.Contains(t, systemMsg.Content, "copy-editor")
+	require.Equal(t, agent.RoleUser, userMsg.Role)
+	require.Contains(t, userMsg.Content, "=== UPSTREAM REPORT ===")
+	require.Contains(t, userMsg.Content, "Root cause: OOM in web-1.")
+	require.Contains(t, userMsg.Content, "=== ACTION MEMO ===")
+	require.Contains(t, userMsg.Content, "No action taken. Memory change needs a CR.")
+	require.NotContains(t, userMsg.Content, prevStageContext)
+}
+
 func TestSingleShotController_EmptyResponseRetry(t *testing.T) {
 	// First call returns empty, second succeeds.
 	llm := &mockLLMClient{

--- a/pkg/agent/prompt/builder.go
+++ b/pkg/agent/prompt/builder.go
@@ -152,6 +152,16 @@ func (b *PromptBuilder) BuildExecutiveSummaryUserPrompt(finalAnalysis string) st
 	return fmt.Sprintf(executiveSummaryUserTemplate, finalAnalysis)
 }
 
+// BuildComposeSystemPrompt returns the system prompt for compose (amended-report) generation.
+func (b *PromptBuilder) BuildComposeSystemPrompt() string {
+	return composeSystemPrompt
+}
+
+// BuildComposeUserPrompt builds the user prompt from the upstream report and action memo.
+func (b *PromptBuilder) BuildComposeUserPrompt(upstreamReport, actionMemo string) string {
+	return fmt.Sprintf(composeUserTemplate, upstreamReport, actionMemo)
+}
+
 func (b *PromptBuilder) BuildScoringSystemPrompt() string {
 	return judgeSystemPrompt
 }

--- a/pkg/agent/prompt/builder_integration_test.go
+++ b/pkg/agent/prompt/builder_integration_test.go
@@ -401,6 +401,19 @@ func TestIntegration_ExecutiveSummary(t *testing.T) {
 	assertGolden(t, "executive_summary", combined)
 }
 
+func TestIntegration_Compose(t *testing.T) {
+	builder := newIntegrationBuilder()
+
+	systemPrompt := builder.BuildComposeSystemPrompt()
+	userPrompt := builder.BuildComposeUserPrompt(
+		"## Findings\nRoot cause: OOM kill due to memory leak in pod-1.\n\n## Recommendations\n- Increase memory limit to 1Gi.",
+		"No action taken. Memory limit change requires a change request.",
+	)
+
+	combined := systemPrompt + "\n\n=== USER PROMPT ===\n\n" + userPrompt
+	assertGolden(t, "compose", combined)
+}
+
 // ===========================================================================
 // Sanity checks: verify golden files match expected structural properties
 // ===========================================================================

--- a/pkg/agent/prompt/builder_test.go
+++ b/pkg/agent/prompt/builder_test.go
@@ -143,6 +143,26 @@ func TestBuildExecutiveSummaryPrompts(t *testing.T) {
 	assert.Contains(t, userPrompt, "The root cause was OOM.")
 }
 
+func TestBuildComposePrompts(t *testing.T) {
+	builder := newBuilderForTest()
+
+	systemPrompt := builder.BuildComposeSystemPrompt()
+	assert.Contains(t, systemPrompt, "copy-editor")
+	assert.Contains(t, systemPrompt, "Those two tracks are not interchangeable")
+	assert.Contains(t, systemPrompt, "restarting a pod does not fulfill a recommendation to change a resource limit")
+	assert.Contains(t, systemPrompt, "Do not invent a TARSy-standard template")
+	assert.Contains(t, systemPrompt, "Do not improve prose")
+	assert.Contains(t, systemPrompt, "Do not drop sections")
+
+	userPrompt := builder.BuildComposeUserPrompt("upstream findings", "no action taken")
+	assert.Contains(t, userPrompt, "=== UPSTREAM REPORT ===")
+	assert.Contains(t, userPrompt, "=== END UPSTREAM REPORT ===")
+	assert.Contains(t, userPrompt, "=== ACTION MEMO ===")
+	assert.Contains(t, userPrompt, "=== END ACTION MEMO ===")
+	assert.Contains(t, userPrompt, "upstream findings")
+	assert.Contains(t, userPrompt, "no action taken")
+}
+
 func TestBuildFunctionCallingMessages_ChatMode(t *testing.T) {
 	builder := newBuilderForTest()
 	execCtx := newFullExecCtx()

--- a/pkg/agent/prompt/compose.go
+++ b/pkg/agent/prompt/compose.go
@@ -1,0 +1,27 @@
+package prompt
+
+const composeSystemPrompt = `You are a copy-editor for incident reports. You receive two documents: an upstream investigation (or synthesis) report, and an action memo describing what automated remediating agents decided and did.
+
+The investigation often includes a human-facing section (recommendations, remediation, next steps, or similar) — work for operators. The action memo covers only what the action agent could actually execute. Those two tracks are not interchangeable: an automated action does not fulfill a different human recommendation, and a human recommendation does not mean the agent already did it.
+
+Emit a single amended report. Keep the upstream document's own structure, headings, tables, lists, and wording. Fold the action outcome into that document. You are not an investigator and you are not rewriting the report into a new template.
+
+RULES:
+- Emit the upstream report as the body. Preserve its format exactly unless a patch is required below.
+- Fold the action memo in: use an existing actions/status/remediation section if the upstream already has one; otherwise add a short new section in the same style as the rest of the document.
+- Keep both tracks visible. Record what the action agent did (or its decision to take no automated action). Keep human follow-ups from the investigation unless the memo explicitly completed or declined that same item.
+- Patch upstream text as stale only when the memo addresses that same recommendation (done or declined). Do not treat a related-but-different automated action as completing a human follow-up (for example: restarting a pod does not fulfill a recommendation to change a resource limit).
+- Do not invent a TARSy-standard template. Do not improve prose. Do not drop sections. Do not add facts that appear in neither document.
+- Return ONLY the amended report. No preamble, no commentary.`
+
+const composeUserTemplate = `Amend the upstream report with the action outcome.
+
+=== UPSTREAM REPORT ===
+%s
+=== END UPSTREAM REPORT ===
+
+=== ACTION MEMO ===
+%s
+=== END ACTION MEMO ===
+
+Amended report:`

--- a/pkg/agent/prompt/testdata/compose.golden
+++ b/pkg/agent/prompt/testdata/compose.golden
@@ -1,0 +1,31 @@
+You are a copy-editor for incident reports. You receive two documents: an upstream investigation (or synthesis) report, and an action memo describing what automated remediating agents decided and did.
+
+The investigation often includes a human-facing section (recommendations, remediation, next steps, or similar) — work for operators. The action memo covers only what the action agent could actually execute. Those two tracks are not interchangeable: an automated action does not fulfill a different human recommendation, and a human recommendation does not mean the agent already did it.
+
+Emit a single amended report. Keep the upstream document's own structure, headings, tables, lists, and wording. Fold the action outcome into that document. You are not an investigator and you are not rewriting the report into a new template.
+
+RULES:
+- Emit the upstream report as the body. Preserve its format exactly unless a patch is required below.
+- Fold the action memo in: use an existing actions/status/remediation section if the upstream already has one; otherwise add a short new section in the same style as the rest of the document.
+- Keep both tracks visible. Record what the action agent did (or its decision to take no automated action). Keep human follow-ups from the investigation unless the memo explicitly completed or declined that same item.
+- Patch upstream text as stale only when the memo addresses that same recommendation (done or declined). Do not treat a related-but-different automated action as completing a human follow-up (for example: restarting a pod does not fulfill a recommendation to change a resource limit).
+- Do not invent a TARSy-standard template. Do not improve prose. Do not drop sections. Do not add facts that appear in neither document.
+- Return ONLY the amended report. No preamble, no commentary.
+
+=== USER PROMPT ===
+
+Amend the upstream report with the action outcome.
+
+=== UPSTREAM REPORT ===
+## Findings
+Root cause: OOM kill due to memory leak in pod-1.
+
+## Recommendations
+- Increase memory limit to 1Gi.
+=== END UPSTREAM REPORT ===
+
+=== ACTION MEMO ===
+No action taken. Memory limit change requires a change request.
+=== END ACTION MEMO ===
+
+Amended report:

--- a/pkg/api/system_config.go
+++ b/pkg/api/system_config.go
@@ -85,6 +85,7 @@ type ChainView struct {
 	Scoring                  *ScoringView           `json:"scoring,omitempty"`
 	LLMProvider              string                 `json:"llm_provider,omitempty"`
 	ExecutiveSummaryProvider string                 `json:"executive_summary_provider,omitempty"`
+	ComposeProvider          string                 `json:"compose_provider,omitempty"`
 	LLMBackend               string                 `json:"llm_backend,omitempty"`
 	FallbackProviders        []FallbackProviderView `json:"fallback_providers,omitempty"`
 	MaxIterations            *int                   `json:"max_iterations,omitempty"`
@@ -201,6 +202,7 @@ type SkillMetaView struct {
 // DefaultsView is system-wide defaults.
 type DefaultsView struct {
 	LLMProvider       string                 `json:"llm_provider,omitempty"`
+	ComposeProvider   string                 `json:"compose_provider,omitempty"`
 	MaxIterations     *int                   `json:"max_iterations,omitempty"`
 	LLMBackend        string                 `json:"llm_backend,omitempty"`
 	FallbackProviders []FallbackProviderView `json:"fallback_providers,omitempty"`
@@ -395,6 +397,7 @@ func buildDefaultsView(d *config.Defaults) *DefaultsView {
 	}
 	view := &DefaultsView{
 		LLMProvider:       d.LLMProvider,
+		ComposeProvider:   d.ComposeProvider,
 		MaxIterations:     d.MaxIterations,
 		LLMBackend:        string(d.LLMBackend),
 		FallbackProviders: buildFallbackProviders(d.FallbackProviders),
@@ -638,6 +641,7 @@ func buildChainView(c *config.ChainConfig) ChainView {
 		Scoring:                  buildScoringView(c.Scoring),
 		LLMProvider:              c.LLMProvider,
 		ExecutiveSummaryProvider: c.ExecutiveSummaryProvider,
+		ComposeProvider:          c.ComposeProvider,
 		LLMBackend:               string(c.LLMBackend),
 		FallbackProviders:        buildFallbackProviders(c.FallbackProviders),
 		MaxIterations:            c.MaxIterations,

--- a/pkg/api/system_config_test.go
+++ b/pkg/api/system_config_test.go
@@ -421,8 +421,9 @@ func TestSystemConfigHandler(t *testing.T) {
 		s := &Server{
 			cfg: &config.Config{
 				Defaults: &config.Defaults{
-					LLMProvider:   "google-default",
-					MaxIterations: &maxIter,
+					LLMProvider:     "google-default",
+					ComposeProvider: "google-default",
+					MaxIterations:   &maxIter,
 					LLMBackend:    config.LLMBackendNativeGemini,
 					Summarization: &config.SummarizationConfig{
 						LLMProvider: "google-default",
@@ -466,9 +467,10 @@ func TestSystemConfigHandler(t *testing.T) {
 						},
 					},
 					"alpha-chain": {
-						AlertTypes:  []string{"AlphaAlert"},
-						Description: "A chain",
-						LLMProvider: "google-default",
+						AlertTypes:      []string{"AlphaAlert"},
+						Description:     "A chain",
+						LLMProvider:     "google-default",
+						ComposeProvider: "google-default",
 						Stages: []config.StageConfig{
 							{
 								Name: "investigate",
@@ -495,6 +497,7 @@ func TestSystemConfigHandler(t *testing.T) {
 
 		require.NotNil(t, resp.Defaults)
 		assert.Equal(t, "google-default", resp.Defaults.LLMProvider)
+		assert.Equal(t, "google-default", resp.Defaults.ComposeProvider)
 		require.NotNil(t, resp.Defaults.Summarization)
 		assert.Equal(t, "google-default", resp.Defaults.Summarization.LLMProvider)
 		assert.Equal(t, "langchain", resp.Defaults.Summarization.LLMBackend)
@@ -522,6 +525,7 @@ func TestSystemConfigHandler(t *testing.T) {
 		alpha := resp.Chains["alpha-chain"]
 		assert.Equal(t, []string{"AlphaAlert"}, alpha.AlertTypes)
 		assert.Equal(t, "google-default", alpha.LLMProvider)
+		assert.Equal(t, "google-default", alpha.ComposeProvider)
 		require.Len(t, alpha.Stages, 1)
 		assert.Equal(t, "investigate", alpha.Stages[0].Name)
 		require.NotNil(t, alpha.Chat)

--- a/pkg/api/system_config_test.go
+++ b/pkg/api/system_config_test.go
@@ -424,7 +424,7 @@ func TestSystemConfigHandler(t *testing.T) {
 					LLMProvider:     "google-default",
 					ComposeProvider: "google-default",
 					MaxIterations:   &maxIter,
-					LLMBackend:    config.LLMBackendNativeGemini,
+					LLMBackend:      config.LLMBackendNativeGemini,
 					Summarization: &config.SummarizationConfig{
 						LLMProvider: "google-default",
 						LLMBackend:  config.LLMBackendLangChain,

--- a/pkg/config/builtin.go
+++ b/pkg/config/builtin.go
@@ -39,6 +39,7 @@ const (
 	AgentNameExecSummary = "ExecSummaryAgent"
 	AgentNameSynthesis   = "SynthesisAgent"
 	AgentNameScoring     = "ScoringAgent"
+	AgentNameCompose     = "ComposeAgent"
 )
 
 var (
@@ -80,6 +81,17 @@ func initBuiltinAgents() map[string]BuiltinAgentConfig {
 			Description: "Generates executive summary of the investigation",
 			Type:        AgentTypeExecSummary,
 			// No MCP servers — single-shot, no tools
+		},
+		AgentNameCompose: {
+			Description: "Amends the upstream investigation report with the action outcome",
+			Type:        AgentTypeCompose,
+			// No MCP servers — single-shot. Native tools must be explicitly
+			// off: omitting them inherits Gemini google_search / url_context.
+			NativeTools: map[GoogleNativeTool]bool{
+				GoogleNativeToolGoogleSearch:  false,
+				GoogleNativeToolURLContext:    false,
+				GoogleNativeToolCodeExecution: false,
+			},
 		},
 		AgentNameScoring: {
 			Description: "Evaluates session quality via a multi-turn LLM conversation",

--- a/pkg/config/builtin_test.go
+++ b/pkg/config/builtin_test.go
@@ -104,6 +104,12 @@ func TestBuiltinAgents(t *testing.T) {
 			wantType: AgentTypeExecSummary,
 		},
 		{
+			name:     AgentNameCompose,
+			agentID:  AgentNameCompose,
+			wantDesc: "Amends the upstream investigation report with the action outcome",
+			wantType: AgentTypeCompose,
+		},
+		{
 			name:     AgentNameScoring,
 			agentID:  AgentNameScoring,
 			wantDesc: "Evaluates session quality via a multi-turn LLM conversation",
@@ -169,6 +175,26 @@ func TestBuiltinAgentNativeToolsAndBackend(t *testing.T) {
 		require.True(t, exists)
 		assert.Empty(t, agent.LLMBackend)
 		assert.Nil(t, agent.NativeTools)
+	})
+
+	t.Run("ComposeAgent has native tools explicitly disabled", func(t *testing.T) {
+		agent, exists := cfg.Agents[AgentNameCompose]
+		require.True(t, exists)
+		assert.Equal(t, AgentTypeCompose, agent.Type)
+		assert.Empty(t, agent.MCPServers)
+		require.NotNil(t, agent.NativeTools)
+
+		val, present := agent.NativeTools[GoogleNativeToolGoogleSearch]
+		assert.True(t, present, "GoogleSearch key must be explicitly present")
+		assert.False(t, val)
+
+		val, present = agent.NativeTools[GoogleNativeToolURLContext]
+		assert.True(t, present, "URLContext key must be explicitly present")
+		assert.False(t, val)
+
+		val, present = agent.NativeTools[GoogleNativeToolCodeExecution]
+		assert.True(t, present, "CodeExecution key must be explicitly present")
+		assert.False(t, val)
 	})
 }
 

--- a/pkg/config/chain.go
+++ b/pkg/config/chain.go
@@ -28,6 +28,9 @@ type ChainConfig struct {
 	// LLM provider for executive summary generation (overrides LLMProvider for this purpose)
 	ExecutiveSummaryProvider string `yaml:"executive_summary_provider,omitempty"`
 
+	// LLM provider for compose (amended-report) generation (overrides defaults.compose_provider)
+	ComposeProvider string `yaml:"compose_provider,omitempty"`
+
 	// Chain-level LLM backend override
 	LLMBackend LLMBackend `yaml:"llm_backend,omitempty"`
 

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -6,6 +6,9 @@ type Defaults struct {
 	// LLM provider default for all agents/chains
 	LLMProvider string `yaml:"llm_provider,omitempty"`
 
+	// LLM provider for compose (amended-report) generation. Beats chain.llm_provider.
+	ComposeProvider string `yaml:"compose_provider,omitempty"`
+
 	// Max iterations default (forces conclusion when reached, no pause/resume)
 	MaxIterations *int `yaml:"max_iterations,omitempty" validate:"omitempty,min=1"`
 

--- a/pkg/config/enums.go
+++ b/pkg/config/enums.go
@@ -14,12 +14,14 @@ const (
 	AgentTypeScoring AgentType = "scoring"
 	// AgentTypeAction evaluates findings and executes remediation actions (iterating controller)
 	AgentTypeAction AgentType = "action"
+	// AgentTypeCompose copy-edits an upstream report with an action memo (single-shot)
+	AgentTypeCompose AgentType = "compose"
 )
 
 // IsValid checks if the agent type is valid (empty string is valid — means default).
 func (t AgentType) IsValid() bool {
 	switch t {
-	case AgentTypeDefault, AgentTypeSynthesis, AgentTypeExecSummary, AgentTypeScoring, AgentTypeAction:
+	case AgentTypeDefault, AgentTypeSynthesis, AgentTypeExecSummary, AgentTypeScoring, AgentTypeAction, AgentTypeCompose:
 		return true
 	default:
 		return false

--- a/pkg/config/enums_test.go
+++ b/pkg/config/enums_test.go
@@ -14,8 +14,10 @@ func TestAgentTypeIsValid(t *testing.T) {
 	}{
 		{"default (empty)", AgentTypeDefault, true},
 		{"synthesis", AgentTypeSynthesis, true},
+		{"exec_summary", AgentTypeExecSummary, true},
 		{"scoring", AgentTypeScoring, true},
 		{"action", AgentTypeAction, true},
+		{"compose", AgentTypeCompose, true},
 		{"invalid", AgentType("invalid"), false},
 		{"orchestrator is now invalid", AgentType("orchestrator"), false},
 	}

--- a/pkg/config/validator.go
+++ b/pkg/config/validator.go
@@ -148,6 +148,11 @@ func (v *Validator) validateDefaults() error {
 		return err
 	}
 
+	if defaults.ComposeProvider != "" && (v.cfg.LLMProviderRegistry == nil || !v.cfg.LLMProviderRegistry.Has(defaults.ComposeProvider)) {
+		return NewValidationError("defaults", "", "compose_provider",
+			fmt.Errorf("LLM provider '%s' not found", defaults.ComposeProvider))
+	}
+
 	// Validate fallback providers if specified
 	if err := v.validateFallbackProviders(defaults.FallbackProviders, "defaults", "", "fallback_providers"); err != nil {
 		return err
@@ -291,6 +296,10 @@ func (v *Validator) validateAgents() error {
 		if agent.Type != "" && !agent.Type.IsValid() {
 			return NewValidationError("agent", name, "type", fmt.Errorf("invalid agent type: %s", agent.Type))
 		}
+		// type: compose is executor-only; YAML may not declare it except on the builtin.
+		if agent.Type == AgentTypeCompose && name != AgentNameCompose {
+			return NewValidationError("agent", name, "type", fmt.Errorf("type %q is executor-only and cannot be used in chain YAML", agent.Type))
+		}
 
 		// Validate LLM backend if specified
 		if agent.LLMBackend != "" && !agent.LLMBackend.IsValid() {
@@ -420,6 +429,10 @@ func (v *Validator) validateChains() error {
 			return NewValidationError("chain", chainID, "llm_provider", fmt.Errorf("LLM provider '%s' not found", chain.LLMProvider))
 		}
 
+		if chain.ComposeProvider != "" && !v.cfg.LLMProviderRegistry.Has(chain.ComposeProvider) {
+			return NewValidationError("chain", chainID, "compose_provider", fmt.Errorf("LLM provider '%s' not found", chain.ComposeProvider))
+		}
+
 		// Validate chain-level fallback providers if specified
 		if err := v.validateFallbackProviders(chain.FallbackProviders, "chain", chainID, "fallback_providers"); err != nil {
 			return err
@@ -468,6 +481,9 @@ func (v *Validator) validateStage(chainID string, stageIndex int, stage *StageCo
 		// Validate agent-level type if specified
 		if agentConfig.Type != "" && !agentConfig.Type.IsValid() {
 			return fmt.Errorf("%s: agent '%s' has invalid type: %s", stageRef, agentConfig.Name, agentConfig.Type)
+		}
+		if agentConfig.Type == AgentTypeCompose {
+			return fmt.Errorf("%s: agent '%s' has type %q which is executor-only and cannot be used in chain YAML", stageRef, agentConfig.Name, agentConfig.Type)
 		}
 
 		// Validate agent-level LLM backend if specified
@@ -719,6 +735,9 @@ func (v *Validator) collectReferencedLLMProviders() map[string]bool {
 		if v.cfg.Defaults.Summarization != nil && v.cfg.Defaults.Summarization.LLMProvider != "" {
 			referenced[v.cfg.Defaults.Summarization.LLMProvider] = true
 		}
+		if v.cfg.Defaults.ComposeProvider != "" {
+			referenced[v.cfg.Defaults.ComposeProvider] = true
+		}
 	}
 
 	if v.cfg.MCPServerRegistry != nil {
@@ -738,6 +757,9 @@ func (v *Validator) collectReferencedLLMProviders() map[string]bool {
 		// Chain-level LLM provider
 		if chain.LLMProvider != "" {
 			referenced[chain.LLMProvider] = true
+		}
+		if chain.ComposeProvider != "" {
+			referenced[chain.ComposeProvider] = true
 		}
 
 		// Chain-level fallback providers

--- a/pkg/config/validator_test.go
+++ b/pkg/config/validator_test.go
@@ -92,6 +92,27 @@ func TestValidateAgents(t *testing.T) {
 			errMsg:  "invalid agent type",
 		},
 		{
+			name: "YAML type compose is rejected",
+			agents: map[string]*AgentConfig{
+				"my-agent": {
+					Type: AgentTypeCompose,
+				},
+			},
+			servers: map[string]*MCPServerConfig{},
+			wantErr: true,
+			errMsg:  "executor-only",
+		},
+		{
+			name: "builtin ComposeAgent with type compose is allowed",
+			agents: map[string]*AgentConfig{
+				AgentNameCompose: {
+					Type: AgentTypeCompose,
+				},
+			},
+			servers: map[string]*MCPServerConfig{},
+			wantErr: false,
+		},
+		{
 			name: "agent with invalid LLM backend",
 			agents: map[string]*AgentConfig{
 				"test-agent": {
@@ -318,6 +339,27 @@ func TestValidateChains(t *testing.T) {
 			providers: map[string]*LLMProviderConfig{},
 			wantErr:   true,
 			errMsg:    "LLM provider 'invalid-provider' not found",
+		},
+		{
+			name: "chain with invalid compose_provider",
+			chains: map[string]*ChainConfig{
+				"test-chain": {
+					AlertTypes:      []string{"test"},
+					ComposeProvider: "invalid-compose",
+					Stages: []StageConfig{
+						{
+							Name:   "stage1",
+							Agents: []StageAgentConfig{{Name: "test-agent"}},
+						},
+					},
+				},
+			},
+			agents: map[string]*AgentConfig{
+				"test-agent": {MCPServers: []string{"test"}},
+			},
+			providers: map[string]*LLMProviderConfig{},
+			wantErr:   true,
+			errMsg:    "compose_provider",
 		},
 		{
 			name: "multiple chains with duplicate alert type",
@@ -1287,6 +1329,27 @@ func TestValidateStageComprehensive(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "stage with type compose is rejected",
+			stage: StageConfig{
+				Name: "stage1",
+				Agents: []StageAgentConfig{
+					{
+						Name: "test-agent",
+						Type: AgentTypeCompose,
+					},
+				},
+			},
+			agents: map[string]*AgentConfig{
+				"test-agent": {MCPServers: []string{"test-server"}},
+			},
+			providers: map[string]*LLMProviderConfig{},
+			servers: map[string]*MCPServerConfig{
+				"test-server": {Transport: TransportConfig{Type: TransportTypeStdio, Command: "test"}},
+			},
+			wantErr: true,
+			errMsg:  "executor-only",
+		},
+		{
 			name: "stage with invalid agent LLM backend",
 			stage: StageConfig{
 				Name: "stage1",
@@ -2205,6 +2268,14 @@ func TestValidateDefaults(t *testing.T) {
 			},
 			wantErr: true,
 			errMsg:  "pattern_group is required when alert masking is enabled",
+		},
+		{
+			name: "unknown compose_provider fails",
+			defaults: &Defaults{
+				ComposeProvider: "no-such-provider",
+			},
+			wantErr: true,
+			errMsg:  "compose_provider",
 		},
 	}
 
@@ -3846,7 +3917,8 @@ func TestValidateFallbackProviders(t *testing.T) {
 func TestCollectReferencedLLMProviders_IncludesFallbackAndSubAgents(t *testing.T) {
 	cfg := &Config{
 		Defaults: &Defaults{
-			LLMProvider: "defaults-primary",
+			LLMProvider:     "defaults-primary",
+			ComposeProvider: "defaults-compose",
 			FallbackProviders: []FallbackProviderEntry{
 				{Provider: "defaults-fallback", Backend: LLMBackendNativeGemini},
 			},
@@ -3867,7 +3939,8 @@ func TestCollectReferencedLLMProviders_IncludesFallbackAndSubAgents(t *testing.T
 		}),
 		ChainRegistry: NewChainRegistry(map[string]*ChainConfig{
 			"chain1": {
-				AlertTypes: []string{"test"},
+				AlertTypes:      []string{"test"},
+				ComposeProvider: "chain-compose",
 				FallbackProviders: []FallbackProviderEntry{
 					{Provider: "chain-fallback", Backend: LLMBackendLangChain},
 				},
@@ -3907,9 +3980,11 @@ func TestCollectReferencedLLMProviders_IncludesFallbackAndSubAgents(t *testing.T
 	referenced := validator.collectReferencedLLMProviders()
 
 	assert.True(t, referenced["defaults-primary"], "defaults primary provider should be referenced")
+	assert.True(t, referenced["defaults-compose"], "defaults compose provider should be referenced")
 	assert.True(t, referenced["defaults-fallback"], "defaults fallback provider should be referenced")
 	assert.True(t, referenced["defaults-summarization"], "defaults summarization provider should be referenced")
 	assert.True(t, referenced["mcp-summarization"], "MCP server summarization provider should be referenced")
+	assert.True(t, referenced["chain-compose"], "chain compose provider should be referenced")
 	assert.True(t, referenced["chain-fallback"], "chain fallback provider should be referenced")
 	assert.True(t, referenced["chain-subagent"], "chain sub-agent provider should be referenced")
 	assert.True(t, referenced["chat-subagent"], "chat.sub_agents provider should be referenced")

--- a/web/dashboard/src/types/system.ts
+++ b/web/dashboard/src/types/system.ts
@@ -267,6 +267,7 @@ export interface ChainConfigView {
   scoring?: ScoringView | null;
   llm_provider?: string;
   executive_summary_provider?: string;
+  compose_provider?: string;
   llm_backend?: string;
   fallback_providers?: FallbackProviderView[];
   max_iterations?: number | null;
@@ -305,6 +306,7 @@ export interface MCPSummarizationView extends SummarizationView {
 
 export interface DefaultsView {
   llm_provider?: string;
+  compose_provider?: string;
   max_iterations?: number | null;
   llm_backend?: string;
   fallback_providers?: FallbackProviderView[];


### PR DESCRIPTION
- Add compose agent type, builtin ComposeAgent, and SingleShot controller
- Keep human follow-ups distinct from automated actions in the compose prompt
- Resolve compose_provider so the default beats chain.llm_provider
- Reject YAML type: compose except on the builtin; expose knobs in system config

Phase 1 of the new action agent action/remediation report composer agent/stage implementation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for compose stages that combine investigation reports with action outcomes into amended reports.
  * Added a built-in Compose agent with configurable provider selection.
  * Added `compose_provider` settings to default and chain configurations.
  * Added compose-stage prompt handling while preserving report formatting.
* **Documentation**
  * Documented compose-stage behavior, relationships, configuration, failure handling, and rollout considerations.
* **Validation**
  * Added configuration validation for compose providers and supported agent types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->