### PR TITLE
feat(config): default omitted fallback backend to langchain

### DIFF
--- a/deploy/config/README.md
+++ b/deploy/config/README.md
@@ -78,7 +78,7 @@ defaults:
   max_iterations: 20
   fallback_providers:
     - provider: "gemini-3.1-pro"
-      backend: "google-native"
+      backend: "google-native"  # omit backend to default to langchain
   # Optional: summarize large MCP results (and search_past_sessions) with a
   # cheaper named provider. Unset keeps the calling agent's model.
   # Omit llm_backend to use langchain. On summarization LLM error, TARSy

--- a/docs/adr/0003-llm-provider-fallback.md
+++ b/docs/adr/0003-llm-provider-fallback.md
@@ -13,7 +13,7 @@ This feature adds **automatic fallback to alternative LLM providers** when the c
 ## Design Principles
 
 1. **Existing retry logic remains the first line of defense.** Python-level retries (3 attempts with exponential backoff) handle transient errors. Fallback only triggers after those retries are exhausted and the Go-level error propagates.
-2. **Each fallback entry is self-contained.** Provider is required. Omitted backend defaults to langchain (not inferred from provider type, not inherited from `defaults.llm_backend`). The system uses the resolved pair as-is — no runtime compatibility filtering. Invalid combinations are caught at startup.
+2. **Each fallback entry is self-contained.** Provider is required. Omitted backend defaults to langchain (not inferred from provider type, not inherited from `defaults.llm_backend`). The resolved pair is used as-is for general compatibility — there is no mapping from provider type. Native-tool-incompatible entries are still skipped at runtime ([ADR-0017](0017-native-tool-fallback-safety.md)); startup warns when a native-tool agent has no `google-native` fallback.
 3. **Operator preference is respected.** The fallback list order represents cost/quality preference. The system does not re-rank providers automatically.
 4. **Minimal blast radius.** The fallback mechanism integrates at the iteration level in the Go controller, not in the Python LLM service. This keeps the Python service stateless and provider-agnostic.
 5. **Observable by default.** Every fallback event is recorded in the timeline, on the execution record, and surfaced in the dashboard without additional configuration.
@@ -139,7 +139,7 @@ An entry in the fallback list: required provider name plus optional backend. The
 
 ### Backend Switching
 
-Each fallback entry specifies a provider and optionally a backend. When fallback triggers, the system switches to both — including changing the backend if the fallback entry uses a different one (e.g., native vs LangChain). If a provider/backend combination doesn't work, that's a configuration error caught at startup.
+Each fallback entry specifies a provider and optionally a backend. When fallback triggers, the system switches to both — including changing the backend if the fallback entry uses a different one (e.g., native vs LangChain). Startup does not verify that the provider works with that backend (Claude on `google-native` is not rejected). Native-tool agents skip non-`google-native` entries at runtime and get a startup warning if the list has none ([ADR-0017](0017-native-tool-fallback-safety.md)).
 
 ### Same-Provider Skip
 
@@ -173,10 +173,10 @@ Fallback is NOT triggered when:
 At startup, the system validates each fallback provider entry:
 
 1. **Provider exists** — the referenced provider name is registered
-2. **Backend is valid** — the backend value is a known enum
+2. **Backend is valid** — the backend value is a known enum (omitted defaults to langchain)
 3. **Credentials are set** — the required environment variable for that provider is present and non-empty
 
-Startup fails if any check fails — a fallback list with broken entries gives a false sense of safety.
+Startup fails if any of those checks fail — a fallback list with broken entries gives a false sense of safety. Provider/backend pairing is not validated. Native-tool agents with no `google-native` entry in the effective list get a warning only ([ADR-0017](0017-native-tool-fallback-safety.md)).
 
 ## Decisions Summary
 

--- a/docs/adr/0003-llm-provider-fallback.md
+++ b/docs/adr/0003-llm-provider-fallback.md
@@ -13,7 +13,7 @@ This feature adds **automatic fallback to alternative LLM providers** when the c
 ## Design Principles
 
 1. **Existing retry logic remains the first line of defense.** Python-level retries (3 attempts with exponential backoff) handle transient errors. Fallback only triggers after those retries are exhausted and the Go-level error propagates.
