### PR TITLE
fix(llm-service): preserve Gemini tool history on provider fallback

### DIFF
--- a/llm-service/llm/providers/google_native.py
+++ b/llm-service/llm/providers/google_native.py
@@ -27,6 +27,22 @@ EMPTY_RESPONSE_RETRY_DELAY = 3  # seconds
 # Executions typically complete in minutes; 1 hour is generous headroom.
 MODEL_CONTENT_CACHE_TTL = 3600  # 1 hour
 
+# Gemini 3 requires a thought_signature on reconstructed functionCall parts
+# that were not produced by Gemini (cross-provider fallback, cache miss).
+# Must be assigned as a str after Part construction: constructor bytes are
+# base64-encoded on the wire, and a constructor str is treated as base64.
+# https://ai.google.dev/gemini-api/docs/thought-signatures
+_SKIP_THOUGHT_SIGNATURE = "skip_thought_signature_validator"
+
+
+def _reconstructed_function_call_part(name: str, args: Dict[str, Any]) -> genai_types.Part:
+    """Build a functionCall Part with Google's dummy thought signature."""
+    part = genai_types.Part(
+        function_call=genai_types.FunctionCall(name=name, args=args),
+    )
+    part.thought_signature = _SKIP_THOUGHT_SIGNATURE
+    return part
+
 
 def _token_count(value) -> int:
     if not value:
@@ -163,9 +179,8 @@ class GoogleNativeProvider(LLMProvider):
                     # and thinking Parts exactly as Gemini returned them.
                     contents.extend(cached_turns[model_turn_idx])
                 else:
-                    # Cache miss fallback: reconstruct from proto fields.
-                    # This path is hit on first call (no history) or if the
-                    # Python service restarted mid-execution.
+                    # Cache miss: reconstruct from proto. Hit on provider
+                    # fallback (clear_cache), Python restart, or first call.
                     parts: List[genai_types.Part] = []
                     if msg.content:
                         parts.append(genai_types.Part(text=msg.content))
