### PR TITLE
fix(agent): pair named LLM providers with langchain

### DIFF
--- a/deploy/config/README.md
+++ b/deploy/config/README.md
@@ -70,10 +70,15 @@ Provider prompt caching (`system.prompt_caching`) is enabled by default. When on
 ```yaml
 defaults:
   llm_provider: "google-default"
+  llm_backend: "google-native"  # sibling of llm_provider; omit → langchain
+  # A named llm_provider (chain, stage-agent, chat, scoring, synthesis, …)
+  # without a sibling llm_backend on that same node resolves to langchain.
+  # google-native must be written next to the provider; it is not inherited.
   # Mid-tier model for compose (amended report after action).
   # Resolution: chain.compose_provider → defaults.compose_provider →
   # chain.llm_provider → defaults.llm_provider.
   # chain.llm_provider does not override defaults.compose_provider.
+  # compose_provider has no sibling backend field; omit → langchain.
   compose_provider: "google-default"
   max_iterations: 20
   fallback_providers:
@@ -298,6 +303,8 @@ agent_chains:
 ```
 
 Effective max_iterations for this agent: **10** (agent-level wins)
+
+Provider and backend are a pair at each YAML node. Setting `llm_provider` without a sibling `llm_backend` uses `langchain` (not `defaults.llm_backend`). Write `llm_backend: google-native` on the same node when you want the Gemini native SDK.
 
 When `sub_agents` are configured at the stage-agent level (or inherited from stage/chain), the agent automatically gains orchestration tools (`dispatch_agent`, `cancel_agent`, `list_agents`) and orchestrator prompt sections. No special agent type is needed. Stage-level `required_skills` and `skills` can also be set — they are **additive** (merged with agent-definition skills).
 

--- a/docs/adr/0003-llm-provider-fallback.md
+++ b/docs/adr/0003-llm-provider-fallback.md
@@ -204,3 +204,5 @@ These original decisions still stand. ADR-0027 changed *how* they behave under s
 ## Amendment (2026-09-01)
 
 **Q3 / backend specification.** Omitted `fallback_providers[].backend` defaults to `langchain`. `google-native` remains explicit. Backend is still not inferred from provider type and does not inherit `defaults.llm_backend`.
+
+The same pairing applies to investigation, chat, scoring, compose, and executive-summary named-provider layers: a YAML node that sets `llm_provider` (or `compose_provider` / `executive_summary_provider`) without a sibling backend resolves backend to `langchain` and does not keep a parent `llm_backend`. `google-native` paired with a non-google provider at the same node is a load-time error.

--- a/pkg/agent/config_resolver.go
+++ b/pkg/agent/config_resolver.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"cmp"
 	"fmt"
 	"log/slog"
 	"slices"
@@ -59,15 +60,11 @@ func ResolveAgentConfig(
 		return nil, fmt.Errorf("agent %q not found: %w", agentConfig.Name, err)
 	}
 