-2. **Each fallback entry is self-contained.** Each entry specifies both provider and backend explicitly. The system uses them as-is — no runtime compatibility filtering. Invalid combinations are caught at startup.
+2. **Each fallback entry is self-contained.** Provider is required. Omitted backend defaults to langchain (not inferred from provider type, not inherited from `defaults.llm_backend`). The system uses the resolved pair as-is — no runtime compatibility filtering. Invalid combinations are caught at startup.
 3. **Operator preference is respected.** The fallback list order represents cost/quality preference. The system does not re-rank providers automatically.
 4. **Minimal blast radius.** The fallback mechanism integrates at the iteration level in the Go controller, not in the Python LLM service. This keeps the Python service stateless and provider-agnostic.
 5. **Observable by default.** Every fallback event is recorded in the timeline, on the execution record, and surfaced in the dashboard without additional configuration.
@@ -97,8 +97,7 @@ defaults:
   fallback_providers:
     - provider: "gemini-2.5-pro"
       backend: "google-native"
-    - provider: "anthropic-vertex"
-      backend: "langchain"
+    - provider: "anthropic-vertex"  # omitted backend → langchain
 
 chains:
   my-chain:
@@ -107,7 +106,7 @@ chains:
         backend: "google-native"
 ```
 
-Each fallback entry explicitly specifies its backend. No implicit mapping — future-proof as new backends are added.
+Omitted `backend` defaults to langchain. `google-native` must be written explicitly. There is no mapping from provider type.
 
 ### Fallback State Tracking
 
@@ -136,11 +135,11 @@ Two new nullable columns on agent executions: `original_llm_provider` and `origi
 
 ### Fallback Provider Entry
 
-An entry in the fallback list: provider name plus backend. The provider name references a registered LLM provider config. The backend specifies which SDK path to use when this provider is active.
+An entry in the fallback list: required provider name plus optional backend. The provider name references a registered LLM provider config. The backend specifies which SDK path to use when this provider is active; omitted backend is langchain.
 
 ### Backend Switching
 
-Each fallback entry specifies both a provider and a backend. When fallback triggers, the system switches to both — including changing the backend if the fallback entry uses a different one (e.g., native vs LangChain). If a provider/backend combination doesn't work, that's a configuration error caught at startup.
+Each fallback entry specifies a provider and optionally a backend. When fallback triggers, the system switches to both — including changing the backend if the fallback entry uses a different one (e.g., native vs LangChain). If a provider/backend combination doesn't work, that's a configuration error caught at startup.
 
 ### Same-Provider Skip
 
@@ -185,7 +184,7 @@ Startup fails if any check fails — a fallback list with broken entries gives a
 |---|---|---|---|
 | Q1 | Fallback scope | Stick with fallback for rest of execution; new executions reset to primary | Provider outages last longer than a single execution. New executions naturally reset via config resolution. Avoids oscillation. |
 | Q2 | Where adaptive timeouts live | Go streaming path; Python's long timeout stays as safety net | Go already processes every chunk in real-time. Single implementation for tiered behavior. |
-| Q3 | Backend specification | Explicit backend per fallback entry; no implicit mapping | Avoids hidden compatibility mappings. Future-proof as backends evolve. Minimal config verbosity. |
+| Q3 | Backend specification | Omitted backend defaults to langchain; google-native must be explicit. No mapping from provider type | Same default as named-provider `llm_backend` layers. Inferring google-native from Gemini providers would silently break Claude/Vertex fallbacks. |
 | Q4 | Credential validation timing | Validate at startup; fail if any fallback provider has missing credentials | A broken fallback is worse than no fallback — false sense of security. Catch misconfigs at deploy time. |
 | Q5 | Fallback metadata storage | Two new nullable columns: `original_llm_provider`, `original_llm_backend` | Directly queryable (`WHERE original_llm_provider IS NOT NULL`). Timeline events provide full audit trail. |
 | Q6 | Fallback scope across controllers | All controllers get fallback (iterating, forced conclusion, single-shot) | Whole session should survive an outage, not just the iteration loop. Scoring/synthesis would otherwise hit the same broken primary. |
@@ -201,3 +200,7 @@ These original decisions still stand. ADR-0027 changed *how* they behave under s
 - **Candidate skip (Same-Provider Skip).** Originally current-name only, so a later list entry with the primary’s name could be selected again. ADR-0027 skips any already-attempted name.
 - **Same-provider Go retry.** Originally appended the full provider-error text into the next model prompt. ADR-0027 keeps `error` / `provider_fallback` timeline events and stops injecting no-partial error JSON into the conversation.
 - **Q1 (sticky for the rest of the execution) is not changed.** Probe/unstick remains out of scope.
