### PR TITLE
fix(llm-service): retry 429/404/5xx before Go fallback

### DIFF
--- a/docs/proposals/llm-transient-outage-design.md
+++ b/docs/proposals/llm-transient-outage-design.md
@@ -1,0 +1,134 @@
+# Transient LLM Outage Handling
+
+**Status:** Draft — verified against source; no blocking questions  
+**Related:** [ADR-0003](../adr/0003-llm-provider-fallback.md), [ADR-0017](../adr/0017-native-tool-fallback-safety.md)
+
+## Overview
+
+Vertex (and similar providers) sometimes return **intermittent** `404 NOT_FOUND` on publisher models that were succeeding in the same session. Today that does not get a real retry. After two `provider_error`s, Go **demotes the execution for good**, can **walk back to a model that already failed**, and injects the 404 JSON into the **model prompt** (operators already see it on the timeline).
+
+This proposal makes retries absorb short blips, and makes fallback monotonic and less hair-trigger. Sticky fallback for a real outage stays.
+
+## Design Principles
+
+1. **HTTP-level retry before fallback.** Same request, no conversation mutation, no extra “please try again” turn.
+2. **Fallback is a demotion, not a search.** Never retry a provider this execution already left.
+3. **“Consecutive” means consecutive.** A success in between resets the streak.
+4. **Operators keep seeing errors; the model does not.** Keep today’s timeline/UI events. Do not put provider-error text into LLM messages. Exception: mid-stream **partial output** still goes into the next prompt so the model can continue (without the error JSON).
+5. **v1 is surgical.** No circuit breaker, no probing the primary, no new YAML.
+
+## Current gaps (why a partial outage cascaded)
+
+Python already has a 3-attempt loop (`MAX_RETRIES = 3`, `delay = 2 ** attempt` including a sleep after the last failed attempt). LangChain only raises `_RetryableError` for **timeout** and **empty response**. google-native also retries typed `ServerError` (5xx). A Vertex `404` is a normal `Exception` / `ClientError` → immediate `provider_error` / `retryable=false`.
+
+SDK `max_retries=0` on Anthropic / Vertex Claude / OpenAI constructors; TARSy’s loop is the retry. Prompt cache does **not** disable that loop: it sits **inside** each `cache_degrade_sequence` variant, so a 404 with cache markers on is retried with the same markers. Cache `400` is a different path (`is_bad_request` → strip TTL, then strip markers) and must stay that way.
+
+Go then:
+
+- Counts `provider_error` toward fallback **without resetting on success**. `IterationState.RecordSuccess()` (already called after a good Generate) only clears timeout-abort tracking. `FallbackState.resetCounters()` runs only after a **successful provider switch**.
+- On the first miss (`tryFallback` returns false), **appends the full error** via `buildRetryMessage` + `storeObservationMessage`. That user turn is resent on the next Generate. Timeline already has `EventTypeError`. The fallback path (`tryFallback` true → `continue`) does **not** append — so classified `max_retries` already avoids the blob.
+- Skips fallback entries only when `candidate.ProviderName ==` the *current* provider ([ADR-0017](../adr/0017-native-tool-fallback-safety.md) native-tool skip is separate and stays). `AttemptedProviders` already records the chain (primary starts in the list) but is not used for skip.
+
+Fallback then **sticks** for the rest of the execution (ADR-0003 Q1). That is still right for a sustained outage; it is wrong as the *first* reaction to a 10–30s blip.
+
+Go’s same-provider retry `continue`s the iterating `for` and **consumes a max-iterations slot**. Python retries do not. That is why HTTP retry belongs in Python.
+
+## How it works
+
+```
+Generate (0 chunks yet)
+  ├─ 429 / 404 / 5xx → Python _RetryableError, 3× backoff
+  │     success → done (Go never sees a failure)
+  │     exhausted → ErrorInfo code=max_retries → Go fallback immediately
+  ├─ cache 400 → existing degrade (unchanged; not an identical retry)
+  └─ other 4xx (400/401/403/…) / unknown → provider_error (unchanged)
+
+Go iterating, on LLM error:
+  ├─ max_retries / credentials → fallback now (no prompt append; already true today)
+  ├─ no-partial provider_error / invalid_request / transport / initial_timeout
+  │     → EventTypeError as today; do NOT append to messages / DB conversation
+  │     → 2nd consecutive → fallback
+  ├─ partial_stream / stall with PartialText → continue-from-here + truncated text only
+  ├─ loop detection → keep today’s instructional nudge (not an error dump)
+  ├─ empty-response nudge → unchanged
+  ├─ success → fbState.resetCounters()
+  └─ fallback skip: name already in AttemptedProviders (including primary);
+        keep RequiresNativeTools skip
+```
+
+### Python (LangChain + google-native)
+
+Raise `_RetryableError` when **no chunks have been yielded** and the error is HTTP **429, 404, or 5xx**.
+
+Do **not** treat all google-native `ClientError` like `ServerError`. `ServerError` is 5xx by type; `ClientError` is **all 4xx**. Catch `ClientError` and retry only when the status is 429 or 404.
+
+Status extraction cannot copy `prompt_cache.is_bad_request` as-is (`status_code` / `status == 400`). Vertex Claude 404s are Anthropic-shaped (`Error code: 404 - [{'error': ...}]`). google-genai uses `.code` (int) and `.status` (`NOT_FOUND`, not `404`). Walk `__cause__` / `__context__` and take the first HTTP-like int from:
+
+- `status_code`, `code` (if int), `status` (if int)
+- nested `response.status_code`
+- otherwise parse `Error code: NNN` in `str(err)` (covers wrapped SDK errors with no attributes)
+
+| Status | Retry? |
+|---|---|
+| 429, 404, 5xx | yes (any provider) |
+| 400 | no identical retry (cache 400 still degrades) |
+| 401 / 403 | no |
+
+Keep `MAX_RETRIES = 3` and existing backoff. A permanently missing model ID waits the current extra sleep window, then `max_retries` → fallback.
+
+After those retries fail, yield `code=max_retries` (not `provider_error`) so Go matches ADR-0003: “Python already retried 3× → fallback immediately.” The `for`/`else` in `langchain_provider.py` / `google_native.py` already does this once the error is `_RetryableError`.
+
+### Go fallback
+
+**Skip already attempted names.** `AttemptedProviders` already records the chain; use it in the `tryFallback` (and `nextSummarizationFallback`) skip loop. Primary starts in that list, so if it also appears later in `fallback_providers` it is not selected again. Native-tool incompatible skip unchanged; those names stay out of `AttemptedProviders`.
+
+**Reset counters on success.** After a successful `callLLMWithStreaming` in `iterating.go`, call `fbState.resetCounters()`. Do not confuse this with `IterationState.RecordSuccess()`. Scoring and single-shot already use `SingleShot` (threshold 1), so reset is optional there. `forceConclusion` shares the iterating `fbState` and has **no** same-provider retry today (fallback-or-fail). After PR 1, 404/429/5xx arrive as `max_retries` and fallback immediately even with counters at 0.
+
+**Show errors to users, not to the model.** Do not add or remove timeline events:
+
+| What happened | Timeline / UI today | v1 |
+|---|---|---|
+| Python retry then success | nothing | unchanged |
+| First Go no-partial error | `EventTypeError` | keep event; **stop** `buildRetryMessage` / `storeObservationMessage` / `messages` append |
+| Fallback switch | `EventTypeProviderFallback` + execution record + dashboard chip; **no** extra `EventTypeError` on that call | unchanged |
+| Summarization failover | log + `summarization_fallback` metadata; no `provider_fallback` event | unchanged |
+
+Prompt injection to **keep**: loop instructional nudge; empty-response “please provide a response”; truncated **partial text** (“continue from where you left off”) **without** `poe.Cause` / publisher-model JSON.
+
+`forceConclusion` / single-shot / scoring already do not call `buildRetryMessage`.
+
+Sticky-for-execution is unchanged.
+
+## Core concepts
+
+- **Python retry** — repeat the same Generate inside the LLM service. Go never sees a failure if it succeeds.
+- **Go same-provider retry** — `continue` with unchanged messages. Operators still get `EventTypeError`. Burns one iterating slot.
+- **Attempted set** — providers this execution has already used; fallback only moves forward.
+
+## Implementation plan
+
+### PR 1 — Python: retry 429 / 404 / 5xx - DONE
+
+- Shared status helper (or small sibling of `is_bad_request`): 429 / 404 / 5xx via the walk above.
+- `langchain_provider.py`: in the `except Exception` path, if `chunks_yielded == 0` and status matches, raise `_RetryableError` (after the cache-400 degrade check, so 400 still degrades).
+- `google_native.py`: retry `ClientError` only for 429/404; `ServerError` stays as today.
+- Exhausted `_RetryableError` → existing `max_retries`.
+- Tests: 404 retries then succeeds (`status_code=404`, `.code=404`, and message-only `Error code: 404 - ...`); 429 retries; exhausted 404 yields `max_retries`; 400 does not enter this loop (cache degrade unchanged); 401/403 do not retry; google-native `ClientError(400)` does not retry; no retry after chunks yielded.
+
+**Gap until PR 2:** Go can still ping-pong and demote on non-adjacent unclassified `provider_error`s. A classified 404 that exhausts Python retries already avoids the prompt blob (`max_retries` → `tryFallback` → `continue`).
+
+### PR 2 — Go: monotonic fallback, reset-on-success, no error-in-prompt
+
+- `fallback.go`: skip names in `AttemptedProviders`. Keep native-tool skip. Same attempted-name skip in `nextSummarizationFallback` (today only skips the walk’s start name via `inUseName`).
+- `iterating.go`: `fbState.resetCounters()` after a successful LLM call.
+- `iterating.go`: skip `buildRetryMessage` / observation append for no-partial errors; keep `EventTypeError` + `provider_fallback`. For `PartialText != ""`, append continue-from-here + truncated text only.
+- Tests: ping-pong skipped; success then one `provider_error` does not fallback; two in a row still does; **timeline still has the error/fallback events**; messages after a 404 retry contain no `Publisher model` blob; partial retry still contains the truncated text.
+- Touch ADR-0003: Python *does* retry 429/404/5xx (then `max_retries`); skip is “already attempted,” not only “same as current”; consecutive resets on success. ADR-0017 skip line: attempted set, not only current name.
+
+e2e: not required in PR 1; optional in PR 2 if an existing fallback fixture can assert skip-already-tried. No new Testcontainers scenario unless a unit test cannot cover skip + conversation.
+
+## Later (not v1)
+
+- **Probe / unstick.** After N successful fallback turns (or a cooldown), try the original primary once. ADR Q1 assumed outages last longer than one execution; a short blip within one session shows the opposite. Easy to oscillate — design separately.
+- **Process-wide circuit breaker.** If a primary 404s twice in ~60s, skip it for ~2 minutes on *all* executions in this replica so a second sub-agent does not rediscover the same blip. Needs shared in-process state + clock.
+- **Do not stick on transient 404.** Only stick on `max_retries` after a long fail, or credentials. Weaker than a probe; still a behavior change to Q1.