@@ -179,11 +194,8 @@ class GoogleNativeProvider(LLMProvider):
                             )
                             args = {}
                         parts.append(
-                            genai_types.Part(
-                                function_call=genai_types.FunctionCall(
-                                    name=tool_name_to_api(tc.name),
-                                    args=args,
-                                )
+                            _reconstructed_function_call_part(
+                                tool_name_to_api(tc.name), args
                             )
                         )
                     contents.append(

--- a/llm-service/pyproject.toml
+++ b/llm-service/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "langchain-openai>=1.6.0",
     "langchain-anthropic>=1.6.0",
     "langchain-xai>=1.3.0",
-    "langchain-google-genai>=4.3.4",
+    "langchain-google-genai>=4.3.7",
     "langchain-google-vertexai>=3.2.4",
 ]
 

--- a/llm-service/requirements.txt
+++ b/llm-service/requirements.txt
@@ -581,9 +581,9 @@ langchain-anthropic==1.6.0 \
     --hash=sha256:0307ec98b24566c747e91bac4158bc4f1510bae4b45f0d25107636cc1b616328 \
     --hash=sha256:a85df4aa8f91a201703a4276e599ff3bcc498ade64294a85f79a96d6991f3154
     # via tarsy-llm
-langchain-core==1.6.0 \
-    --hash=sha256:d8bb924cd413955d9d3192ccced140407427c3ff51e50ffb941222648da92cb2 \
-    --hash=sha256:dc72e36678ed26683ec0ad8829b44011fba461d10f9b31dbd9110215e5ec2333
+langchain-core==1.6.1 \
+    --hash=sha256:1b156cb395aac4f009a8a1b38a574c7d948fe2d5f74c96e0d8a5017b4149e04f \
+    --hash=sha256:954a84132a5cb0435d27b910e336347b6744ecc18fbeef1e2de7029a0959841a
     # via
     #   langchain-anthropic
     #   langchain-google-genai
@@ -591,9 +591,9 @@ langchain-core==1.6.0 \
     #   langchain-openai
     #   langchain-xai
     #   tarsy-llm
-langchain-google-genai==4.3.4 \
-    --hash=sha256:265655baad05f799fa7b83a030eaca7cee0e32c9ab7de846b80ea7f59c26134e \
-    --hash=sha256:618fb0da1b9ba9def5569a8b05cb87e1389de41b8731c802958d09499490d2a5
+langchain-google-genai==4.3.7 \
+    --hash=sha256:8a57f936b1fbde52776fdde6673fdabd99cfa5cbbb122a926f1cff0ba00f6bc6 \
+    --hash=sha256:8d4b1aa8f2c2e17b8e790d34a7e9a7b8e7d13e9a00175679d17647c235104bf9
     # via tarsy-llm
 langchain-google-vertexai==3.2.4 \
     --hash=sha256:65b5615e596fdabc2e149f0160fded88bebef2bbc1ea70095ff81714f7570183 \

--- a/llm-service/tests/test_google_native.py
+++ b/llm-service/tests/test_google_native.py
@@ -167,6 +167,7 @@ class TestGoogleNativeProvider:
         assert contents[0].parts[0].text == "Let me call a tool"
         assert contents[0].parts[1].function_call.name == "server__tool"
         assert contents[0].parts[1].function_call.args["arg"] == "value"
+        assert contents[0].parts[1].thought_signature == _SKIP_THOUGHT_SIGNATURE
 
     def test_convert_messages_tool_result(self, provider):
         """Test conversion of tool result messages."""
@@ -601,6 +602,99 @@ class TestGoogleNativeProvider:
                     for part in content_obj.parts:
                         assert getattr(part, "text", None) != "cached", \
                             "old cached content should have been cleared before generate"
+
+    @pytest.mark.asyncio
+    @patch.dict(os.environ, {"TEST_API_KEY": "test-key-123"})
+    @patch("llm.providers.google_native.genai.Client")
+    async def test_generate_clear_cache_stamps_dummy_thought_signature(
+        self, mock_client_class, provider
+    ):
+        """clear_cache + prior tool calls reconstruct functionCall parts with the skip sentinel."""
+        execution_id = "exec-cross-provider"
+        provider._cache_model_turn(
+            execution_id,
+            [genai_types.Content(
+                role="model",
+                parts=[genai_types.Part(text="stale-anthropic-turn")],
+            )],
+        )
+
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+
+        mock_candidate = MagicMock()
+        mock_candidate.content = genai_types.Content(
+            role="model", parts=[genai_types.Part(text="ok")]
+        )
+        mock_candidate.grounding_metadata = None
+        mock_chunk = MagicMock()
+        mock_chunk.candidates = [mock_candidate]
+        mock_chunk.usage_metadata = None
+
+        captured = {}
+
+        async def fake_stream(**kwargs):
+            captured["contents"] = kwargs["contents"]
+
+            async def gen():
+                yield mock_chunk
+
+            return gen()
+
+        mock_client.aio.models.generate_content_stream = AsyncMock(side_effect=fake_stream)
+
+        request = pb.GenerateRequest(
+            session_id="sess-1",
+            execution_id=execution_id,
+            clear_cache=True,
+            llm_config=pb.LLMConfig(
+                backend="google-native",
+                model="gemini-3.7-flash",
+                api_key_env="TEST_API_KEY",
+            ),
+            messages=[
+                pb.ConversationMessage(role="user", content="Investigate."),
+                pb.ConversationMessage(
+                    role="assistant",
+                    content="",
+                    tool_calls=[
+                        pb.ToolCall(
+                            id="tc1",
+                            name="kubernetes-server.pods_log",
+                            arguments='{"name":"app"}',
+                        ),
+                    ],
+                ),
+                pb.ConversationMessage(
+                    role="tool",
+                    tool_name="kubernetes-server.pods_log",
+                    tool_call_id="tc1",
+                    content='{"text":"log lines"}',
+                ),
+            ],
+        )
+
+        async for _ in provider.generate(request):
+            pass
+
+        contents = captured["contents"]
+        fc_parts = [
+            p
+            for c in contents
+            for p in (c.parts or [])
+            if getattr(p, "function_call", None)
+        ]
+        assert len(fc_parts) == 1
+        assert fc_parts[0].function_call.name == "kubernetes-server__pods_log"
+        assert fc_parts[0].thought_signature == _SKIP_THOUGHT_SIGNATURE
+        assert isinstance(fc_parts[0].thought_signature, str)
+        texts = [
+            p.text
+            for c in contents
+            for p in (c.parts or [])
+            if getattr(p, "text", None)
+        ]
+        assert "stale-anthropic-turn" not in texts
 
     @pytest.mark.asyncio
     @patch.dict(os.environ, {"TEST_API_KEY": "test-key-123"})

--- a/llm-service/tests/test_google_native.py
+++ b/llm-service/tests/test_google_native.py
@@ -7,7 +7,10 @@ from google.genai import errors as genai_errors
 from google.genai import types as genai_types
 
 from llm_proto import llm_service_pb2 as pb
-from llm.providers.google_native import GoogleNativeProvider
+from llm.providers.google_native import (
+    GoogleNativeProvider,
+    _SKIP_THOUGHT_SIGNATURE,
+)
 from llm.providers.tool_names import tool_name_to_api, tool_name_from_api
 
 pytestmark = pytest.mark.unit
@@ -451,12 +454,46 @@ class TestGoogleNativeProvider:
 
         _, contents = provider._convert_messages(messages, "no-cache-exec")
 
-        # Fallback reconstruction: text Part + function_call Part (no thought_signature)
+        # Fallback reconstruction: text Part + function_call Part with dummy signature
         assert len(contents) == 1
         assert contents[0].role == "model"
         assert len(contents[0].parts) == 2
         assert contents[0].parts[0].text == "response text"
         assert contents[0].parts[1].function_call.name == "server__tool"
+        assert contents[0].parts[1].thought_signature == _SKIP_THOUGHT_SIGNATURE
+        assert isinstance(contents[0].parts[1].thought_signature, str)
+
+    def test_convert_messages_fallback_dummy_signature_on_each_function_call(self, provider):
+        """Cross-provider fallback reconstructs every functionCall with the skip sentinel."""
+        messages = [
+            pb.ConversationMessage(role="user", content="Investigate."),
+            pb.ConversationMessage(
+                role="assistant",
+                content="",
+                tool_calls=[
+                    pb.ToolCall(
+                        id="tc1",
+                        name="kubernetes-server.pods_log",
+                        arguments='{"name": "app"}',
+                    ),
+                    pb.ToolCall(
+                        id="tc2",
+                        name="kubernetes-server.pods_list",
+                        arguments='{"namespace": "ns"}',
+                    ),
+                ],
+            ),
+        ]
+
+        _, contents = provider._convert_messages(messages, "fallback-exec")
+
+        assert contents[1].role == "model"
+        assert len(contents[1].parts) == 2
+        assert contents[1].parts[0].function_call.name == "kubernetes-server__pods_log"
+        assert contents[1].parts[1].function_call.name == "kubernetes-server__pods_list"
+        for part in contents[1].parts:
+            assert part.thought_signature == _SKIP_THOUGHT_SIGNATURE
+            assert isinstance(part.thought_signature, str)
 
     def test_convert_messages_unknown_role_raises(self, provider):
         """Test that unknown message role raises ValueError."""

--- a/llm-service/uv.lock
+++ b/llm-service/uv.lock
@@ -985,7 +985,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.6.0"
+version = "1.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -999,14 +999,14 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uuid-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/97/88/ebc98df187c525d729725ab39759337c56d5d2803423632376aa35bde899/langchain_core-1.6.0.tar.gz", hash = "sha256:dc72e36678ed26683ec0ad8829b44011fba461d10f9b31dbd9110215e5ec2333", size = 992493, upload-time = "2026-08-19T15:55:40.642Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/90/12/aff76ca89c219ebe6f9dd3c5dbc4e3b1cf5450e9fc7037dccad23d45cd7a/langchain_core-1.6.1.tar.gz", hash = "sha256:1b156cb395aac4f009a8a1b38a574c7d948fe2d5f74c96e0d8a5017b4149e04f", size = 1003359, upload-time = "2026-08-27T19:31:14.956Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/4c/508a90b9d2e3bd7738fd93cb2ac2178ce734662c75e69b3b81c445f1b360/langchain_core-1.6.0-py3-none-any.whl", hash = "sha256:d8bb924cd413955d9d3192ccced140407427c3ff51e50ffb941222648da92cb2", size = 570006, upload-time = "2026-08-19T15:55:38.935Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/25/f50dd65673c819aa33d3c34df58c115dbb6ec627d19f93e6e401dd0fc8d7/langchain_core-1.6.1-py3-none-any.whl", hash = "sha256:954a84132a5cb0435d27b910e336347b6744ecc18fbeef1e2de7029a0959841a", size = 571478, upload-time = "2026-08-27T19:31:13.34Z" },
 ]
 
 [[package]]
 name = "langchain-google-genai"