+
+## Amendment (2026-09-01)
+
+**Q3 / backend specification.** Omitted `fallback_providers[].backend` defaults to `langchain`. `google-native` remains explicit. Backend is still not inferred from provider type and does not inherit `defaults.llm_backend`.

--- a/pkg/agent/config_resolver.go
+++ b/pkg/agent/config_resolver.go
@@ -14,7 +14,7 @@ const DefaultMaxIterations = 20
 // DefaultLLMBackend is the fallback when no level in the config hierarchy
 // specifies an LLM backend. LangChain is the general-purpose multi-provider
 // backend and matches the typical production default.
-const DefaultLLMBackend = config.LLMBackendLangChain
+const DefaultLLMBackend = config.DefaultLLMBackend
 
 // DefaultIterationTimeout is the overall per-iteration timeout.
 // Each iteration (LLM call + tool execution) gets its own context.WithTimeout
@@ -634,7 +634,7 @@ func resolveFullFallbackEntries(cfg *config.Config, entries []config.FallbackPro
 		}
 		resolved = append(resolved, ResolvedFallbackEntry{
 			ProviderName: entry.Provider,
-			Backend:      entry.Backend,
+			Backend:      entry.ResolvedBackend(),
 			Config:       applyAgentNativeTools(provider, agentNativeTools),
 		})
 	}

--- a/pkg/agent/config_resolver_test.go
+++ b/pkg/agent/config_resolver_test.go
@@ -1520,6 +1520,32 @@ func TestResolvedFallbackProviders(t *testing.T) {
 		assert.Equal(t, "gpt-fallback-2", resolved.ResolvedFallbackProviders[1].Config.Model)
 	})
 