--- a/llm-service/llm/providers/google_native.py
+++ b/llm-service/llm/providers/google_native.py
@@ -13,6 +13,7 @@ from google.genai import types as genai_types
 
 from llm_proto import llm_service_pb2 as pb
 from llm.providers.base import LLMProvider
+from llm.providers.http_status import is_retryable_http
 from llm.providers.tool_names import tool_name_to_api, tool_name_from_api
 
 logger = logging.getLogger(__name__)
@@ -567,6 +568,13 @@ class GoogleNativeProvider(LLMProvider):
         except genai_errors.ServerError as exc:
             # 5xx errors from Google API are transient and should be retried
             raise _RetryableError(f"[{request_id}] Google API server error: {exc}") from exc
+
+        except genai_errors.ClientError as exc:
+            if is_retryable_http(exc):
+                raise _RetryableError(
+                    f"[{request_id}] Google API client error: {exc}",
+                ) from exc
+            raise
 
         except asyncio.TimeoutError as exc:
             raise _RetryableError(f"[{request_id}] Generation timed out after {timeout_seconds}s") from exc

--- a/llm-service/llm/providers/http_status.py
+++ b/llm-service/llm/providers/http_status.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from collections import deque
 from typing import Optional
 
 _HTTP_MIN = 100
@@ -20,8 +21,11 @@ def _http_status(value: object) -> Optional[int]:
 def extract_http_status(err: BaseException) -> Optional[int]:
     """First HTTP status found on err or its cause/context chain."""
     seen: set[int] = set()