-	// Resolve LLM backend (defaults → agentDef → chain → agentConfig)
-	backend := resolveLLMBackend(
-		defaults.LLMBackend, agentDef.LLMBackend,
-		chain.LLMBackend, agentConfig.LLMBackend,
-	)
-
-	// Resolve LLM provider (defaults → chain → agentConfig)
-	provider, providerName, err := resolveLLMProvider(cfg,
-		defaults.LLMProvider, chain.LLMProvider, agentConfig.LLMProvider,
+	provider, providerName, backend, err := ResolveLLMPair(cfg,
+		LLMLayer{Provider: defaults.LLMProvider, Backend: defaults.LLMBackend},
+		LLMLayer{Backend: agentDef.LLMBackend},
+		LLMLayer{Provider: chain.LLMProvider, Backend: chain.LLMBackend},
+		LLMLayer{Provider: agentConfig.LLMProvider, Backend: agentConfig.LLMBackend},
 	)
 	if err != nil {
 		return nil, err
@@ -193,15 +190,11 @@ func ResolveChatAgentConfig(
 		chatMaxIter = chatCfg.MaxIterations
 	}
 
-	// Resolve LLM backend (defaults → agentDef → chain → chatCfg)
-	backend := resolveLLMBackend(
-		defaults.LLMBackend, agentDef.LLMBackend,
-		chain.LLMBackend, chatBackend,
-	)
-
-	// Resolve LLM provider (defaults → chain → chatCfg)
-	provider, providerName, err := resolveLLMProvider(cfg,
-		defaults.LLMProvider, chain.LLMProvider, chatProvider,
+	provider, providerName, backend, err := ResolveLLMPair(cfg,
+		LLMLayer{Provider: defaults.LLMProvider, Backend: defaults.LLMBackend},
+		LLMLayer{Backend: agentDef.LLMBackend},
+		LLMLayer{Provider: chain.LLMProvider, Backend: chain.LLMBackend},
+		LLMLayer{Provider: chatProvider, Backend: chatBackend},
 	)
 	if err != nil {
 		return nil, err
@@ -318,18 +311,15 @@ func ResolveScoringConfig(
 		scoringMaxIter = scoringCfg.MaxIterations
 	}
 
-	// Resolve LLM backend (defaults → agentDef → defaults.Scoring → scoringCfg).
-	// chain.LLMBackend is intentionally excluded: the chain-level
-	// backend targets investigation agents.
-	backend := resolveLLMBackend(
-		defaults.LLMBackend, agentDef.LLMBackend,
-		defaultsScoringBackend, scoringBackend,
-	)
-
-	// Resolve LLM provider (defaults → defaults.Scoring → chain → scoringCfg)
-	provider, providerName, err := resolveLLMProvider(cfg,
-		defaults.LLMProvider, defaultsScoringProvider,
-		chain.LLMProvider, scoringProvider,
+	// chain.LLMBackend is excluded: it targets investigation agents.
+	// A chain llm_provider without a scoring-level backend therefore
+	// pairs with langchain.
+	provider, providerName, backend, err := ResolveLLMPair(cfg,
+		LLMLayer{Provider: defaults.LLMProvider, Backend: defaults.LLMBackend},
+		LLMLayer{Backend: agentDef.LLMBackend},
+		LLMLayer{Provider: defaultsScoringProvider, Backend: defaultsScoringBackend},
+		LLMLayer{Provider: chain.LLMProvider},
+		LLMLayer{Provider: scoringProvider, Backend: scoringBackend},
 	)
 	if err != nil {
 		return nil, err
@@ -407,16 +397,12 @@ func ResolveExecSummaryConfig(
 		return nil, fmt.Errorf("agent %q not found: %w", config.AgentNameExecSummary, err)
 	}
 
-	// Resolve LLM backend (defaults → agentDef → chain).
-	backend := resolveLLMBackend(
-		defaults.LLMBackend, agentDef.LLMBackend, chain.LLMBackend,
-	)
-
-	// Resolve LLM provider (defaults → chain.llm_provider → chain.executive_summary_provider).
-	// executive_summary_provider is the highest-priority override, allowing a dedicated
-	// model for summaries without affecting investigation agents.
-	provider, providerName, err := resolveLLMProvider(cfg,
-		defaults.LLMProvider, chain.LLMProvider, chain.ExecutiveSummaryProvider,
+	// executive_summary_provider has no sibling backend field; omit → langchain.
+	provider, providerName, backend, err := ResolveLLMPair(cfg,
+		LLMLayer{Provider: defaults.LLMProvider, Backend: defaults.LLMBackend},
+		LLMLayer{Backend: agentDef.LLMBackend},
+		LLMLayer{Provider: chain.LLMProvider, Backend: chain.LLMBackend},
+		LLMLayer{Provider: chain.ExecutiveSummaryProvider},
 	)
 	if err != nil {
 		return nil, err
@@ -480,12 +466,13 @@ func ResolveComposeConfig(
 		return nil, fmt.Errorf("agent %q not found: %w", config.AgentNameCompose, err)
 	}
 
-	backend := resolveLLMBackend(
-		defaults.LLMBackend, agentDef.LLMBackend, chain.LLMBackend,
-	)
-
-	provider, providerName, err := resolveLLMProvider(cfg,
-		defaults.LLMProvider, chain.LLMProvider, defaults.ComposeProvider, chain.ComposeProvider,
+	// compose_provider has no sibling backend field; omit → langchain.
+	provider, providerName, backend, err := ResolveLLMPair(cfg,
+		LLMLayer{Provider: defaults.LLMProvider, Backend: defaults.LLMBackend},
+		LLMLayer{Backend: agentDef.LLMBackend},
+		LLMLayer{Provider: chain.LLMProvider, Backend: chain.LLMBackend},
+		LLMLayer{Provider: defaults.ComposeProvider},
+		LLMLayer{Provider: chain.ComposeProvider},
 	)
 	if err != nil {
 		return nil, err
@@ -564,33 +551,40 @@ func applyAgentNativeTools(provider *config.LLMProviderConfig, agentTools map[co
 	return &cloned
 }
 
-// resolveLLMBackend returns the last non-empty backend from the
-// given overrides, listed in lowest-to-highest precedence order.
-// Falls back to DefaultLLMBackend when no override provides a value.
-func resolveLLMBackend(overrides ...config.LLMBackend) config.LLMBackend {
-	backend := DefaultLLMBackend
-	for _, o := range overrides {
-		if o != "" {
-			backend = o
-		}
-	}
-	return backend
+// LLMLayer is one config level in provider/backend pairing.
+// A layer that names a provider without a sibling backend resolves
+// backend to langchain and does not inherit a parent backend.
+type LLMLayer struct {
+	Provider string
+	Backend  config.LLMBackend
 }
 
-// resolveLLMProvider picks the last non-empty provider name from the given
-// overrides and looks it up in the config registry.
-func resolveLLMProvider(cfg *config.Config, providerNames ...string) (*config.LLMProviderConfig, string, error) {
-	var name string
-	for _, n := range providerNames {
-		if n != "" {
-			name = n
+// applyLLMLayers walks layers lowest-to-highest and returns the resolved pair.
+func applyLLMLayers(layers ...LLMLayer) (providerName string, backend config.LLMBackend) {
+	backend = DefaultLLMBackend
+	for _, layer := range layers {
+		if layer.Provider != "" {
+			providerName = layer.Provider
+			backend = cmp.Or(layer.Backend, DefaultLLMBackend)
+		} else if layer.Backend != "" {
+			backend = layer.Backend
 		}
+	}
+	return providerName, backend
+}
+
+// ResolveLLMPair walks layers (lowest to highest) and looks up the provider.
+// On lookup failure, name and backend from the walk are still returned.
+func ResolveLLMPair(cfg *config.Config, layers ...LLMLayer) (*config.LLMProviderConfig, string, config.LLMBackend, error) {
+	name, backend := applyLLMLayers(layers...)
+	if cfg == nil {
+		return nil, name, backend, fmt.Errorf("LLM provider %q not found: config is nil", name)
 	}
 	provider, err := cfg.GetLLMProvider(name)
 	if err != nil {
-		return nil, "", fmt.Errorf("LLM provider %q not found: %w", name, err)
+		return nil, name, backend, fmt.Errorf("LLM provider %q not found: %w", name, err)
 	}
-	return provider, name, nil
+	return provider, name, backend, nil
 }
 
 // resolveFallbackProviders returns the last non-nil fallback list from the

--- a/pkg/agent/config_resolver_test.go
+++ b/pkg/agent/config_resolver_test.go
@@ -2415,3 +2415,295 @@ func TestResolvedAgentConfig_OnDemandSkillNameSet(t *testing.T) {
 		})
 	}
 }
+
+func TestApplyLLMLayers(t *testing.T) {
+	tests := []struct {
+		name         string
+		layers       []LLMLayer
+		wantProvider string
+		wantBackend  config.LLMBackend
+	}{
+		{
+			name:         "empty layers default to langchain",
+			wantBackend:  DefaultLLMBackend,
+			wantProvider: "",
+		},
+		{
+			name: "defaults pair is kept",
+			layers: []LLMLayer{
+				{Provider: "google-default", Backend: config.LLMBackendNativeGemini},
+			},
+			wantProvider: "google-default",
+			wantBackend:  config.LLMBackendNativeGemini,
+		},
+		{
+			name: "named provider without sibling backend resets to langchain",
+			layers: []LLMLayer{
+				{Provider: "google-default", Backend: config.LLMBackendNativeGemini},
+				{Provider: "openai-default"},
+			},
+			wantProvider: "openai-default",
+			wantBackend:  config.LLMBackendLangChain,
+		},
+		{
+			name: "explicit sibling backend is kept",
+			layers: []LLMLayer{
+				{Provider: "google-default", Backend: config.LLMBackendNativeGemini},
+				{Provider: "google-default", Backend: config.LLMBackendNativeGemini},
+			},
+			wantProvider: "google-default",
+			wantBackend:  config.LLMBackendNativeGemini,
+		},
+		{
+			name: "backend-only override keeps provider",
+			layers: []LLMLayer{
+				{Provider: "google-default", Backend: config.LLMBackendNativeGemini},
+				{Backend: config.LLMBackendLangChain},
+			},
+			wantProvider: "google-default",
+			wantBackend:  config.LLMBackendLangChain,
+		},
+		{
+			name: "agent-def backend-only after defaults",
+			layers: []LLMLayer{
+				{Provider: "google-default", Backend: config.LLMBackendLangChain},
+				{Backend: config.LLMBackendNativeGemini},
+			},
+			wantProvider: "google-default",
+			wantBackend:  config.LLMBackendNativeGemini,
+		},
+		{
+			name: "provider-only after agent-def native backend resets to langchain",
+			layers: []LLMLayer{
+				{Provider: "google-default", Backend: config.LLMBackendLangChain},
+				{Backend: config.LLMBackendNativeGemini},
+				{Provider: "google-default"},
+			},
+			wantProvider: "google-default",
+			wantBackend:  config.LLMBackendLangChain,
+		},
+		{
+			name: "empty layer does not change the pair",
+			layers: []LLMLayer{
+				{Provider: "google-default", Backend: config.LLMBackendNativeGemini},
+				{},
+			},
+			wantProvider: "google-default",
+			wantBackend:  config.LLMBackendNativeGemini,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotProvider, gotBackend := applyLLMLayers(tt.layers...)
+			assert.Equal(t, tt.wantProvider, gotProvider)
+			assert.Equal(t, tt.wantBackend, gotBackend)
+		})
+	}
+}
+
+func TestLLMProviderBackendPairing(t *testing.T) {
+	google := &config.LLMProviderConfig{
+		Type: config.LLMProviderTypeGoogle, Model: "gemini", APIKeyEnv: "GOOGLE_API_KEY",
+	}
+	openai := &config.LLMProviderConfig{
+		Type: config.LLMProviderTypeOpenAI, Model: "gpt-5", APIKeyEnv: "OPENAI_API_KEY",
+	}
+
+	cfg := &config.Config{
+		Defaults: &config.Defaults{
+			LLMProvider: "google-default",
+			LLMBackend:  config.LLMBackendNativeGemini,
+		},
+		AgentRegistry: config.NewAgentRegistry(map[string]*config.AgentConfig{
+			"PlainAgent":                {},
+			"WebResearcher":             {LLMBackend: config.LLMBackendNativeGemini},
+			config.AgentNameChat:        {},
+			config.AgentNameScoring:     {Type: config.AgentTypeScoring},
+			config.AgentNameExecSummary: {Type: config.AgentTypeExecSummary},
+			config.AgentNameCompose:     {Type: config.AgentTypeCompose},
+		}),
+		LLMProviderRegistry: config.NewLLMProviderRegistry(map[string]*config.LLMProviderConfig{
+			"google-default": google,
+			"openai-default": openai,
+		}),
+	}
+
+	t.Run("stage provider without sibling backend uses langchain", func(t *testing.T) {
+		resolved, err := ResolveAgentConfig(cfg, &config.ChainConfig{}, config.StageConfig{},
+			config.StageAgentConfig{Name: "PlainAgent", LLMProvider: "openai-default"})
+		require.NoError(t, err)
+		assert.Equal(t, "openai-default", resolved.LLMProviderName)
+		assert.Equal(t, config.LLMBackendLangChain, resolved.LLMBackend)
+	})
+
+	t.Run("stage google pair with explicit google-native is kept", func(t *testing.T) {
+		resolved, err := ResolveAgentConfig(cfg, &config.ChainConfig{}, config.StageConfig{},
+			config.StageAgentConfig{
+				Name:        "PlainAgent",
+				LLMProvider: "google-default",
+				LLMBackend:  config.LLMBackendNativeGemini,
+			})
+		require.NoError(t, err)
+		assert.Equal(t, "google-default", resolved.LLMProviderName)
+		assert.Equal(t, config.LLMBackendNativeGemini, resolved.LLMBackend)
+	})
+
+	t.Run("backend-only override keeps inherited provider", func(t *testing.T) {
+		resolved, err := ResolveAgentConfig(cfg, &config.ChainConfig{}, config.StageConfig{},
+			config.StageAgentConfig{Name: "PlainAgent", LLMBackend: config.LLMBackendLangChain})
+		require.NoError(t, err)
+		assert.Equal(t, "google-default", resolved.LLMProviderName)
+		assert.Equal(t, config.LLMBackendLangChain, resolved.LLMBackend)
+	})
+
+	t.Run("agent-def google-native is kept when stage does not name a provider", func(t *testing.T) {
+		resolved, err := ResolveAgentConfig(cfg, &config.ChainConfig{}, config.StageConfig{},
+			config.StageAgentConfig{Name: "WebResearcher"})
+		require.NoError(t, err)
+		assert.Equal(t, "google-default", resolved.LLMProviderName)
+		assert.Equal(t, config.LLMBackendNativeGemini, resolved.LLMBackend)
+	})
+
+	t.Run("agent-def google-native resets when stage names a provider without backend", func(t *testing.T) {
+		resolved, err := ResolveAgentConfig(cfg, &config.ChainConfig{}, config.StageConfig{},
+			config.StageAgentConfig{Name: "WebResearcher", LLMProvider: "openai-default"})
+		require.NoError(t, err)
+		assert.Equal(t, "openai-default", resolved.LLMProviderName)
+		assert.Equal(t, config.LLMBackendLangChain, resolved.LLMBackend)
+	})
+
+	t.Run("chain provider without chain backend uses langchain", func(t *testing.T) {
+		resolved, err := ResolveAgentConfig(cfg, &config.ChainConfig{LLMProvider: "openai-default"},
+			config.StageConfig{}, config.StageAgentConfig{Name: "PlainAgent"})
+		require.NoError(t, err)
+		assert.Equal(t, "openai-default", resolved.LLMProviderName)
+		assert.Equal(t, config.LLMBackendLangChain, resolved.LLMBackend)
+	})
+
+	t.Run("chat provider without sibling backend uses langchain", func(t *testing.T) {
+		resolved, err := ResolveChatAgentConfig(cfg, &config.ChainConfig{},
+			&config.ChatConfig{LLMProvider: "openai-default"})
+		require.NoError(t, err)
+		assert.Equal(t, "openai-default", resolved.LLMProviderName)
+		assert.Equal(t, config.LLMBackendLangChain, resolved.LLMBackend)
+	})
+
+	t.Run("chat without provider keeps chain google-native pair", func(t *testing.T) {
+		resolved, err := ResolveChatAgentConfig(cfg, &config.ChainConfig{
+			LLMProvider: "google-default",
+			LLMBackend:  config.LLMBackendNativeGemini,
+		}, nil)
+		require.NoError(t, err)
+		assert.Equal(t, "google-default", resolved.LLMProviderName)
+		assert.Equal(t, config.LLMBackendNativeGemini, resolved.LLMBackend)
+	})
+
+	t.Run("scoring named provider without scoring backend uses langchain", func(t *testing.T) {
+		cfgScoring := *cfg
+		cfgScoring.Defaults = &config.Defaults{
+			LLMProvider: "google-default",
+			LLMBackend:  config.LLMBackendNativeGemini,
+			Scoring:     &config.ScoringConfig{LLMProvider: "openai-default"},
+		}
+		resolved, err := ResolveScoringConfig(&cfgScoring, &config.ChainConfig{}, nil)
+		require.NoError(t, err)
+		assert.Equal(t, "openai-default", resolved.LLMProviderName)
+		assert.Equal(t, config.LLMBackendLangChain, resolved.LLMBackend)
+	})
+
+	t.Run("chain scoring provider without scoring backend uses langchain", func(t *testing.T) {
+		resolved, err := ResolveScoringConfig(cfg, &config.ChainConfig{},
+			&config.ScoringConfig{LLMProvider: "openai-default"})
+		require.NoError(t, err)
+		assert.Equal(t, "openai-default", resolved.LLMProviderName)
+		assert.Equal(t, config.LLMBackendLangChain, resolved.LLMBackend)
+	})
+
+	t.Run("scoring chain provider without scoring backend uses langchain", func(t *testing.T) {
+		resolved, err := ResolveScoringConfig(cfg, &config.ChainConfig{
+			LLMProvider: "openai-default",
+			LLMBackend:  config.LLMBackendNativeGemini,
+		}, nil)
+		require.NoError(t, err)
+		assert.Equal(t, "openai-default", resolved.LLMProviderName)
+		assert.Equal(t, config.LLMBackendLangChain, resolved.LLMBackend)
+	})
+
+	t.Run("scoring ignores chain llm_backend", func(t *testing.T) {
+		resolved, err := ResolveScoringConfig(cfg, &config.ChainConfig{
+			LLMBackend: config.LLMBackendLangChain,
+		}, nil)
+		require.NoError(t, err)
+		assert.Equal(t, "google-default", resolved.LLMProviderName)
+		assert.Equal(t, config.LLMBackendNativeGemini, resolved.LLMBackend)
+	})
+
+	t.Run("executive_summary_provider without sibling uses langchain", func(t *testing.T) {
+		resolved, err := ResolveExecSummaryConfig(cfg, &config.ChainConfig{
+			LLMBackend:               config.LLMBackendNativeGemini,
+			ExecutiveSummaryProvider: "openai-default",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "openai-default", resolved.LLMProviderName)
+		assert.Equal(t, config.LLMBackendLangChain, resolved.LLMBackend)
+	})
+
+	t.Run("compose_provider without sibling uses langchain", func(t *testing.T) {
+		cfgCompose := *cfg
+		cfgCompose.Defaults = &config.Defaults{
+			LLMProvider:     "google-default",
+			LLMBackend:      config.LLMBackendNativeGemini,
+			ComposeProvider: "openai-default",
+		}
+		resolved, err := ResolveComposeConfig(&cfgCompose, &config.ChainConfig{
+			LLMBackend: config.LLMBackendNativeGemini,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "openai-default", resolved.LLMProviderName)
+		assert.Equal(t, config.LLMBackendLangChain, resolved.LLMBackend)
+	})
+
+	t.Run("chain compose_provider without sibling uses langchain", func(t *testing.T) {
+		resolved, err := ResolveComposeConfig(cfg, &config.ChainConfig{
+			LLMBackend:      config.LLMBackendNativeGemini,
+			ComposeProvider: "openai-default",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "openai-default", resolved.LLMProviderName)
+		assert.Equal(t, config.LLMBackendLangChain, resolved.LLMBackend)
+	})
+}
+
+func TestResolveLLMPair(t *testing.T) {
+	google := &config.LLMProviderConfig{
+		Type: config.LLMProviderTypeGoogle, Model: "gemini", APIKeyEnv: "GOOGLE_API_KEY",
+	}
+	cfg := &config.Config{
+		LLMProviderRegistry: config.NewLLMProviderRegistry(map[string]*config.LLMProviderConfig{
+			"google-default": google,
+		}),
+	}
+
+	t.Run("lookup success returns provider and pair", func(t *testing.T) {
+		provider, name, backend, err := ResolveLLMPair(cfg,
+			LLMLayer{Provider: "google-default", Backend: config.LLMBackendNativeGemini},
+		)
+		require.NoError(t, err)
+		assert.Equal(t, google, provider)
+		assert.Equal(t, "google-default", name)
+		assert.Equal(t, config.LLMBackendNativeGemini, backend)
+	})
+
+	t.Run("unknown provider still returns paired name and langchain", func(t *testing.T) {
+		provider, name, backend, err := ResolveLLMPair(cfg,
+			LLMLayer{Provider: "google-default", Backend: config.LLMBackendNativeGemini},
+			LLMLayer{Provider: "missing-provider"},
+		)
+		require.Error(t, err)
+		assert.Nil(t, provider)
+		assert.Equal(t, "missing-provider", name)
+		assert.Equal(t, config.LLMBackendLangChain, backend)
+		assert.Contains(t, err.Error(), `LLM provider "missing-provider" not found`)
+	})
+}

--- a/pkg/config/validator.go
+++ b/pkg/config/validator.go
@@ -138,6 +138,9 @@ func (v *Validator) validateDefaults() error {
 			return NewValidationError("defaults", "", "scoring.llm_provider",
 				fmt.Errorf("LLM provider '%s' not found", defaults.Scoring.LLMProvider))
 		}
+		if err := v.googleNativeRequiresGoogleProvider(defaults.Scoring.LLMProvider, defaults.Scoring.LLMBackend); err != nil {
+			return NewValidationError("defaults", "", "scoring.llm_backend", err)
+		}
 		if defaults.Scoring.MaxIterations != nil && *defaults.Scoring.MaxIterations < 1 {
 			return NewValidationError("defaults", "", "scoring.max_iterations",
 				fmt.Errorf("must be at least 1"))
@@ -146,6 +149,10 @@ func (v *Validator) validateDefaults() error {
 
 	if err := v.validateDefaultsSummarization(defaults.Summarization); err != nil {
 		return err
+	}
+
+	if err := v.googleNativeRequiresGoogleProvider(defaults.LLMProvider, defaults.LLMBackend); err != nil {
+		return NewValidationError("defaults", "", "llm_backend", err)
 	}
 
 	if defaults.ComposeProvider != "" && (v.cfg.LLMProviderRegistry == nil || !v.cfg.LLMProviderRegistry.Has(defaults.ComposeProvider)) {
@@ -224,6 +231,29 @@ func (v *Validator) validateSummarizationLLM(sum *SummarizationConfig, component
 	if sum.LLMProvider != "" && (v.cfg.LLMProviderRegistry == nil || !v.cfg.LLMProviderRegistry.Has(sum.LLMProvider)) {
 		return NewValidationError(component, id, fieldPrefix+".llm_provider",
 			fmt.Errorf("LLM provider '%s' not found", sum.LLMProvider))
+	}
+	if err := v.googleNativeRequiresGoogleProvider(sum.LLMProvider, sum.LLMBackend); err != nil {
+		return NewValidationError(component, id, fieldPrefix+".llm_backend", err)
+	}
+	return nil
+}
+
+// googleNativeRequiresGoogleProvider rejects an explicit google-native backend
+// paired with a non-google provider at the same YAML node. Unknown providers
+// are reported elsewhere. Backend-only overrides (no sibling provider) pass.
+func (v *Validator) googleNativeRequiresGoogleProvider(providerName string, backend LLMBackend) error {
+	if backend != LLMBackendNativeGemini || providerName == "" {
+		return nil
+	}
+	if v.cfg.LLMProviderRegistry == nil {
+		return nil
+	}
+	provider, err := v.cfg.LLMProviderRegistry.Get(providerName)
+	if err != nil {
+		return nil
+	}
+	if provider.Type != LLMProviderTypeGoogle {
+		return fmt.Errorf("llm_backend %q requires a google provider, got type %q for %q", backend, provider.Type, providerName)
 	}
 	return nil
 }
@@ -377,6 +407,9 @@ func (v *Validator) validateChains() error {
 			if chain.Chat.LLMProvider != "" && !v.cfg.LLMProviderRegistry.Has(chain.Chat.LLMProvider) {
 				return NewValidationError("chain", chainID, "chat.llm_provider", fmt.Errorf("LLM provider '%s' not found", chain.Chat.LLMProvider))
 			}
+			if err := v.googleNativeRequiresGoogleProvider(chain.Chat.LLMProvider, chain.Chat.LLMBackend); err != nil {
+				return NewValidationError("chain", chainID, "chat.llm_backend", err)
+			}
 
 			// Validate chat max iterations if specified
 			if chain.Chat.MaxIterations != nil && *chain.Chat.MaxIterations < 1 {
@@ -410,6 +443,9 @@ func (v *Validator) validateChains() error {
 			if chain.Scoring.LLMProvider != "" && !v.cfg.LLMProviderRegistry.Has(chain.Scoring.LLMProvider) {
 				return NewValidationError("chain", chainID, "scoring.llm_provider", fmt.Errorf("LLM provider '%s' not found", chain.Scoring.LLMProvider))
 			}
+			if err := v.googleNativeRequiresGoogleProvider(chain.Scoring.LLMProvider, chain.Scoring.LLMBackend); err != nil {
+				return NewValidationError("chain", chainID, "scoring.llm_backend", err)
+			}
 
 			// Validate scoring max iterations if specified
 			if chain.Scoring.MaxIterations != nil && *chain.Scoring.MaxIterations < 1 {
@@ -427,6 +463,9 @@ func (v *Validator) validateChains() error {
 		// Validate chain-level LLM provider if specified
 		if chain.LLMProvider != "" && !v.cfg.LLMProviderRegistry.Has(chain.LLMProvider) {
 			return NewValidationError("chain", chainID, "llm_provider", fmt.Errorf("LLM provider '%s' not found", chain.LLMProvider))
+		}
+		if err := v.googleNativeRequiresGoogleProvider(chain.LLMProvider, chain.LLMBackend); err != nil {
+			return NewValidationError("chain", chainID, "llm_backend", err)
 		}
 
 		if chain.ComposeProvider != "" && !v.cfg.LLMProviderRegistry.Has(chain.ComposeProvider) {
@@ -494,6 +533,9 @@ func (v *Validator) validateStage(chainID string, stageIndex int, stage *StageCo
 		// Validate agent-level LLM provider if specified
 		if agentConfig.LLMProvider != "" && !v.cfg.LLMProviderRegistry.Has(agentConfig.LLMProvider) {
 			return fmt.Errorf("%s: agent '%s' specifies LLM provider '%s' which is not found", stageRef, agentConfig.Name, agentConfig.LLMProvider)
+		}
+		if err := v.googleNativeRequiresGoogleProvider(agentConfig.LLMProvider, agentConfig.LLMBackend); err != nil {
+			return fmt.Errorf("%s: agent '%s': %w", stageRef, agentConfig.Name, err)
 		}
 
 		// Validate agent-level max iterations if specified
@@ -571,6 +613,9 @@ func (v *Validator) validateStage(chainID string, stageIndex int, stage *StageCo
 		// Validate synthesis LLM provider if specified
 		if stage.Synthesis.LLMProvider != "" && !v.cfg.LLMProviderRegistry.Has(stage.Synthesis.LLMProvider) {
 			return fmt.Errorf("%s: synthesis specifies LLM provider '%s' which is not found", stageRef, stage.Synthesis.LLMProvider)
+		}
+		if err := v.googleNativeRequiresGoogleProvider(stage.Synthesis.LLMProvider, stage.Synthesis.LLMBackend); err != nil {
+			return fmt.Errorf("%s: synthesis: %w", stageRef, err)
 		}
 	}
 
@@ -861,6 +906,9 @@ func (v *Validator) validateSubAgentRefs(subAgents SubAgentRefs, section, name, 
 		if ref.LLMProvider != "" && !v.cfg.LLMProviderRegistry.Has(ref.LLMProvider) {
 			return NewValidationError(section, name, field, fmt.Errorf("sub-agent '%s' specifies LLM provider '%s' which is not found", ref.Name, ref.LLMProvider))
 		}
+		if err := v.googleNativeRequiresGoogleProvider(ref.LLMProvider, ref.LLMBackend); err != nil {
+			return NewValidationError(section, name, field, fmt.Errorf("sub-agent '%s': %w", ref.Name, err))
+		}
 		if ref.MaxIterations != nil && *ref.MaxIterations < 1 {
 			return NewValidationError(section, name, field, fmt.Errorf("sub-agent '%s' max_iterations must be at least 1", ref.Name))
 		}
@@ -917,6 +965,9 @@ func (v *Validator) validateFallbackProviders(entries []FallbackProviderEntry, s
 		if !entry.ResolvedBackend().IsValid() {
 			return NewValidationError(section, name, entryRef,
 				fmt.Errorf("invalid LLM backend: %s", entry.Backend))
+		}
+		if err := v.googleNativeRequiresGoogleProvider(entry.Provider, entry.Backend); err != nil {
+			return NewValidationError(section, name, entryRef, err)
 		}
 
 		// Credentials must be set

--- a/pkg/config/validator_test.go
+++ b/pkg/config/validator_test.go
@@ -680,6 +680,27 @@ func TestValidateMCPServersSummarizationProvider(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "google-native overlay with openai provider fails",
+			servers: map[string]*MCPServerConfig{
+				"test-server": {
+					Transport: TransportConfig{
+						Type:    TransportTypeStdio,
+						Command: "test",
+					},
+					Summarization: &SummarizationConfig{
+						SizeThresholdTokens: 5000,
+						LLMProvider:         "openai-default",
+						LLMBackend:          LLMBackendNativeGemini,
+					},
+				},
+			},
+			providers: map[string]*LLMProviderConfig{
+				"openai-default": {Type: LLMProviderTypeOpenAI, Model: "gpt-5"},
+			},
+			wantErr: true,
+			errMsg:  "requires a google provider",
+		},
+		{
 			name: "invalid backend fails",
 			servers: map[string]*MCPServerConfig{
 				"test-server": {
@@ -1392,6 +1413,73 @@ func TestValidateStageComprehensive(t *testing.T) {
 			errMsg:  "LLM provider 'nonexistent-provider' which is not found",
 		},
 		{
+			name: "stage agent google-native with openai provider fails",
+			stage: StageConfig{
+				Name: "stage1",
+				Agents: []StageAgentConfig{
+					{
+						Name:        "test-agent",
+						LLMProvider: "openai-default",
+						LLMBackend:  LLMBackendNativeGemini,
+					},
+				},
+			},
+			agents: map[string]*AgentConfig{
+				"test-agent": {MCPServers: []string{"test-server"}},
+			},
+			providers: map[string]*LLMProviderConfig{
+				"openai-default": {Type: LLMProviderTypeOpenAI, Model: "gpt-5"},
+			},
+			servers: map[string]*MCPServerConfig{
+				"test-server": {Transport: TransportConfig{Type: TransportTypeStdio, Command: "test"}},
+			},
+			wantErr: true,
+			errMsg:  "requires a google provider",
+		},
+		{
+			name: "stage agent google-native with google provider passes",
+			stage: StageConfig{
+				Name: "stage1",
+				Agents: []StageAgentConfig{
+					{
+						Name:        "test-agent",
+						LLMProvider: "google-default",
+						LLMBackend:  LLMBackendNativeGemini,
+					},
+				},
+			},
+			agents: map[string]*AgentConfig{
+				"test-agent": {MCPServers: []string{"test-server"}},
+			},
+			providers: map[string]*LLMProviderConfig{
+				"google-default": {Type: LLMProviderTypeGoogle, Model: "gemini"},
+			},
+			servers: map[string]*MCPServerConfig{
+				"test-server": {Transport: TransportConfig{Type: TransportTypeStdio, Command: "test"}},
+			},
+			wantErr: false,
+		},
+		{
+			name: "stage agent backend-only google-native passes",
+			stage: StageConfig{
+				Name: "stage1",
+				Agents: []StageAgentConfig{
+					{
+						Name:       "test-agent",
+						LLMBackend: LLMBackendNativeGemini,
+					},
+				},
+			},
+			agents: map[string]*AgentConfig{
+				"test-agent": {MCPServers: []string{"test-server"}},
+			},
+			providers: map[string]*LLMProviderConfig{},
+			servers: map[string]*MCPServerConfig{
+				"test-server": {Transport: TransportConfig{Type: TransportTypeStdio, Command: "test"}},
+			},
+			wantErr: false,
+		},
+		{
 			name: "stage with agent-level invalid max iterations",
 			stage: StageConfig{
 				Name: "stage1",
@@ -1544,6 +1632,50 @@ func TestValidateStageComprehensive(t *testing.T) {
 			},
 			wantErr: true,
 			errMsg:  "LLM provider 'nonexistent-provider' which is not found",
+		},
+		{
+			name: "synthesis google-native with openai provider fails",
+			stage: StageConfig{
+				Name:   "stage1",
+				Agents: []StageAgentConfig{{Name: "test-agent"}},
+				Synthesis: &SynthesisConfig{
+					LLMProvider: "openai-default",
+					LLMBackend:  LLMBackendNativeGemini,
+				},
+			},
+			agents: map[string]*AgentConfig{
+				"test-agent": {MCPServers: []string{"test-server"}},
+			},
+			providers: map[string]*LLMProviderConfig{
+				"openai-default": {Type: LLMProviderTypeOpenAI, Model: "gpt-5"},
+			},
+			servers: map[string]*MCPServerConfig{
+				"test-server": {Transport: TransportConfig{Type: TransportTypeStdio, Command: "test"}},
+			},
+			wantErr: true,
+			errMsg:  "requires a google provider",
+		},
+		{
+			name: "synthesis google-native with anthropic provider fails",
+			stage: StageConfig{
+				Name:   "stage1",
+				Agents: []StageAgentConfig{{Name: "test-agent"}},
+				Synthesis: &SynthesisConfig{
+					LLMProvider: "anthropic-default",
+					LLMBackend:  LLMBackendNativeGemini,
+				},
+			},
+			agents: map[string]*AgentConfig{
+				"test-agent": {MCPServers: []string{"test-server"}},
+			},
+			providers: map[string]*LLMProviderConfig{
+				"anthropic-default": {Type: LLMProviderTypeAnthropic, Model: "claude-sonnet"},
+			},
+			servers: map[string]*MCPServerConfig{
+				"test-server": {Transport: TransportConfig{Type: TransportTypeStdio, Command: "test"}},
+			},
+			wantErr: true,
+			errMsg:  "requires a google provider",
 		},
 		{
 			name: "stage with action agent type is valid",
@@ -1866,7 +1998,64 @@ func TestValidateChainsEdgeCases(t *testing.T) {
 			},
 			wantErr: false,
 		},
-		// Scoring validation tests
+		{
+			name: "chain google-native with openai provider fails",
+			chains: map[string]*ChainConfig{
+				"test-chain": {
+					AlertTypes:  []string{"test"},
+					LLMProvider: "openai-default",
+					LLMBackend:  LLMBackendNativeGemini,
+					Stages: []StageConfig{
+						{
+							Name:   "stage1",
+							Agents: []StageAgentConfig{{Name: "test-agent"}},
+						},
+					},
+				},
+			},
+			agents: map[string]*AgentConfig{
+				"test-agent": {MCPServers: []string{"test-server"}},
+			},
+			providers: map[string]*LLMProviderConfig{
+				"openai-default": {Type: LLMProviderTypeOpenAI, Model: "gpt-5"},
+			},
+			servers: map[string]*MCPServerConfig{
+				"test-server": {Transport: TransportConfig{Type: TransportTypeStdio, Command: "test"}},
+			},
+			wantErr: true,
+			errMsg:  "requires a google provider",
+		},
+		{
+			name: "chat google-native with openai provider fails",
+			chains: map[string]*ChainConfig{
+				"test-chain": {
+					AlertTypes: []string{"test"},
+					Chat: &ChatConfig{
+						Enabled:     true,
+						Agent:       "test-agent",
+						LLMProvider: "openai-default",
+						LLMBackend:  LLMBackendNativeGemini,
+					},
+					Stages: []StageConfig{
+						{
+							Name:   "stage1",
+							Agents: []StageAgentConfig{{Name: "test-agent"}},
+						},
+					},
+				},
+			},
+			agents: map[string]*AgentConfig{
+				"test-agent": {MCPServers: []string{"test-server"}},
+			},
+			providers: map[string]*LLMProviderConfig{
+				"openai-default": {Type: LLMProviderTypeOpenAI, Model: "gpt-5"},
+			},
+			servers: map[string]*MCPServerConfig{
+				"test-server": {Transport: TransportConfig{Type: TransportTypeStdio, Command: "test"}},
+			},
+			wantErr: true,
+			errMsg:  "requires a google provider",
+		},
 		{
 			name: "scoring enabled uses built-in agent by default",
 			chains: map[string]*ChainConfig{
@@ -2202,10 +2391,11 @@ func TestValidateMCPServersSSETransport(t *testing.T) {
 
 func TestValidateDefaults(t *testing.T) {
 	tests := []struct {
-		name     string
-		defaults *Defaults
-		wantErr  bool
-		errMsg   string
+		name      string
+		defaults  *Defaults
+		providers map[string]*LLMProviderConfig
+		wantErr   bool
+		errMsg    string
 	}{
 		{
 			name:     "nil defaults passes",
@@ -2277,12 +2467,25 @@ func TestValidateDefaults(t *testing.T) {
 			wantErr: true,
 			errMsg:  "compose_provider",
 		},
+		{
+			name: "google-native with openai defaults provider fails",
+			defaults: &Defaults{
+				LLMProvider: "openai-default",
+				LLMBackend:  LLMBackendNativeGemini,
+			},
+			providers: map[string]*LLMProviderConfig{
+				"openai-default": {Type: LLMProviderTypeOpenAI, Model: "gpt-5"},
+			},
+			wantErr: true,
+			errMsg:  "requires a google provider",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := &Config{
-				Defaults: tt.defaults,
+				Defaults:            tt.defaults,
+				LLMProviderRegistry: NewLLMProviderRegistry(tt.providers),
 			}
 
 			validator := NewValidator(cfg)
@@ -2379,6 +2582,21 @@ func TestValidateDefaultsScoring(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "google-native with openai scoring provider fails",
+			defaults: &Defaults{
+				Scoring: &ScoringConfig{
+					LLMProvider: "openai-default",
+					LLMBackend:  LLMBackendNativeGemini,
+				},
+			},
+			agents: map[string]*AgentConfig{},
+			providers: map[string]*LLMProviderConfig{
+				"openai-default": {Type: LLMProviderTypeOpenAI, Model: "gpt-5"},
+			},
+			wantErr: true,
+			errMsg:  "requires a google provider",
+		},
+		{
 			name: "invalid scoring max_iterations fails",
 			defaults: &Defaults{
 				Scoring: &ScoringConfig{MaxIterations: intPtr(0)},
@@ -2451,6 +2669,20 @@ func TestValidateDefaultsSummarization(t *testing.T) {
 				"test-provider": {Type: LLMProviderTypeGoogle, Model: "test"},
 			},
 			wantErr: false,
+		},
+		{
+			name: "google-native with openai summarization provider fails",
+			defaults: &Defaults{
+				Summarization: &SummarizationConfig{
+					LLMProvider: "openai-default",
+					LLMBackend:  LLMBackendNativeGemini,
+				},
+			},
+			providers: map[string]*LLMProviderConfig{
+				"openai-default": {Type: LLMProviderTypeOpenAI, Model: "gpt-5"},
+			},
+			wantErr: true,
+			errMsg:  "requires a google provider",
 		},
 		{
 			name: "unknown provider fails",
@@ -3356,7 +3588,32 @@ func TestValidateSubAgents(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("sub_agent ref unknown required_skill", func(t *testing.T) {
+	t.Run("sub_agent google-native with openai provider fails", func(t *testing.T) {
+		cfg := &Config{
+			AgentRegistry:     NewAgentRegistry(baseAgents),
+			MCPServerRegistry: NewMCPServerRegistry(map[string]*MCPServerConfig{}),
+			LLMProviderRegistry: NewLLMProviderRegistry(map[string]*LLMProviderConfig{
+				"openai-default": {Type: LLMProviderTypeOpenAI, Model: "gpt-5"},
+			}),
+			ChainRegistry: NewChainRegistry(map[string]*ChainConfig{
+				"chain1": {
+					AlertTypes: []string{"test"},
+					SubAgents: SubAgentRefs{
+						{Name: "LogAnalyzer", LLMProvider: "openai-default", LLMBackend: LLMBackendNativeGemini},
+					},
+					Stages: []StageConfig{
+						{Name: "s1", Agents: []StageAgentConfig{{Name: "MetricChecker"}}},
+					},
+				},
+			}),
+		}
+		validator := NewValidator(cfg)
+		err := validator.validateChains()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "requires a google provider")
+	})
+
+	t.Run("sub_agent ref with unknown required_skill fails", func(t *testing.T) {
 		reg := NewSkillRegistry(map[string]*SkillConfig{
 			"known-skill": {Name: "known-skill", Description: "d", Body: "b"},
 		})
@@ -3866,6 +4123,20 @@ func TestValidateFallbackProviders(t *testing.T) {
 			env:     map[string]string{"GOOD_KEY": "secret"},
 			wantErr: true,
 			errMsg:  "LLM provider 'bad-provider' not found",
+		},
+		{
+			name: "fallback google-native with openai provider fails",
+			defaults: &Defaults{
+				FallbackProviders: []FallbackProviderEntry{
+					{Provider: "openai-fb", Backend: LLMBackendNativeGemini},
+				},
+			},
+			providers: map[string]*LLMProviderConfig{
+				"openai-fb": {Type: LLMProviderTypeOpenAI, Model: "gpt-5", APIKeyEnv: "FB_KEY"},
+			},
+			env:     map[string]string{"FB_KEY": "secret"},
+			wantErr: true,
+			errMsg:  "requires a google provider",
 		},
 		{
 			name: "empty fallback list is valid",

--- a/pkg/queue/executor.go
+++ b/pkg/queue/executor.go
@@ -575,28 +575,20 @@ func (e *RealSessionExecutor) executeAgent(
 	)
 
 	// Best-effort provider/backend for the error path (before ResolveAgentConfig
-	// succeeds). The happy path uses resolvedConfig instead, keeping
-	// ResolveAgentConfig as the single source of truth.
-	var fallbackProviderName string
-	fallbackBackend := agent.DefaultLLMBackend
+	// succeeds). Same pairing as ResolveAgentConfig, minus agent-def (lookup
+	// may be what failed). Lookup errors are ignored; name/backend still apply.
+	var layers []agent.LLMLayer
 	if e.cfg.Defaults != nil {
-		fallbackProviderName = e.cfg.Defaults.LLMProvider
-		if e.cfg.Defaults.LLMBackend != "" {
-			fallbackBackend = e.cfg.Defaults.LLMBackend
-		}
+		layers = append(layers, agent.LLMLayer{
+			Provider: e.cfg.Defaults.LLMProvider,
+			Backend:  e.cfg.Defaults.LLMBackend,
+		})
 	}
-	if input.chain.LLMProvider != "" {
-		fallbackProviderName = input.chain.LLMProvider
-	}
-	if agentConfig.LLMProvider != "" {
-		fallbackProviderName = agentConfig.LLMProvider
-	}
-	if input.chain.LLMBackend != "" {
-		fallbackBackend = input.chain.LLMBackend
-	}
-	if agentConfig.LLMBackend != "" {
-		fallbackBackend = agentConfig.LLMBackend
-	}
+	layers = append(layers,
+		agent.LLMLayer{Provider: input.chain.LLMProvider, Backend: input.chain.LLMBackend},
+		agent.LLMLayer{Provider: agentConfig.LLMProvider, Backend: agentConfig.LLMBackend},
+	)
+	_, fallbackProviderName, fallbackBackend, _ := agent.ResolveLLMPair(e.cfg, layers...)
 
 	// Resolve agent config from hierarchy (before creating execution record
 	// so the DB record captures the correctly resolved iteration strategy).

--- a/pkg/queue/executor_integration_test.go
+++ b/pkg/queue/executor_integration_test.go
@@ -2326,6 +2326,70 @@ func TestExecutor_AgentCreationFailureEmitsTerminalStatus(t *testing.T) {
 	assert.Equal(t, 1, failedEvents[0].AgentIndex, "single agent should have agent_index=1")
 }
 
+func TestExecutor_ResolveFailureStoresPairedBackend(t *testing.T) {
+	// Stage names a provider without a sibling backend. ResolveAgentConfig
+	// fails (unknown provider), but the failed execution record must still
+	// store langchain — not defaults.llm_backend google-native.
+	entClient, _ := util.SetupTestDatabase(t)
+
+	maxIter := 1
+	chain := &config.ChainConfig{
+		AlertTypes: []string{"test-alert"},
+		Stages: []config.StageConfig{
+			{
+				Name: "investigation",
+				Agents: []config.StageAgentConfig{
+					{Name: "TestAgent", LLMProvider: "missing-provider"},
+				},
+			},
+		},
+	}
+
+	cfg := &config.Config{
+		Defaults: &config.Defaults{
+			LLMProvider:   "test-provider",
+			LLMBackend:    config.LLMBackendNativeGemini,
+			MaxIterations: &maxIter,
+		},
+		AgentRegistry: config.NewAgentRegistry(map[string]*config.AgentConfig{
+			"TestAgent": {
+				MaxIterations: &maxIter,
+			},
+			config.AgentNameExecSummary: {
+				Type: config.AgentTypeExecSummary,
+			},
+		}),
+		LLMProviderRegistry: config.NewLLMProviderRegistry(map[string]*config.LLMProviderConfig{
+			"test-provider": {
+				Type:  config.LLMProviderTypeGoogle,
+				Model: "test-model",
+			},
+		}),
+		ChainRegistry: config.NewChainRegistry(map[string]*config.ChainConfig{
+			"test-chain": chain,
+		}),
+		MCPServerRegistry: config.NewMCPServerRegistry(nil),
+	}
+
+	publisher := &testEventPublisher{}
+	executor := NewRealSessionExecutor(cfg, entClient, &mockLLMClient{}, publisher, nil, nil, nil, nil)
+	session := createExecutorTestSession(t, entClient, "test-chain")
+
+	result := executor.Execute(context.Background(), session)
+	require.NotNil(t, result)
+	assert.Equal(t, alertsession.StatusFailed, result.Status)
+	require.NotNil(t, result.Error)
+	assert.Contains(t, result.Error.Error(), "failed to resolve agent config")
+
+	execs, err := entClient.AgentExecution.Query().All(context.Background())
+	require.NoError(t, err)
+	require.Len(t, execs, 1)
+	assert.Equal(t, agentexecution.StatusFailed, execs[0].Status)
+	require.NotNil(t, execs[0].LlmProvider)
+	assert.Equal(t, "missing-provider", *execs[0].LlmProvider)
+	assert.Equal(t, string(config.LLMBackendLangChain), execs[0].LlmBackend)
+}
+
 // ────────────────────────────────────────────────────────────
 // Orchestrator integration tests
 // ────────────────────────────────────────────────────────────

--- a/test/e2e/action_test.go
+++ b/test/e2e/action_test.go
@@ -103,9 +103,11 @@ func TestE2E_ActionChain(t *testing.T) {
 				"restart_service":    StaticToolHandler(restartResult),
 			},
 		}),
+		WithDeferredWorkerStart(),
 	)
 
-	// Connect WS and subscribe.
+	// Connect WS and subscribe before workers start so transient
+	// execution.progress events are not lost (they are not in catchup).
 	ctx := context.Background()
 	ws, err := WSConnect(ctx, app.WSURL)
 	require.NoError(t, err)
@@ -116,6 +118,7 @@ func TestE2E_ActionChain(t *testing.T) {
 	require.NotEmpty(t, sessionID)
 
 	require.NoError(t, ws.Subscribe("session:"+sessionID))
+	app.StartWorkers()
 
 	app.WaitForSessionStatus(t, sessionID, "completed")
 

--- a/test/e2e/harness.go
+++ b/test/e2e/harness.go
@@ -70,6 +70,7 @@ type testAppConfig struct {
 	slackService          *tarsyslack.Service // optional Slack service (for Slack notification tests)
 	memoryService         *memory.Service     // optional memory service (for memory injection tests)
 	memoryConfig          *config.MemoryConfig
+	deferWorkerStart      bool // leave the pool stopped until StartWorkers (for transient WS events)
 }
 
 // TestAppOption configures the test app.
@@ -144,6 +145,14 @@ func WithMemoryService(svc *memory.Service, cfg *config.MemoryConfig) TestAppOpt
 		c.memoryService = svc
 		c.memoryConfig = cfg
 	}
+}
+
+// WithDeferredWorkerStart leaves the worker pool stopped until the test calls
+// StartWorkers. Use this when the test must subscribe to a session channel
+// before execution.progress events fire — those events are transient and are
+// not included in subscribe catchup.
+func WithDeferredWorkerStart() TestAppOption {
+	return func(c *testAppConfig) { c.deferWorkerStart = true }
 }
 
 // NewTestApp creates and starts a full TARSy test instance.
@@ -259,7 +268,9 @@ func NewTestApp(t *testing.T, opts ...TestAppOption) *TestApp {
 		podID = fmt.Sprintf("e2e-test-%s", t.Name())
 	}
 	workerPool := queue.NewWorkerPool(podID, entClient, tc.cfg.Queue, sessionExecutor, scoringExecutor, eventPublisher, tc.slackService)
-	require.NoError(t, workerPool.Start(ctx))
+	if !tc.deferWorkerStart {
+		require.NoError(t, workerPool.Start(ctx))
+	}
 
 	// 11. Chat executor.
 	chatExecutor := queue.NewChatMessageExecutor(
@@ -341,6 +352,12 @@ func NewTestApp(t *testing.T, opts ...TestAppOption) *TestApp {
 	})
 
 	return app
+}
+
+// StartWorkers starts the worker pool. Only needed after WithDeferredWorkerStart.
+func (app *TestApp) StartWorkers() {
+	app.t.Helper()
+	require.NoError(app.t, app.WorkerPool.Start(context.Background()))
 }
 
 // defaultTestConfig creates a minimal config suitable for tests that don't

--- a/test/e2e/testdata/golden/action-chain/session.golden
+++ b/test/e2e/testdata/golden/action-chain/session.golden
@@ -151,7 +151,7 @@
           "estimated_cost_usd": 0,
           "execution_id": "{EXEC_ID_4}",
           "input_tokens": 60,
-          "llm_backend": "google-native",
+          "llm_backend": "langchain",
           "llm_provider": "test-provider",
           "model_name": "test-model",
           "output_tokens": 20,

--- a/test/e2e/testdata/golden/memory-feedback/trace_interactions/07_FeedbackReflector_llm_memory_extraction_1.golden
+++ b/test/e2e/testdata/golden/memory-feedback/trace_interactions/07_FeedbackReflector_llm_memory_extraction_1.golden
@@ -120,7 +120,7 @@ Investigation complete: pod-1 is OOMKilled with 5 restarts.
 
 ## Stage 2: Executive Summary
 
-**Agent:** ExecSummaryAgent (google-native, test-model)
+**Agent:** ExecSummaryAgent (langchain, test-model)
 **Status**: completed
 
 **Agent Response:**

--- a/test/e2e/testdata/golden/memory-feedback/trace_interactions/08_ScoringAgent_llm_scoring_1.golden
+++ b/test/e2e/testdata/golden/memory-feedback/trace_interactions/08_ScoringAgent_llm_scoring_1.golden
@@ -134,7 +134,7 @@ Investigation complete: pod-1 is OOMKilled with 5 restarts.
 
 ## Stage 2: Executive Summary
 
-**Agent:** ExecSummaryAgent (google-native, test-model)
+**Agent:** ExecSummaryAgent (langchain, test-model)
 **Status**: completed
 
 **Agent Response:**

--- a/test/e2e/testdata/golden/memory-feedback/trace_interactions/09_ScoringAgent_llm_scoring_2.golden
+++ b/test/e2e/testdata/golden/memory-feedback/trace_interactions/09_ScoringAgent_llm_scoring_2.golden
@@ -134,7 +134,7 @@ Investigation complete: pod-1 is OOMKilled with 5 restarts.
 
 ## Stage 2: Executive Summary
 
-**Agent:** ExecSummaryAgent (google-native, test-model)
+**Agent:** ExecSummaryAgent (langchain, test-model)
 **Status**: completed
 
 **Agent Response:**

--- a/test/e2e/testdata/golden/memory-feedback/trace_interactions/10_ScoringAgent_llm_memory_extraction_1.golden
+++ b/test/e2e/testdata/golden/memory-feedback/trace_interactions/10_ScoringAgent_llm_memory_extraction_1.golden
@@ -157,7 +157,7 @@ Investigation complete: pod-1 is OOMKilled with 5 restarts.
 
 ## Stage 2: Executive Summary
 
-**Agent:** ExecSummaryAgent (google-native, test-model)
+**Agent:** ExecSummaryAgent (langchain, test-model)
 **Status**: completed
 
 **Agent Response:**

--- a/test/e2e/testdata/golden/orchestrator/session.golden
+++ b/test/e2e/testdata/golden/orchestrator/session.golden
@@ -109,7 +109,7 @@
           "estimated_cost_usd": 0,
           "execution_id": "{UUID}",
           "input_tokens": 10,
-          "llm_backend": "google-native",
+          "llm_backend": "langchain",
           "llm_provider": "test-provider",
           "model_name": "test-model",
           "output_tokens": 5,

--- a/test/e2e/testdata/golden/pipeline/session.golden
+++ b/test/e2e/testdata/golden/pipeline/session.golden
@@ -286,7 +286,7 @@
           "estimated_cost_usd": 0,
           "execution_id": "{EXEC_ID_9}",
           "input_tokens": 10,
-          "llm_backend": "google-native",
+          "llm_backend": "langchain",
           "llm_provider": "test-provider-fast",
           "model_name": "test-model-fast",
           "output_tokens": 5,

--- a/test/e2e/testdata/golden/scoring/prompt_turn1.golden
+++ b/test/e2e/testdata/golden/scoring/prompt_turn1.golden
@@ -169,7 +169,7 @@ Restarted pod-1. Recommend increasing memory limit to 1Gi.
 
 ## Stage 3: Executive Summary
 
-**Agent:** ExecSummaryAgent (google-native, test-model)
+**Agent:** ExecSummaryAgent (langchain, test-model)
 **Status**: completed
 
 **Agent Response:**

--- a/test/e2e/testdata/golden/scoring/prompt_turn2.golden
+++ b/test/e2e/testdata/golden/scoring/prompt_turn2.golden
@@ -169,7 +169,7 @@ Restarted pod-1. Recommend increasing memory limit to 1Gi.
 
 ## Stage 3: Executive Summary
 
-**Agent:** ExecSummaryAgent (google-native, test-model)
+**Agent:** ExecSummaryAgent (langchain, test-model)
 **Status**: completed
 
 **Agent Response:**

--- a/test/e2e/testdata/golden/scoring/trace_interactions/01_scoring_llm_scoring_eval.golden
+++ b/test/e2e/testdata/golden/scoring/trace_interactions/01_scoring_llm_scoring_eval.golden
@@ -189,7 +189,7 @@ Restarted pod-1. Recommend increasing memory limit to 1Gi.
 
 ## Stage 3: Executive Summary
 
-**Agent:** ExecSummaryAgent (google-native, test-model)
+**Agent:** ExecSummaryAgent (langchain, test-model)
 **Status**: completed
 
 **Agent Response:**

--- a/test/e2e/testdata/golden/scoring/trace_interactions/02_scoring_llm_scoring_tool_report.golden
+++ b/test/e2e/testdata/golden/scoring/trace_interactions/02_scoring_llm_scoring_tool_report.golden
@@ -189,7 +189,7 @@ Restarted pod-1. Recommend increasing memory limit to 1Gi.
 
 ## Stage 3: Executive Summary
 
-**Agent:** ExecSummaryAgent (google-native, test-model)
+**Agent:** ExecSummaryAgent (langchain, test-model)
 **Status**: completed
 
 **Agent Response:**

--- a/test/e2e/testdata/golden/skills/session.golden
+++ b/test/e2e/testdata/golden/skills/session.golden
@@ -118,7 +118,7 @@
           "estimated_cost_usd": 0,
           "execution_id": "{EXEC_ID_3}",
           "input_tokens": 10,
-          "llm_backend": "google-native",
+          "llm_backend": "langchain",
           "llm_provider": "test-provider",
           "model_name": "test-model",
           "output_tokens": 5,


### PR DESCRIPTION
- Resolve provider and backend as a pair so omitting llm_backend no longer inherits defaults.llm_backend
- Reject google-native next to a non-google provider at the same YAML node
- Keep the same pairing on executor failed-execution labels


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved LLM provider and backend resolution across agents, chats, scoring, summaries, and compose workflows.
  * Provider-only overrides now default to LangChain instead of inheriting an incompatible backend.
  * Added validation to prevent native Gemini backends from being paired with non-Google providers.
  * Improved execution failure reporting to preserve resolved provider and backend details.

* **Documentation**
  * Updated configuration and architecture guidance for backend defaults and provider pairing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->