+	t.Run("omitted fallback backend resolves to langchain", func(t *testing.T) {
+		cfgOmit := *cfg
+		cfgOmit.Defaults = &config.Defaults{
+			LLMProvider: "primary",
+			LLMBackend:  config.LLMBackendNativeGemini,
+			FallbackProviders: []config.FallbackProviderEntry{
+				{Provider: "fb-2"},
+				{Provider: "fb-1", Backend: config.LLMBackendNativeGemini},
+			},
+		}
+		resolved, err := ResolveAgentConfig(&cfgOmit,
+			&config.ChainConfig{},
+			config.StageConfig{},
+			config.StageAgentConfig{Name: "TestAgent"},
+		)
+		require.NoError(t, err)
+		require.Len(t, resolved.ResolvedFallbackProviders, 2)
+		assert.Equal(t, "fb-2", resolved.ResolvedFallbackProviders[0].ProviderName)
+		assert.Equal(t, config.LLMBackendLangChain, resolved.ResolvedFallbackProviders[0].Backend,
+			"omitted backend must be langchain, not defaults.llm_backend")
+		assert.Equal(t, "fb-1", resolved.ResolvedFallbackProviders[1].ProviderName)
+		assert.Equal(t, config.LLMBackendNativeGemini, resolved.ResolvedFallbackProviders[1].Backend)
+		assert.Empty(t, resolved.FallbackProviders[0].Backend,
+			"raw fallback list keeps omitted backend empty")
+	})
+
 	t.Run("ResolveChatAgentConfig populates ResolvedFallbackProviders", func(t *testing.T) {
 		resolved, err := ResolveChatAgentConfig(cfg, &config.ChainConfig{}, nil)
 		require.NoError(t, err)

--- a/pkg/api/system_config.go
+++ b/pkg/api/system_config.go
@@ -781,7 +781,7 @@ func buildFallbackProviders(entries []config.FallbackProviderEntry) []FallbackPr
 	for _, e := range entries {
 		out = append(out, FallbackProviderView{
 			Provider: e.Provider,
-			Backend:  string(e.Backend),
+			Backend:  string(e.ResolvedBackend()),
 		})
 	}
 	return out

--- a/pkg/api/system_config_test.go
+++ b/pkg/api/system_config_test.go
@@ -605,6 +605,24 @@ func TestSystemConfigHandler(t *testing.T) {
 		assert.NotContains(t, string(raw), "E2E_SENTINEL_BASE_URL")
 		assert.NotContains(t, string(raw), "E2E_SENTINEL_QUERY")
 	})
+
+	t.Run("omitted fallback backend is langchain in the config view", func(t *testing.T) {
+		resp := buildSystemConfigResponse(&config.Config{
+			Defaults: &config.Defaults{
+				LLMBackend: config.LLMBackendNativeGemini,
+				FallbackProviders: []config.FallbackProviderEntry{
+					{Provider: "claude-fb"},
+					{Provider: "gemini-fb", Backend: config.LLMBackendNativeGemini},
+				},
+			},
+		}, nil)
+		require.NotNil(t, resp.Defaults)
+		require.Len(t, resp.Defaults.FallbackProviders, 2)
+		assert.Equal(t, FallbackProviderView{Provider: "claude-fb", Backend: "langchain"},
+			resp.Defaults.FallbackProviders[0])
+		assert.Equal(t, FallbackProviderView{Provider: "gemini-fb", Backend: "google-native"},
+			resp.Defaults.FallbackProviders[1])
+	})
 }
 
 func TestSanitizeURL(t *testing.T) {

--- a/pkg/config/enums.go
+++ b/pkg/config/enums.go
@@ -38,7 +38,12 @@ const (
 	LLMBackendLangChain LLMBackend = "langchain"
 )
 
-// IsValid checks if the LLM backend is valid (empty string is NOT valid — must be explicit).
+// DefaultLLMBackend is used when a named provider is set but backend is omitted.
+// LangChain is the general-purpose multi-provider path; google-native must be explicit.
+const DefaultLLMBackend = LLMBackendLangChain
+
+// IsValid checks if the LLM backend is a known value. Empty is not valid;
+// callers should apply DefaultLLMBackend before checking omitted config fields.
 func (b LLMBackend) IsValid() bool {
 	return b == LLMBackendNativeGemini || b == LLMBackendLangChain
 }

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -1336,6 +1336,7 @@ defaults:
   fallback_providers:
     - provider: "fb-defaults"
       backend: "google-native"
+    - provider: "fb-defaults-omit"
 
 agents:
   test-agent:
@@ -1371,11 +1372,13 @@ agent_chains:
 	cfg, err := loader.loadTarsyYAML()
 	require.NoError(t, err)
 
-	// Defaults-level: single entry
+	// Defaults-level: explicit backend and omitted backend (stays empty until resolve)
 	require.NotNil(t, cfg.Defaults)
-	require.Len(t, cfg.Defaults.FallbackProviders, 1)
+	require.Len(t, cfg.Defaults.FallbackProviders, 2)
 	assert.Equal(t, "fb-defaults", cfg.Defaults.FallbackProviders[0].Provider)
 	assert.Equal(t, LLMBackendNativeGemini, cfg.Defaults.FallbackProviders[0].Backend)
+	assert.Equal(t, "fb-defaults-omit", cfg.Defaults.FallbackProviders[1].Provider)
+	assert.Empty(t, cfg.Defaults.FallbackProviders[1].Backend)
 
 	chain := cfg.AgentChains["test-chain"]
 

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"cmp"
 	"fmt"
 
 	"gopkg.in/yaml.v3"
@@ -172,10 +173,15 @@ func (r SubAgentRefs) Names() []string {
 }
 
 // FallbackProviderEntry is a single entry in the fallback provider list.
-// Each entry explicitly specifies both provider and backend.
+// Provider is required. Omitted backend defaults to langchain (see ResolvedBackend).
 type FallbackProviderEntry struct {
 	Provider string     `yaml:"provider" validate:"required"`
-	Backend  LLMBackend `yaml:"backend" validate:"required"`
+	Backend  LLMBackend `yaml:"backend,omitempty"`
+}
+
+// ResolvedBackend returns the entry's backend, or DefaultLLMBackend when omitted.
+func (e FallbackProviderEntry) ResolvedBackend() LLMBackend {
+	return cmp.Or(e.Backend, DefaultLLMBackend)
 }
 
 // SynthesisConfig defines synthesis agent configuration

--- a/pkg/config/types_test.go
+++ b/pkg/config/types_test.go
@@ -144,6 +144,37 @@ func TestSubAgentRefs_Names(t *testing.T) {
 	})
 }
 