-    current: Optional[BaseException] = err
-    while current is not None and id(current) not in seen:
+    pending: deque[BaseException] = deque([err])
+    while pending:
+        current = pending.popleft()
+        if id(current) in seen:
+            continue
         seen.add(id(current))
         for attr in ("status_code", "code", "status"):
             status = _http_status(getattr(current, attr, None))
@@ -37,7 +41,10 @@ def extract_http_status(err: BaseException) -> Optional[int]:
             status = _http_status(int(match.group(1)))
             if status is not None:
                 return status
-        current = current.__cause__ or current.__context__
+        if current.__cause__ is not None:
+            pending.append(current.__cause__)
+        if current.__context__ is not None:
+            pending.append(current.__context__)
     return None
 
 

--- a/llm-service/llm/providers/http_status.py
+++ b/llm-service/llm/providers/http_status.py
@@ -1,0 +1,49 @@
+"""HTTP status extraction for classifying provider errors as retryable."""
+
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+_HTTP_MIN = 100
+_HTTP_MAX = 599
+_ERROR_CODE_RE = re.compile(r"Error code:\s*(\d+)")
+_RETRYABLE_EXACT = {429, 404}
+
+
+def _http_status(value: object) -> Optional[int]:
+    if isinstance(value, int) and not isinstance(value, bool) and _HTTP_MIN <= value <= _HTTP_MAX:
+        return value
+    return None
+
+
+def extract_http_status(err: BaseException) -> Optional[int]:
+    """First HTTP status found on err or its cause/context chain."""
+    seen: set[int] = set()
+    current: Optional[BaseException] = err
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        for attr in ("status_code", "code", "status"):
+            status = _http_status(getattr(current, attr, None))
+            if status is not None:
+                return status
+        response = getattr(current, "response", None)
+        if response is not None:
+            status = _http_status(getattr(response, "status_code", None))
+            if status is not None:
+                return status
+        match = _ERROR_CODE_RE.search(str(current))
+        if match:
+            status = _http_status(int(match.group(1)))
+            if status is not None:
+                return status
+        current = current.__cause__ or current.__context__
+    return None
+
+
+def is_retryable_http(err: BaseException) -> bool:
+    """True for HTTP 429, 404, or 5xx — safe to retry with the same request."""
+    status = extract_http_status(err)
+    if status is None:
+        return False
+    return status in _RETRYABLE_EXACT or 500 <= status <= 599

