### PR TITLE
fix(dashboard): remember Usage filters across tab switches

### DIFF
--- a/web/dashboard/src/pages/UsagePage.tsx
+++ b/web/dashboard/src/pages/UsagePage.tsx
@@ -52,8 +52,13 @@ import { websocketService } from '../services/websocket.ts';
 import { EVENT_SESSION_STATUS } from '../constants/eventTypes.ts';
 import { isTerminalStatus, type SessionStatus } from '../constants/sessionStatus.ts';
 import { formatEstimatedCostUsd, formatTimestamp, formatTokens, formatTokensCompact } from '../utils/format.ts';
+import {
+  loadUsageFiltersFromStorage,
+  saveUsageFiltersToStorage,
+} from '../utils/filterPersistence.ts';
 import { sessionDetailPath } from '../constants/routes.ts';
 import type { UsageRankBy, UsageSummaryResponse } from '../types/api.ts';
+import type { UsagePageFilters } from '../types/dashboard.ts';
 import type { SessionStatusPayload } from '../types/events.ts';
 
 /** Throttle for re-fetching the summary in response to WebSocket session events —
@@ -63,6 +68,61 @@ const WS_REFRESH_THROTTLE_MS = 2000;
 function defaultThirtyDayRange(): { start: Date; end: Date; preset: string } {
   const range = USAGE_TIME_PRESETS.find((p) => p.value === '30d')!.getDateRange();
   return { start: range.start, end: range.end, preset: '30d' };
+}
+
+function parseStoredDate(value: string | null | undefined): Date | null {
+  if (!value) return null;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function rangeFromStoredFilters(saved: UsagePageFilters | null): {
+  start: Date;
+  end: Date;
+  preset: string | null;
+} {
+  const fallback = defaultThirtyDayRange();
+  if (!saved) return fallback;
+
+  if (saved.date_preset) {
+    const preset = USAGE_TIME_PRESETS.find((p) => p.value === saved.date_preset);
+    if (preset) {
+      const range = preset.getDateRange();
+      return { start: range.start, end: range.end, preset: preset.value };
+    }
+  }
+
+  const start = parseStoredDate(saved.start_date);
+  const end = parseStoredDate(saved.end_date);
+  if (start && end && start < end) {
+    return { start, end, preset: null };
+  }
+
+  return fallback;
+}
+
+function parseStoredRankBy(value: unknown): UsageRankBy | undefined {
+  return value === 'cost' || value === 'tokens' ? value : undefined;
+}
+
+function loadInitialUsageView(): {
+  start: Date;
+  end: Date;
+  preset: string | null;
+  alertType: string | null;
+  chainId: string | null;
+  rankBy: UsageRankBy | undefined;
+} {
+  const saved = loadUsageFiltersFromStorage();
+  const range = rangeFromStoredFilters(saved);
+  return {
+    start: range.start,
+    end: range.end,
+    preset: range.preset,
+    alertType: saved?.alert_type ?? null,
+    chainId: saved?.chain_id ?? null,
+    rankBy: parseStoredRankBy(saved?.rank_by),
+  };
 }
 
 /** Explains exactly what "Incomplete" means for a model's priced status. */