-version = "4.3.4"
+version = "4.3.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filetype" },
@@ -1014,9 +1014,9 @@ dependencies = [
     { name = "langchain-core" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d4/ae/8ba8ee41bd20a23dee95cda109632c8b19a53141fbc81d9f87a72f0e975c/langchain_google_genai-4.3.4.tar.gz", hash = "sha256:265655baad05f799fa7b83a030eaca7cee0e32c9ab7de846b80ea7f59c26134e", size = 287396, upload-time = "2026-08-14T18:10:00.119Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/17/dcf759ad83ab3566db1b02c8b21211f43085c66f3b5964f6fe573ffe8664/langchain_google_genai-4.3.7.tar.gz", hash = "sha256:8a57f936b1fbde52776fdde6673fdabd99cfa5cbbb122a926f1cff0ba00f6bc6", size = 373696, upload-time = "2026-08-27T20:44:05.203Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c9/f8/9fe4a28e319e9d6b20454e85fea9c243bf011dc866f2c3b9a89d64f9c1a1/langchain_google_genai-4.3.4-py3-none-any.whl", hash = "sha256:618fb0da1b9ba9def5569a8b05cb87e1389de41b8731c802958d09499490d2a5", size = 73338, upload-time = "2026-08-14T18:09:58.772Z" },
+    { url = "https://files.pythonhosted.org/packages/47/2f/ade5d1a7ecfbc88f7de65c6610ef89d80905b29fa3dd28a764f7028f3d42/langchain_google_genai-4.3.7-py3-none-any.whl", hash = "sha256:8d4b1aa8f2c2e17b8e790d34a7e9a7b8e7d13e9a00175679d17647c235104bf9", size = 79611, upload-time = "2026-08-27T20:44:03.884Z" },
 ]
 
 [[package]]
@@ -1854,7 +1854,7 @@ requires-dist = [
     { name = "grpcio-tools", specifier = ">=1.81.1,<1.82.0" },
     { name = "langchain-anthropic", specifier = ">=1.6.0" },
     { name = "langchain-core", specifier = ">=1.6.0" },
-    { name = "langchain-google-genai", specifier = ">=4.3.4" },
+    { name = "langchain-google-genai", specifier = ">=4.3.7" },
     { name = "langchain-google-vertexai", specifier = ">=3.2.4" },
     { name = "langchain-openai", specifier = ">=1.6.0" },
     { name = "langchain-xai", specifier = ">=1.3.0" },

--- a/pkg/agent/controller/iterating_test.go
+++ b/pkg/agent/controller/iterating_test.go
@@ -1232,6 +1232,50 @@ func TestIteratingController_FallbackOnMaxRetries(t *testing.T) {
 	require.Equal(t, config.LLMBackendNativeGemini, execCtx.Config.LLMBackend)
 }
 
+func TestIteratingController_FallbackReplaysToolHistory(t *testing.T) {
+	// Primary completes a tool turn, then fails. The fallback Generate must
+	// replay those tool calls with ClearCache so the next provider can continue.
+	llm := &mockLLMClient{
+		capture: true,
+		responses: []mockLLMResponse{
+			{chunks: []agent.Chunk{
+				&agent.ToolCallChunk{CallID: "call-1", Name: "test.tool", Arguments: `{"component":"api"}`},
+			}},
+			{chunks: []agent.Chunk{
+				&agent.ErrorChunk{Message: "retries exhausted", Code: "max_retries", Retryable: false},
+			}},
+			{chunks: []agent.Chunk{
+				&agent.TextChunk{Content: "Healthy after fallback."},
+			}},
+		},
+	}
+
+	executor := &mockToolExecutor{
+		tools: []agent.ToolDefinition{{Name: "test.tool", Description: "A test tool"}},
+		results: map[string]*agent.ToolResult{
+			"test.tool": {Content: `{"status":"ok"}`},
+		},
+	}
+
+	execCtx := newTestExecCtx(t, llm, executor)
+	execCtx.Config.LLMProviderName = "primary-provider"
+	execCtx.Config.ResolvedFallbackProviders = []agent.ResolvedFallbackEntry{
+		makeFallbackEntry("fallback-provider", config.LLMBackendNativeGemini, "fallback-model"),
+	}
+
+	ctrl := NewIteratingController()
+	result, err := ctrl.Run(t.Context(), execCtx, "")
+	require.NoError(t, err)
+	require.Equal(t, agent.ExecutionStatusCompleted, result.Status)
+	require.Equal(t, "Healthy after fallback.", result.FinalAnalysis)
+	require.Len(t, llm.capturedInputs, 3)
+
+	fallback := llm.capturedInputs[2]
+	assert.Equal(t, "fallback-model", fallback.Config.Model)
+	assert.True(t, fallback.ClearCache)
+	requireAssistantToolHistory(t, fallback.Messages, "test.tool", "call-1")
+}
+
 func TestIteratingController_FallbackOnCredentials_Immediate(t *testing.T) {
 	// credentials errors trigger immediate fallback (no Go retry needed)
 	llm := &mockLLMClient{
@@ -1606,4 +1650,24 @@ func TestIteratingController_PromptCache(t *testing.T) {
 		require.Len(t, llm.capturedInputs, 1)
 		assert.False(t, llm.capturedInputs[0].PromptCache)
 	})
+}
+
+func requireAssistantToolHistory(t *testing.T, msgs []agent.ConversationMessage, toolName, callID string) {
+	t.Helper()
+	var assistant, tool *agent.ConversationMessage
+	for i := range msgs {
+		m := &msgs[i]
+		if m.Role == agent.RoleAssistant && len(m.ToolCalls) > 0 {
+			assistant = m
+		}
+		if m.Role == agent.RoleTool && m.ToolCallID == callID {
+			tool = m
+		}
+	}
+	require.NotNil(t, assistant, "fallback Generate must replay assistant tool calls")
+	require.Len(t, assistant.ToolCalls, 1)
+	assert.Equal(t, toolName, assistant.ToolCalls[0].Name)
+	assert.Equal(t, callID, assistant.ToolCalls[0].ID)
+	require.NotNil(t, tool, "fallback Generate must replay tool results")
+	assert.Equal(t, toolName, tool.ToolName)
 }

--- a/test/e2e/fallback_test.go
+++ b/test/e2e/fallback_test.go
@@ -137,6 +137,89 @@ func TestE2E_FallbackOnMaxRetries(t *testing.T) {
 }
 
 // ────────────────────────────────────────────────────────────
+// TestE2E_FallbackAfterToolCall — Primary completes a tool turn, then fails.
+// Fallback continues with that tool history (the Gemini 3 thought-signature case).
+//
+// Verifies:
+//   - Session completes after mid-investigation fallback
+//   - Post-fallback Generate has ClearCache and replays the tool call + result
+// ────────────────────────────────────────────────────────────
+
+func TestE2E_FallbackAfterToolCall(t *testing.T) {
+	llm := NewScriptedLLMClient()
+
+	llm.AddRouted("Investigator", LLMScriptEntry{
+		Chunks: []agent.Chunk{
+			&agent.ThinkingChunk{Content: "Checking system status."},
+			&agent.ToolCallChunk{CallID: "call-1", Name: "test-mcp__check_status", Arguments: `{"component":"api"}`},
+			&agent.UsageChunk{InputTokens: 40, OutputTokens: 15, TotalTokens: 55},
+		},
+	})
+	llm.AddRouted("Investigator", LLMScriptEntry{
+		Chunks: []agent.Chunk{
+			&agent.ErrorChunk{
+				Message:   "rate limit exceeded after 3 retries",
+				Code:      "max_retries",
+				Retryable: true,
+			},
+		},
+	})
+	llm.AddRouted("Investigator", LLMScriptEntry{
+		Chunks: []agent.Chunk{
+			&agent.TextChunk{Content: "API server is healthy. Investigation complete after fallback."},
+			&agent.UsageChunk{InputTokens: 80, OutputTokens: 30, TotalTokens: 110},
+		},
+	})
+	llm.AddSequential(LLMScriptEntry{Text: "Investigation completed after fallback with prior tool results."})
+
+	app := NewTestApp(t,
+		WithConfig(configs.Load(t, "fallback")),
+		WithLLMClient(llm),
+		WithMCPServers(map[string]map[string]mcpsdk.ToolHandler{
+			"test-mcp": {
+				"check_status": StaticToolHandler(`{"status":"healthy","uptime":"72h"}`),
+			},
+		}),
+	)
+
+	_, sessionID := submitAndSubscribe(t, app, "test-fallback", "API server alert triggered")
+	app.WaitForSessionStatus(t, sessionID, "completed")
+
+	session := app.GetSession(t, sessionID)
+	assert.Equal(t, "completed", session["status"])
+
+	execs := app.QueryExecutions(t, sessionID)
+	investigator := findExecution(execs, "Investigator")
+	require.NotNil(t, investigator)
+	require.NotNil(t, investigator.OriginalLlmProvider)
+	assert.Equal(t, "primary-provider", *investigator.OriginalLlmProvider)
+	require.NotNil(t, investigator.LlmProvider)
+	assert.Equal(t, "fallback-1", *investigator.LlmProvider)
+
+	inputs := llm.CapturedInputs()
+	require.GreaterOrEqual(t, len(inputs), 3)
+	assert.False(t, inputs[0].ClearCache)
+	assert.False(t, inputs[1].ClearCache)
+	assert.True(t, inputs[2].ClearCache, "first Generate after fallback must clear cache")
+
+	var hasToolCall, hasToolResult bool
+	for _, msg := range inputs[2].Messages {
+		if msg.Role == agent.RoleAssistant {
+			for _, tc := range msg.ToolCalls {
+				if tc.ID == "call-1" && tc.Name == "test-mcp__check_status" {
+					hasToolCall = true
+				}
+			}
+		}
+		if msg.Role == agent.RoleTool && msg.ToolCallID == "call-1" {
+			hasToolResult = true
+		}
+	}
+	assert.True(t, hasToolCall, "fallback Generate must include the prior assistant tool call")
+	assert.True(t, hasToolResult, "fallback Generate must include the prior tool result")
+}
+
+// ────────────────────────────────────────────────────────────
 // TestE2E_FallbackCascade — Primary provider and first fallback both fail
 // with credentials errors; second fallback succeeds.
 //

--- a/test/e2e/testdata/configs/fallback/tarsy.yaml
+++ b/test/e2e/testdata/configs/fallback/tarsy.yaml
@@ -36,7 +36,7 @@ agents:
     custom_instructions: "You are BetaChecker, analyzing logs."
 
 agent_chains:
-  # Used by: TestE2E_FallbackOnMaxRetries, TestE2E_FallbackCascade
+  # Used by: TestE2E_FallbackOnMaxRetries, TestE2E_FallbackAfterToolCall, TestE2E_FallbackCascade
   single-fallback:
     alert_types: [test-fallback, test-cascade]
     executive_summary_provider: "primary-provider"


### PR DESCRIPTION
- Stamp Google's skip_thought_signature_validator on reconstructed functionCall parts
- Assign it as a str after Part construction so the SDK does not base64-encode the sentinel

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved provider fallback after completed tool calls.
  - Preserved assistant tool calls and corresponding results when switching providers.
  - Cleared stale cached content during fallback retries to ensure the correct conversation history is used.
  - Improved compatibility with Gemini function-call messages by retaining required call metadata.

- **Tests**
  - Added coverage for multiple tool calls, cache clearing, provider fallback, and successful end-to-end completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->