--- a/llm-service/llm/providers/langchain_provider.py
+++ b/llm-service/llm/providers/langchain_provider.py
@@ -26,6 +26,7 @@ from langchain_core.messages import (
 from llm_proto import llm_service_pb2 as pb
 from llm.providers import prompt_cache
 from llm.providers.base import LLMProvider
+from llm.providers.http_status import is_retryable_http
 from llm.providers.tool_names import tool_name_to_api, tool_name_from_api
 from llm.providers.usage import (
     extract_anthropic_raw_input,
@@ -480,6 +481,17 @@ class LangChainProvider(LLMProvider):
                         )
                         last_error = e
                         break
+                    if chunks_yielded == 0 and is_retryable_http(e):
+                        last_error = _RetryableError(
+                            f"[{request_id}] Transient HTTP error: {e}",
+                        )
+                        delay = RETRY_BACKOFF_BASE ** attempt
+                        logger.warning(
+                            "[%s] Retryable error (attempt %d/%d), retrying in %ds: %s",
+                            request_id, attempt + 1, MAX_RETRIES, delay, last_error,
+                        )
+                        await asyncio.sleep(delay)
+                        continue
                     logger.exception("[%s] Non-retryable error", request_id)
                     yield pb.GenerateResponse(
                         error=pb.ErrorInfo(

--- a/llm-service/tests/test_google_native.py
+++ b/llm-service/tests/test_google_native.py
@@ -3,6 +3,7 @@ import json
 import os
 import pytest
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
+from google.genai import errors as genai_errors
 from google.genai import types as genai_types
 
 from llm_proto import llm_service_pb2 as pb
@@ -866,6 +867,109 @@ class TestGoogleNativeProvider:
         assert responses[1].HasField("error")
         assert responses[1].error.code == "partial_stream_error"
         assert responses[1].is_final
+
+    @staticmethod
+    def _client_error(code, message="not found"):
+        status = {
+            400: "INVALID_ARGUMENT",
+            401: "UNAUTHENTICATED",
+            403: "PERMISSION_DENIED",
+            404: "NOT_FOUND",
+            429: "RESOURCE_EXHAUSTED",
+        }.get(code, "UNKNOWN")
+        return genai_errors.ClientError(
+            code, {"message": message, "status": status, "code": code},
+        )
+
+    @staticmethod
+    def _text_chunk(text):
+        mock_part = MagicMock()
+        mock_part.thought = False
+        mock_part.text = text
+        mock_part.function_call = None
+        mock_part.executable_code = None
+        mock_part.code_execution_result = None
+        mock_candidate = MagicMock()
+        mock_candidate.content = MagicMock()
+        mock_candidate.content.parts = [mock_part]
+        mock_candidate.grounding_metadata = None
+        mock_chunk = MagicMock()
+        mock_chunk.candidates = [mock_candidate]
+        mock_chunk.usage_metadata = None
+        return mock_chunk
+
+    @staticmethod
+    def _generate_request():
+        return pb.GenerateRequest(
+            session_id="sess-1",
+            execution_id="exec-1",
+            llm_config=pb.LLMConfig(
+                backend="google-native",
+                model="gemini-2.5-pro",
+                api_key_env="TEST_API_KEY",
+            ),
+            messages=[pb.ConversationMessage(role="user", content="Hi")],
+        )
+
+    @pytest.mark.asyncio
+    @patch.dict(os.environ, {"TEST_API_KEY": "test-key-123"})
+    @patch("llm.providers.google_native.genai.Client")
+    @patch("asyncio.sleep", new_callable=AsyncMock)
+    @pytest.mark.parametrize("code", [404, 429])
+    async def test_generate_retries_on_client_error_then_succeeds(
+        self, mock_sleep, mock_client_class, code, provider,
+    ):
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+        call_count = {"n": 0}
+        good = self._text_chunk("Success after retry")
+
+        async def good_stream():
+            yield good
+
+        async def side_effect(*args, **kwargs):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise self._client_error(code)
+            return good_stream()
+
+        mock_client.aio.models.generate_content_stream = AsyncMock(side_effect=side_effect)
+
+        responses = []
+        async for resp in provider.generate(self._generate_request()):
+            responses.append(resp)
+
+        assert call_count["n"] == 2
+        text_responses = [r for r in responses if r.HasField("text")]
+        assert len(text_responses) == 1
+        assert text_responses[0].text.content == "Success after retry"
+
+    @pytest.mark.asyncio
+    @patch.dict(os.environ, {"TEST_API_KEY": "test-key-123"})
+    @patch("llm.providers.google_native.genai.Client")
+    @pytest.mark.parametrize("code", [400, 401, 403])
+    async def test_generate_client_error_4xx_does_not_retry(
+        self, mock_client_class, code, provider,
+    ):
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+        call_count = {"n": 0}
+
+        async def side_effect(*args, **kwargs):
+            call_count["n"] += 1
+            raise self._client_error(code, message="client failure")
+
+        mock_client.aio.models.generate_content_stream = AsyncMock(side_effect=side_effect)
+
+        responses = []
+        async for resp in provider.generate(self._generate_request()):
+            responses.append(resp)
+
+        assert call_count["n"] == 1
+        assert len(responses) == 1
+        assert responses[0].HasField("error")
+        assert responses[0].error.code == "provider_error"
+        assert responses[0].is_final
 
 
 class TestStreamPartTypes:

--- a/llm-service/tests/test_http_status.py
+++ b/llm-service/tests/test_http_status.py
@@ -1,0 +1,89 @@
+"""Tests for HTTP status extraction used by provider retries."""
+
+import pytest
+
+from llm.providers import http_status
+
+pytestmark = pytest.mark.unit
+
+
+def _exc(*, message="err", status_code=None, code=None, status=None, response_status=None):
+    err = Exception(message)
+    if status_code is not None:
+        err.status_code = status_code
+    if code is not None:
+        err.code = code
+    if status is not None:
+        err.status = status
+    if response_status is not None:
+        err.response = type("Resp", (), {"status_code": response_status})()
+    return err
+
+
+class TestExtractHttpStatus:
+    @pytest.mark.parametrize(
+        "err,expected",
+        [
+            (_exc(status_code=404), 404),
+            (_exc(code=404, status="NOT_FOUND"), 404),
+            (_exc(message="Error code: 404 - [{'error': {'message': 'not found'}}]"), 404),
+            (_exc(status_code=429), 429),
+            (_exc(status_code=503), 503),
+            (_exc(status_code=400), 400),
+            (_exc(status_code=401), 401),
+            (_exc(status_code=403), 403),
+            (_exc(response_status=404), 404),
+            (_exc(code=5, message="Error code: 404 - [{'error': ...}]"), 404),
+            (_exc(status="NOT_FOUND"), None),
+            (RuntimeError("timeout"), None),
+        ],
+        ids=[
+            "status_code_404",
+            "code_attr_404",
+            "message_only_404",
+            "status_code_429",
+            "status_code_503",
+            "status_code_400",
+            "status_code_401",
+            "status_code_403",
+            "nested_response",
+            "skip_grpc_code",
+            "string_not_found",
+            "plain_runtime",
+        ],
+    )
+    def test_extract(self, err, expected):
+        assert http_status.extract_http_status(err) == expected
+
+    def test_walks_cause(self):
+        inner = _exc(status_code=404)
+        wrapped = RuntimeError("outer")
+        wrapped.__cause__ = inner
+        assert http_status.extract_http_status(wrapped) == 404
+
+
+class TestIsRetryableHttp:
+    @pytest.mark.parametrize(
+        "err,expected",
+        [
+            (_exc(status_code=404), True),
+            (_exc(code=404, status="NOT_FOUND"), True),
+            (_exc(message="Error code: 404 - [{'error': ...}]"), True),
+            (_exc(status_code=429), True),
+            (_exc(status_code=503), True),
+            (_exc(status_code=500), True),
+            (_exc(status_code=400), False),
+            (_exc(status_code=401), False),
+            (_exc(status_code=403), False),
+            (_exc(status="NOT_FOUND"), False),
+            (RuntimeError("timeout"), False),
+        ],
+    )
+    def test_retryable(self, err, expected):
+        assert http_status.is_retryable_http(err) is expected
+
+    def test_wrapped_404_is_retryable(self):
+        inner = _exc(message="Error code: 404 - [{'error': ...}]")
+        wrapped = RuntimeError("outer")
+        wrapped.__cause__ = inner
+        assert http_status.is_retryable_http(wrapped)

--- a/llm-service/tests/test_http_status.py
+++ b/llm-service/tests/test_http_status.py
@@ -61,6 +61,14 @@ class TestExtractHttpStatus:
         wrapped.__cause__ = inner
         assert http_status.extract_http_status(wrapped) == 404
 
+    @pytest.mark.parametrize("status", [404, 429, 503])
+    def test_walks_context_when_cause_has_no_status(self, status):
+        wrapped = RuntimeError("outer")
+        wrapped.__cause__ = RuntimeError("unclassified")
+        wrapped.__context__ = _exc(status_code=status)
+        assert http_status.extract_http_status(wrapped) == status
+        assert http_status.is_retryable_http(wrapped)
+
 
 class TestIsRetryableHttp:
     @pytest.mark.parametrize(

--- a/llm-service/tests/test_langchain_provider.py
+++ b/llm-service/tests/test_langchain_provider.py
@@ -942,6 +942,193 @@ class TestLangChainProviderGenerate:
             assert "Something unexpected" in responses[0].error.message
             assert responses[0].is_final
 
+    @staticmethod
+    def _http_exc(*, status_code=None, code=None, status=None, message="not found"):
+        exc = Exception(message)
+        if status_code is not None:
+            exc.status_code = status_code
+        if code is not None:
+            exc.code = code
+        if status is not None:
+            exc.status = status
+        return exc
+
+    @staticmethod
+    def _fail_then_ok_model(exc, fail_times=1):
+        call_count = {"n": 0}
+        chunk = AIMessageChunk(content="Success after retry")
+        chunk.usage_metadata = None
+
+        class MockModel:
+            def astream(self, messages):
+                call_count["n"] += 1
+                if call_count["n"] <= fail_times:
+                    async def boom(_messages=messages):
+                        raise exc
+                        yield
+                    return boom()
+
+                async def good(_messages=messages):
+                    yield chunk
+                return good()
+
+        return MockModel(), call_count
+
+    @staticmethod
+    def _openai_request(**kwargs):
+        return pb.GenerateRequest(
+            session_id="sess-1",
+            execution_id="exec-1",
+            llm_config=pb.LLMConfig(
+                backend="langchain",
+                provider="openai",
+                model="o4-mini",
+                api_key_env="TEST_KEY",
+            ),
+            messages=[pb.ConversationMessage(role="user", content="Hi")],
+            **kwargs,
+        )
+
+    @pytest.mark.asyncio
+    @patch.dict(os.environ, {"TEST_KEY": "test-value"})
+    @patch("asyncio.sleep", new_callable=AsyncMock)
+    @pytest.mark.parametrize(
+        "exc_kwargs",
+        [
+            {"status_code": 404},
+            {"code": 404, "status": "NOT_FOUND"},
+            {"message": "Error code: 404 - [{'error': {'message': 'Publisher model not found'}}]"},
+        ],
+        ids=["status_code", "code_attr", "message_only"],
+    )
+    async def test_generate_retries_on_404_then_succeeds(self, mock_sleep, exc_kwargs, provider):
+        model, call_count = self._fail_then_ok_model(self._http_exc(**exc_kwargs))
+        with patch.object(provider, "_get_or_create_model", return_value=model):
+            responses = []
+            async for resp in provider.generate(self._openai_request()):
+                responses.append(resp)
+
+        assert call_count["n"] == 2
+        text_responses = [r for r in responses if r.HasField("text")]
+        assert len(text_responses) == 1
+        assert text_responses[0].text.content == "Success after retry"
+
+    @pytest.mark.asyncio
+    @patch.dict(os.environ, {"TEST_KEY": "test-value"})
+    @patch("asyncio.sleep", new_callable=AsyncMock)
+    async def test_generate_retries_on_429_then_succeeds(self, mock_sleep, provider):
+        model, call_count = self._fail_then_ok_model(self._http_exc(status_code=429, message="rate limited"))
+        with patch.object(provider, "_get_or_create_model", return_value=model):
+            responses = []
+            async for resp in provider.generate(self._openai_request()):
+                responses.append(resp)
+
+        assert call_count["n"] == 2
+        text_responses = [r for r in responses if r.HasField("text")]
+        assert text_responses[0].text.content == "Success after retry"
+
+    @pytest.mark.asyncio
+    @patch.dict(os.environ, {"TEST_KEY": "test-value"})
+    @patch("asyncio.sleep", new_callable=AsyncMock)
+    async def test_generate_exhausted_404_yields_max_retries(self, mock_sleep, provider):
+        model, call_count = self._fail_then_ok_model(
+            self._http_exc(status_code=404), fail_times=3,
+        )
+        with patch.object(provider, "_get_or_create_model", return_value=model):
+            responses = []
+            async for resp in provider.generate(self._openai_request()):
+                responses.append(resp)
+
+        assert call_count["n"] == 3
+        assert len(responses) == 1
+        assert responses[0].HasField("error")
+        assert responses[0].error.code == "max_retries"
+        assert responses[0].is_final
+
+    @pytest.mark.asyncio
+    @patch.dict(os.environ, {"TEST_KEY": "test-value"})
+    @pytest.mark.parametrize("status", [401, 403])
+    async def test_generate_401_403_does_not_retry(self, status, provider):
+        model, call_count = self._fail_then_ok_model(self._http_exc(status_code=status))
+        with patch.object(provider, "_get_or_create_model", return_value=model):
+            responses = []
+            async for resp in provider.generate(self._openai_request()):
+                responses.append(resp)
+
+        assert call_count["n"] == 1
+        assert responses[0].HasField("error")
+        assert responses[0].error.code == "provider_error"
+        assert responses[0].is_final
+
+    @pytest.mark.asyncio
+    @patch.dict(os.environ, {"TEST_KEY": "test-value"})
+    async def test_generate_no_retry_on_404_after_partial_output(self, provider):
+        call_count = {"n": 0}
+        exc = self._http_exc(status_code=404)
+
+        class MockModel:
+            def astream(self, messages):
+                call_count["n"] += 1
+
+                async def gen():
+                    yield AIMessageChunk(content="Partial data")
+                    raise exc
+                return gen()
+
+        with patch.object(provider, "_get_or_create_model", return_value=MockModel()):
+            responses = []
+            async for resp in provider.generate(self._openai_request()):
+                responses.append(resp)
+
+        assert call_count["n"] == 1
+        assert responses[0].HasField("text")
+        assert responses[0].text.content == "Partial data"
+        assert responses[1].HasField("error")
+        assert responses[1].error.code == "provider_error"
+        assert responses[1].is_final
+
+    @pytest.mark.asyncio
+    @patch.dict(os.environ, {"TEST_KEY": "test-value"})
+    @patch("asyncio.sleep", new_callable=AsyncMock)
+    async def test_404_does_not_degrade_cache_markers(self, mock_sleep, provider):
+        kinds = []
+        attempt = {"n": 0}
+        exc = self._http_exc(status_code=404, message="Publisher model not found")
+
+        def fake_get(config, tools, cache_kind=prompt_cache.NONE, strip_ttl=False, execution_id=""):
+            kinds.append((cache_kind, strip_ttl))
+
+            class Model:
+                def astream(self, messages):
+                    async def gen():
+                        attempt["n"] += 1
+                        if attempt["n"] == 1:
+                            raise exc
+                        chunk = AIMessageChunk(content="ok after 404")
+                        chunk.usage_metadata = None
+                        yield chunk
+                    return gen()
+            return Model()
+
+        with patch.object(provider, "_get_or_create_model", side_effect=fake_get):
+            request = pb.GenerateRequest(
+                session_id="sess-1",
+                execution_id="exec-1",
+                prompt_cache=True,
+                llm_config=pb.LLMConfig(
+                    provider="anthropic", model="claude-sonnet-4-5", api_key_env="TEST_KEY",
+                ),
+                messages=[pb.ConversationMessage(role="user", content="hi")],
+            )
+            texts = []
+            async for resp in provider.generate(request):
+                if resp.HasField("text"):
+                    texts.append(resp.text.content)
+
+        assert kinds == [(prompt_cache.ANTHROPIC, False)]
+        assert attempt["n"] == 2
+        assert texts == ["ok after 404"]
+
 
 def _looping_tool_history():
     return [

--- a/pkg/agent/controller/iterating_test.go
+++ b/pkg/agent/controller/iterating_test.go
@@ -1126,13 +1126,15 @@ func TestIteratingController_NilCollectorSkipsDrainWait(t *testing.T) {
 }
 
 func TestIteratingController_FallbackOnMaxRetries(t *testing.T) {
-	// First call: max_retries error → immediate fallback
-	// Second call (with fallback provider): success
+	// Exhausted Python HTTP retries (429/404/5xx) arrive as max_retries.
+	// Immediate fallback; the publisher-model error must not be injected into
+	// the next Generate (tryFallback continue skips buildRetryMessage).
+	const vertex404 = "Error code: 404 - [{'error': {'message': 'Publisher Model `foo` not found.'}}]"
 	llm := &mockLLMClient{
 		capture: true,
 		responses: []mockLLMResponse{
 			{chunks: []agent.Chunk{
-				&agent.ErrorChunk{Message: "all retries exhausted", Code: "max_retries", Retryable: false},
+				&agent.ErrorChunk{Message: vertex404, Code: "max_retries", Retryable: false},
 			}},
 			{chunks: []agent.Chunk{
 				&agent.TextChunk{Content: "Analysis complete with fallback provider."},
@@ -1159,6 +1161,11 @@ func TestIteratingController_FallbackOnMaxRetries(t *testing.T) {
 	require.Len(t, llm.capturedInputs, 2)
 	require.Equal(t, "fallback-model", llm.capturedInputs[1].Config.Model)
 	require.True(t, llm.capturedInputs[1].ClearCache, "second call should have ClearCache set")
+
+	for _, msg := range llm.capturedInputs[1].Messages {
+		assert.NotContains(t, msg.Content, "Publisher Model")
+		assert.NotContains(t, msg.Content, "Error from previous attempt")
+	}
 
 	// Verify provider was swapped in execCtx
 	require.Equal(t, "fallback-provider", execCtx.Config.LLMProviderName)


### PR DESCRIPTION
- Treat 429/404/5xx as retryable when no chunks have been yielded
- Walk status_code, .code, and Error code: NNN so Vertex Claude 404s retry
- Exhausted retries yield max_retries so Go falls back without injecting the error JSON into the prompt
- Leave cache 400 degrade and 401/403 unchanged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Reliability**
  - Improved handling of temporary AI provider outages, including automatic retries for rate limits, unavailable models, and server errors.
  - Requests that continue to fail now transition promptly to an alternate provider.
  - Errors after partial streamed output retain their existing handling.

- **Bug Fixes**
  - Permanent client errors avoid unnecessary retries.
  - Provider failure details are excluded from subsequent model prompts, while operator-facing error reporting is preserved.
  - Added coverage for retry, fallback, and HTTP error classification scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->