+func TestFallbackProviderEntry_ResolvedBackend(t *testing.T) {
+	tests := []struct {
+		name    string
+		yamlSrc string
+		want    LLMBackend
+	}{
+		{
+			name:    "omitted backend defaults to langchain",
+			yamlSrc: "provider: foo\n",
+			want:    DefaultLLMBackend,
+		},
+		{
+			name:    "explicit langchain preserved",
+			yamlSrc: "provider: foo\nbackend: langchain\n",
+			want:    LLMBackendLangChain,
+		},
+		{
+			name:    "invalid backend is not replaced",
+			yamlSrc: "provider: foo\nbackend: bogus\n",
+			want:    LLMBackend("bogus"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var entry FallbackProviderEntry
+			require.NoError(t, yaml.Unmarshal([]byte(tt.yamlSrc), &entry))
+			assert.Equal(t, tt.want, entry.ResolvedBackend())
+		})
+	}
+}
+
 func TestEmbeddingProviderType_IsValid(t *testing.T) {
 	tests := []struct {
 		provider EmbeddingProviderType

--- a/pkg/config/validator.go
+++ b/pkg/config/validator.go
@@ -913,8 +913,8 @@ func (v *Validator) validateFallbackProviders(entries []FallbackProviderEntry, s
 				fmt.Errorf("LLM provider '%s' not found", entry.Provider))
 		}
 
-		// Backend must be valid
-		if !entry.Backend.IsValid() {
+		// Backend must be valid (omitted defaults to langchain)
+		if !entry.ResolvedBackend().IsValid() {
 			return NewValidationError(section, name, entryRef,
 				fmt.Errorf("invalid LLM backend: %s", entry.Backend))
 		}
@@ -1186,7 +1186,7 @@ func (v *Validator) warnIfNativeAgentLacksFallback(
 	}
 
 	for _, entry := range effective {
-		if entry.Backend == LLMBackendNativeGemini {
+		if entry.ResolvedBackend() == LLMBackendNativeGemini {
 			return
 		}
 	}

--- a/pkg/config/validator_test.go
+++ b/pkg/config/validator_test.go
@@ -3668,6 +3668,19 @@ func TestValidateFallbackProviders(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "defaults-level fallback with omitted backend",
+			defaults: &Defaults{
+				FallbackProviders: []FallbackProviderEntry{
+					{Provider: "fallback-1"},
+				},
+			},
+			providers: map[string]*LLMProviderConfig{
+				"fallback-1": {Type: LLMProviderTypeGoogle, Model: "gemini-2.5-pro", APIKeyEnv: "FB_KEY"},
+			},
+			env:     map[string]string{"FB_KEY": "secret"},
+			wantErr: false,
+		},
+		{
 			name: "defaults-level fallback with missing provider",
 			defaults: &Defaults{
 				FallbackProviders: []FallbackProviderEntry{
@@ -4440,6 +4453,37 @@ func TestWarnNativeToolAgentsWithoutCompatibleFallback(t *testing.T) {
 
 		assert.Contains(t, buf.String(), "native-tool agent with no compatible fallback")
 		assert.Contains(t, buf.String(), "WebResearcher")
+	})
+
+	t.Run("warns when native-tool agent has fallback with omitted backend", func(t *testing.T) {
+		buf, restore := captureLogs(t)
+		t.Cleanup(restore)
+
+		cfg := &Config{
+			Defaults: &Defaults{
+				FallbackProviders: []FallbackProviderEntry{
+					{Provider: "openai-fb"},
+				},
+			},
+			AgentRegistry: NewAgentRegistry(map[string]*AgentConfig{
+				"WebResearcher": {
+					NativeTools: map[GoogleNativeTool]bool{
+						GoogleNativeToolGoogleSearch: true,
+					},
+				},
+			}),
+			ChainRegistry: NewChainRegistry(map[string]*ChainConfig{
+				"test-chain": {
+					Stages: []StageConfig{
+						{Name: "s1", Agents: []StageAgentConfig{{Name: "WebResearcher"}}},
+					},
+				},
+			}),
+		}
+		v := NewValidator(cfg)
+		v.warnNativeToolAgentsWithoutCompatibleFallback()
+
+		assert.Contains(t, buf.String(), "native-tool agent with no compatible fallback")
 	})
 
 	t.Run("no warning when fallback includes google-native entry", func(t *testing.T) {


### PR DESCRIPTION
- Make fallback_providers[].backend optional; resolve to langchain at runtime
- Do not inherit defaults.llm_backend or infer from provider type
- Expose resolved backend in config viewer and update ADR-0003


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Fallback providers may omit a backend configuration.
  * Omitted backends now default to `langchain`.
  * Explicitly configured backends, including `google-native`, remain unchanged.

* **Bug Fixes**
  * Improved fallback backend resolution, validation, and native-tool compatibility checks.
  * Prevented omitted fallback backends from incorrectly inheriting the global default backend.

* **Documentation**
  * Updated configuration guidance and architecture documentation to reflect the new fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->