@@ -88,16 +148,27 @@ function unpricedCostTooltip(tokenCount: number | undefined, interactionCount: n
 }
 
 export function UsagePage() {
-  const initial = defaultThirtyDayRange();
+  const [initial] = useState(loadInitialUsageView);
   const [startDate, setStartDate] = useState<Date>(initial.start);
   const [endDate, setEndDate] = useState<Date>(initial.end);
   const [datePreset, setDatePreset] = useState<string | null>(initial.preset);
   const [timeRangeOpen, setTimeRangeOpen] = useState(false);
 
-  const [alertType, setAlertType] = useState<string | null>(null);
-  const [chainId, setChainId] = useState<string | null>(null);
+  const [alertType, setAlertType] = useState<string | null>(initial.alertType);
+  const [chainId, setChainId] = useState<string | null>(initial.chainId);
   /** Undefined = let the server pick the default (cost when enabled, else tokens). */
-  const [rankBy, setRankBy] = useState<UsageRankBy | undefined>(undefined);
+  const [rankBy, setRankBy] = useState<UsageRankBy | undefined>(initial.rankBy);
+
+  useEffect(() => {
+    saveUsageFiltersToStorage({
+      date_preset: datePreset,
+      start_date: datePreset ? null : startDate.toISOString(),
+      end_date: datePreset ? null : endDate.toISOString(),
+      alert_type: alertType,
+      chain_id: chainId,
+      rank_by: rankBy,
+    });
+  }, [startDate, endDate, datePreset, alertType, chainId, rankBy]);
 
   const [alertTypeOptions, setAlertTypeOptions] = useState<string[]>([]);
   const [chainIdOptions, setChainIdOptions] = useState<string[]>([]);

--- a/web/dashboard/src/test/pages/UsagePage.test.tsx
+++ b/web/dashboard/src/test/pages/UsagePage.test.tsx
@@ -133,6 +133,7 @@ function renderUsagePage() {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  localStorage.clear();
   mockGetFilterOptions.mockResolvedValue({
     alert_types: ['kubernetes'],
     chain_ids: ['default'],
@@ -171,6 +172,128 @@ describe('UsagePage', () => {
     expect(screen.getByRole('button', { name: 'Select time range' })).toHaveTextContent(
       'Last 30 days',
     );
+  });
+
+  it('restores a saved time preset and filters from localStorage', async () => {
+    localStorage.setItem(
+      'tarsy-usage-filters',
+      JSON.stringify({
+        date_preset: '7d',
+        start_date: null,
+        end_date: null,
+        alert_type: 'kubernetes',
+        chain_id: 'default',
+        rank_by: 'tokens',
+      }),
+    );
+    mockGetUsageSummary.mockResolvedValue(makeSummary({ rank_by: 'tokens' }));
+
+    renderUsagePage();
+
+    await waitFor(() => {
+      expect(mockGetUsageSummary).toHaveBeenCalled();
+    });
+
+    const params = mockGetUsageSummary.mock.calls[0][0];
+    const start = new Date(params.start_date).getTime();
+    const end = new Date(params.end_date).getTime();
+    const dayMs = 24 * 60 * 60 * 1000;
+    expect(end - start).toBeGreaterThan(6 * dayMs);
+    expect(end - start).toBeLessThan(8 * dayMs);
+    expect(params.alert_type).toBe('kubernetes');
+    expect(params.chain_id).toBe('default');
+    expect(params.rank_by).toBe('tokens');
+
+    expect(screen.getByRole('button', { name: 'Select time range' })).toHaveTextContent(
+      'Last 7 days',
+    );
+    expect(screen.getByRole('combobox', { name: 'Alert type' })).toHaveValue('kubernetes');
+    expect(screen.getByRole('combobox', { name: 'Chain' })).toHaveValue('default');
+  });
+
+  it('restores a custom date range from localStorage', async () => {
+    localStorage.setItem(
+      'tarsy-usage-filters',
+      JSON.stringify({
+        date_preset: null,
+        start_date: '2026-01-01T00:00:00.000Z',
+        end_date: '2026-01-15T00:00:00.000Z',
+        alert_type: null,
+        chain_id: null,
+      }),
+    );
+    mockGetUsageSummary.mockResolvedValue(makeSummary());
+
+    renderUsagePage();
+
+    await waitFor(() => {
+      expect(mockGetUsageSummary).toHaveBeenCalled();
+    });
+
+    const params = mockGetUsageSummary.mock.calls[0][0];
+    expect(params.start_date).toBe('2026-01-01T00:00:00.000Z');
+    expect(params.end_date).toBe('2026-01-15T00:00:00.000Z');
+  });
+
+  it('falls back to 30d when the stored preset is unknown', async () => {
+    localStorage.setItem(
+      'tarsy-usage-filters',
+      JSON.stringify({
+        date_preset: 'not-a-real-preset',
+        start_date: null,
+        end_date: null,
+        alert_type: null,
+        chain_id: null,
+      }),
+    );
+    mockGetUsageSummary.mockResolvedValue(makeSummary());
+
+    renderUsagePage();
+
+    await waitFor(() => {
+      expect(mockGetUsageSummary).toHaveBeenCalled();
+    });
+
+    expect(screen.getByRole('button', { name: 'Select time range' })).toHaveTextContent(
+      'Last 30 days',
+    );
+  });
+
+  it('persists the time range across remounts', async () => {
+    const user = userEvent.setup();
+    mockGetUsageSummary.mockResolvedValue(makeSummary());
+
+    const { unmount } = renderUsagePage();
+    await screen.findByText('Totals');
+
+    await user.click(screen.getByRole('button', { name: 'Select time range' }));
+    await user.click(await screen.findByRole('button', { name: 'Last 7 days' }));
+    await user.click(screen.getByRole('button', { name: 'Apply Filter' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Select time range' })).toHaveTextContent(
+        'Last 7 days',
+      );
+    });
+
+    unmount();
+    mockGetUsageSummary.mockClear();
+    mockGetUsageSummary.mockResolvedValue(makeSummary());
+
+    renderUsagePage();
+
+    await waitFor(() => {
+      expect(mockGetUsageSummary).toHaveBeenCalled();
+    });
+    expect(screen.getByRole('button', { name: 'Select time range' })).toHaveTextContent(
+      'Last 7 days',
+    );
+    const params = mockGetUsageSummary.mock.calls[0][0];
+    const start = new Date(params.start_date).getTime();
+    const end = new Date(params.end_date).getTime();
+    const dayMs = 24 * 60 * 60 * 1000;
+    expect(end - start).toBeGreaterThan(6 * dayMs);
+    expect(end - start).toBeLessThan(8 * dayMs);
   });
 
   it('re-fetches when rank_by changes', async () => {

--- a/web/dashboard/src/test/utils/filterPersistence.test.ts
+++ b/web/dashboard/src/test/utils/filterPersistence.test.ts
@@ -20,8 +20,10 @@ import {
   clearAllDashboardState,
   saveTriageFilters,
   loadTriageFilters,
+  saveUsageFiltersToStorage,
+  loadUsageFiltersFromStorage,
 } from '../../utils/filterPersistence';
-import type { SessionFilter, SortState } from '../../types/dashboard';
+import type { SessionFilter, SortState, UsagePageFilters } from '../../types/dashboard';
 
 // ---------------------------------------------------------------------------
 // localStorage mock
@@ -228,6 +230,42 @@ describe('triage filters persistence', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Usage filters persistence
+// ---------------------------------------------------------------------------
+
+describe('usage filters persistence', () => {
+  const filters: UsagePageFilters = {
+    date_preset: '7d',
+    start_date: null,
+    end_date: null,
+    alert_type: 'kubernetes',
+    chain_id: 'default',
+    rank_by: 'tokens',
+  };
+
+  it('round-trips a valid filters object', () => {
+    saveUsageFiltersToStorage(filters);
+    expect(loadUsageFiltersFromStorage()).toEqual(filters);
+  });
+
+  it('returns null when nothing saved', () => {
+    expect(loadUsageFiltersFromStorage()).toBeNull();
+  });
+
+  it('returns null for corrupted JSON', () => {
+    localStorageMock.setItem('tarsy-usage-filters', '{broken');
+    expect(loadUsageFiltersFromStorage()).toBeNull();
+  });
+
+  it('silently handles storage errors on save', () => {
+    localStorageMock.setItem.mockImplementationOnce(() => {
+      throw new Error('QuotaExceededError');
+    });
+    expect(() => saveUsageFiltersToStorage(filters)).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // clearAllDashboardState
 // ---------------------------------------------------------------------------
 
@@ -237,6 +275,13 @@ describe('clearAllDashboardState', () => {
     savePaginationToStorage({ page: 5 });
     saveSortToStorage({ field: 'created_at', direction: 'desc' });
     saveTriageFilters({ assignee: 'mine' });
+    saveUsageFiltersToStorage({
+      date_preset: '7d',
+      start_date: null,
+      end_date: null,
+      alert_type: null,
+      chain_id: null,
+    });
 
     clearAllDashboardState();
 
@@ -244,5 +289,6 @@ describe('clearAllDashboardState', () => {
     expect(loadPaginationFromStorage()).toBeNull();
     expect(loadSortFromStorage()).toBeNull();
     expect(loadTriageFilters()).toBeNull();
+    expect(loadUsageFiltersFromStorage()).toBeNull();
   });
 });

--- a/web/dashboard/src/types/dashboard.ts
+++ b/web/dashboard/src/types/dashboard.ts
@@ -38,3 +38,14 @@ export type DashboardTab = 'sessions' | 'triage';
 export interface TriageFilter {
   assignee: 'all' | 'mine' | 'unassigned';
 }
+
+/** Persisted Usage page filters (time window + optional drill-down). */
+export interface UsagePageFilters {
+  /** Preset value (e.g. '7d', 'mtd'); null means a custom start/end. */
+  date_preset: string | null;
+  start_date: string | null; // RFC3339, used when date_preset is null
+  end_date: string | null; // RFC3339, used when date_preset is null
+  alert_type: string | null;
+  chain_id: string | null;
+  rank_by?: 'cost' | 'tokens';
+}

--- a/web/dashboard/src/utils/filterPersistence.ts
+++ b/web/dashboard/src/utils/filterPersistence.ts
@@ -1,8 +1,8 @@
 /**
- * localStorage persistence for dashboard filter, pagination, and sort state.
+ * localStorage persistence for dashboard filter, pagination, sort, and Usage page state.
  */
 
-import type { SessionFilter, PaginationState, SortState, TriageFilter } from '../types/dashboard.ts';
+import type { SessionFilter, PaginationState, SortState, TriageFilter, UsagePageFilters } from '../types/dashboard.ts';
 
 // Storage keys
 const FILTER_KEY = 'tarsy-filters';
@@ -10,6 +10,7 @@ const PAGINATION_KEY = 'tarsy-pagination';
 const SORT_KEY = 'tarsy-sort';
 const DASHBOARD_TAB_KEY = 'tarsy-dashboard-tab';
 const TRIAGE_FILTERS_KEY = 'tarsy-triage-filters';
+const USAGE_FILTERS_KEY = 'tarsy-usage-filters';
 
 // ────────────────────────────────────────────────────────────
 // Defaults
@@ -143,6 +144,7 @@ export function clearAllDashboardState(): void {
     localStorage.removeItem(SORT_KEY);
     localStorage.removeItem(DASHBOARD_TAB_KEY);
     localStorage.removeItem(TRIAGE_FILTERS_KEY);
+    localStorage.removeItem(USAGE_FILTERS_KEY);
   } catch {
     // ignore
   }
@@ -170,6 +172,28 @@ export function loadTriageFilters(): TriageFilter | null {
     if (raw) return JSON.parse(raw) as TriageFilter;
   } catch {
     // ignore
+  }
+  return null;
+}
+
+// ────────────────────────────────────────────────────────────
+// Usage page filters
+// ────────────────────────────────────────────────────────────
+
+export function saveUsageFiltersToStorage(filters: UsagePageFilters): void {
+  try {
+    localStorage.setItem(USAGE_FILTERS_KEY, JSON.stringify(filters));
+  } catch {
+    // quota exceeded or private browsing — silently ignore
+  }
+}
+
+export function loadUsageFiltersFromStorage(): UsagePageFilters | null {
+  try {
+    const raw = localStorage.getItem(USAGE_FILTERS_KEY);
+    if (raw) return JSON.parse(raw) as UsagePageFilters;
+  } catch {
+    // corrupted data — ignore
   }
   return null;
 }


### PR DESCRIPTION
- Persist time range, alert type, chain, and ranking in localStorage
- Recompute preset windows on load so rolling ranges stay current


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Usage page filters now persist between visits and remounts.
  * Restores date ranges, custom dates, alert types, chains, and ranking preferences.
  * Invalid or unavailable saved values automatically fall back to safe defaults.

* **Bug Fixes**
  * Improved handling of missing, corrupted, or unavailable saved filter data.
  * Clearing dashboard state now also removes saved Usage page filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->