### PR TITLE
fix: repair GPT-5.6 prompt cache on looping calls

### DIFF
--- a/docs/adr/0026-prompt-caching.md
+++ b/docs/adr/0026-prompt-caching.md
@@ -24,7 +24,7 @@ Python now normalizes `input_tokens` to **uncached** input. Shipping that withou
 This decision:
 
 1. Surfaces provider cache usage through proto → DB → Prometheus → trace LLM interactions → Usage totals / by-model, and prices those tokens.
-2. Turns on Anthropic/Vertex Claude `cache_control` and GPT-5.6+ OpenAI explicit breakpoints on investigation-style iterating loops (not action, scoring, or one-shots).
+2. Turns on Anthropic/Vertex Claude `cache_control` and GPT-5.6+ OpenAI explicit breakpoints on investigation-style iterating loops and forced conclusion (not action, scoring, or one-shots). GPT-5.6+ ineligible calls send explicit mode with no breakpoints.
 3. Leaves Gemini implicit caching alone except to measure and price it.
 4. Does **not** introduce Gemini explicit `CachedContent` objects, a local prompt store, or response caching.
 
@@ -45,7 +45,7 @@ This decision:
 |---|-------|----------|-----------|
 | Q1 | v1 scope | Persist cache usage, enable Claude `cache_control` and GPT-5.6+ explicit OpenAI caching on looping calls, price cache tokens, and ship scoped operator UI | Behavior, telemetry, Est. $, and per-call hit/miss land together so ADR-0020’s gap actually closes. Prompt layout, Gemini explicit caches, Usage-page charts, and session-list cache SUMs stay follow-ups. Rejected: observe-only (Claude iterating agents keep paying full input); observe + breakpoints without pricing (Est. $ undercounts once input is normalized). |
 | Q2 | Kill switch | Cluster `system.prompt_caching.enabled` (default true, omit-means-on). Python 400-retry strips Claude `cache_control` / OpenAI cache options. Toggle does **not** disable Gemini implicit caching. No per-agent YAML | GitOps kill switch, same pattern as cost estimation. Python has no `tarsy.yaml`; Go ANDs the toggle onto `GenerateRequest.prompt_cache`. Vertex projects with caching disabled (or older OpenAI models that reject 5.6 fields) degrade instead of failing. Rejected: no YAML (Vertex 400s until a code change); per-provider/per-agent YAML (duplicates eligibility). |
-| Q3 | Eligibility | Controllers set `PromptCache` from eligibility only (`AgentTypeDefault` iterating **loop**). Action, forced conclusion, scoring, single-shot, and summarization stay off | Eligibility is a property of the control flow. Action is usually one “no action” Generate — a 2× Claude write never read. Scoring is two turns with the same last-write problem. Python applies breakpoints only when the proto field is true (already AND-ed with the cluster toggle). Rejected: Python heuristic; all Generate calls. |
+| Q3 | Eligibility | Controllers set `PromptCache` from eligibility (`AgentTypeDefault` iterating **loop** and **forced conclusion**). Action, scoring, single-shot, and summarization stay off | Forced conclusion continues the looping prefix; cache **reads** reuse tools+system+history. The conclusion user prompt sits after the last tool-result breakpoint and is not a 1.25× write. Action is usually one “no action” Generate — a write never read. Scoring is two turns with the same last-write problem. Python stamps Claude `cache_control` / OpenAI breakpoints only when the proto field is true (already AND-ed with the cluster toggle). GPT-5.6+ ineligible calls still send `mode=explicit` with **no** breakpoints so implicit 1.25× writes do not fire. Rejected: Python heuristic; all Generate calls. |
 | Q4 | Claude breakpoints | Last tool + system + last message (growing prefix). Skip the tool breakpoint when there are no tools | Each turn writes the new suffix and reads the prior conversation; stays within Anthropic’s four-breakpoint cap. Rejected: last tool only (skills and history stay full-price); tools + system only (growing history stays uncached). |
 | Q5 | Claude TTL | Hardcoded 1h. On 400, retry without `ttl` (5m default), then strip `cache_control` entirely | Covers sub-agent waits and typical session timeouts; TTL refreshes on hits. Old Vertex Claude 3.x may reject 1h. Rejected: 5m (orchestrator and slow MCP sequences miss); YAML `5m`\|`1h` (extra knob). |
 | Q6 | Gemini explicit caches | Implicit only in v1. Extract and price `cached_content_token_count`. No `CachedContent` objects | Evidence-driven; Gemini looping agents may already get implicit hits. Explicit caches need named objects and replica state. |
@@ -53,7 +53,7 @@ This decision:
 | Q8 | Cost formula | Price cache-read and cache-creation. Catalog/snapshot cache rates when present; overlays stay flat and derive 0.1× read and 2× (Claude) / 1.25× (else) create. Tier selection uses prompt size | Closes the known gap. YAML promotions/`model_rates` stay input/output only (same v1 limit as ADR-0020). Claude 1h writes must not use the 5m catalog create rate. Prompt size = uncached + cache_read + cache_creation so Gemini 200k tiers still fire on cache-heavy calls. Missing cache rates still derive so a row is not silently undercounted. Rejected: keep the gap; defer pricing. |
 | Q9 | System-prompt layout | Leave layout in v1. Intra-session looping is the win | Tier 0 wall-clock time sits first in the system prompt, so cross-session reuse of skills + tools will not hit. Reorder/split is golden-prompt churn for little token volume. Growing-history breakpoints already cache intra-session turns. |
 | Q10 | Operator surfaces | DB + Prometheus `cache_read` / `cache_creation` + Config Viewer toggle + **trace LLM list/detail** + **Usage totals and by-model**. No session-list / header / `ExecutionOverview` / by-alert / by-chain / top-sessions / Usage-chart SUMs | Per-call hit/miss is the diagnostic that matters; fleet hit rate lives on Usage totals and the by-model table. Session totals do not locate a miss. `TokenUsageDisplay` renders cache only when the DTO has the fields (session surfaces omit them). Thinking tokens never landed on trace DTOs; cache does. |
-| Q11 | OpenAI | GPT-5.6+ looping calls: explicit mode, 30m TTL, key = `execution_id`, breakpoints on last tool, system-as-content-block, last **non-tool-result** message. GPT-5.5 and older: extract only | Implicit 5.6 breakpoints sit on the volatile last message and bill 1.25× writes with ~0 prefix reads. Walk back past tool results so a `function_call_output` breakpoint is not relied on to write. Do not bake cache policy into the shared LangChain model instance; pass key/options per request. 400 → retry stripped. Rejected: extract-only on 5.6; ignore OpenAI; tools+system only; key-only; explicit on all OpenAI. |
+| Q11 | OpenAI | GPT-5.6+ looping calls: explicit mode, 30m TTL, key = `execution_id`, sticky breakpoints on last tool schema, system-as-content-block, **first user**, last **tool result** (if any). Ineligible GPT-5.6+ calls: explicit mode with no breakpoints (no implicit write tax). GPT-5.5 and older: extract only | Implicit 5.6 breakpoints sit on the volatile last message and bill 1.25× writes with ~0 prefix reads. Restyling a prior user from content-block+breakpoint to a plain string busts everything after system; sticky first-user + last-tool-result stay stable. Do not mark assistant / tool-call-only messages. Do not bake cache policy into the shared LangChain model instance; pass key/options per request. 400 → retry stripped. Rejected: extract-only on 5.6; ignore OpenAI; tools+system only; key-only; implicit last-message on one-shots. |
 
 ## Architecture
 
@@ -78,7 +78,7 @@ Python has **no** `tarsy.yaml`. The only request it sees is `GenerateRequest`. C
 - `UsageInfo.cache_read_tokens` / `cache_creation_tokens` → `llm_interactions` columns
 - Cluster kill switch: `system.prompt_caching.enabled` (default **true**, same `*bool` omit-means-on pattern as `system.cost_estimation.enabled`)
 
-Controllers set `PromptCache` from **eligibility only**. The streaming LLM helper ANDs the cluster toggle before gRPC (`prompt_cache = eligible && enabled`). Python applies Claude `cache_control` / OpenAI `prompt_cache_options` **only** when `GenerateRequest.prompt_cache` is true. When the toggle is false, Go still records cache usage if the provider sent it (Gemini implicit still happens).
+Controllers set `PromptCache` from **eligibility only**. The streaming LLM helper ANDs the cluster toggle before gRPC (`prompt_cache = eligible && enabled`). Python stamps Claude `cache_control` / OpenAI breakpoints only when `GenerateRequest.prompt_cache` is true. GPT-5.6+ still binds `prompt_cache_options` `{mode: explicit}` with **no** breakpoints when the flag is false so implicit writes stay off. When the toggle is false, Go still records cache usage if the provider sent it (Gemini implicit still happens).
 
 Copy cluster `PromptCaching.Enabled` onto the execution context when the executor builds it — it is cluster-wide, not per-agent YAML.
 
@@ -90,11 +90,13 @@ flowchart TD
   toggle -->|prompt_cache true or false| grpc[gRPC Generate]
   grpc --> py{Python backend}
   py -->|LangChain Claude / Vertex Claude| claude[cache_control on last tool + system + last message]
-  py -->|OpenAI gpt-5.6+| oai[explicit mode + key=execution_id + breakpoints]
+  py -->|OpenAI gpt-5.6+ eligible| oai[explicit mode + key=execution_id + sticky breakpoints]
+  py -->|OpenAI gpt-5.6+ ineligible| oaiOff[explicit mode, no breakpoints]
   py -->|OpenAI older| oaiOld[Extract cached_tokens only]
   py -->|google-native / LangChain Google| gemini[No breakpoint; extract cached_content_token_count]
   claude --> usage[UsageInfo + cache fields]
   oai --> usage
+  oaiOff --> usage
   oaiOld --> usage
   gemini --> usage
   usage --> db[(llm_interactions)]
@@ -110,12 +112,12 @@ flowchart TD
 |-----------|--------|----------------|
 | Investigation / chat / sub-agent / orchestrator loop (`AgentTypeDefault`) | Yes | **on** |
 | Action / remediation loop (`AgentTypeAction`, same iterating controller) | Usually 1 turn | **off** |
-| Forced conclusion (no tools; same iterating controller) | No | **off** |
+| Forced conclusion (same tools, `disable_tool_calls`; same iterating controller) | Continuation | **on** (investigation); **off** (action) |
 | Scoring controller (score + tool-report) | 2 turns | **off** |
 | Single-shot (synthesis, exec summary, compose, memory reflector) | No | **off** |
 | Tool / `search_past_sessions` summarization | No | **off** |
 
-Do **not** set the flag true for every iterating-controller Generate. Gate the loop call on agent type ≠ action. Forced conclusion stays off.
+Do **not** set the flag true for every iterating-controller Generate. Gate the loop and forced-conclusion calls on agent type ≠ action. Forced conclusion is eligible for **reads** of the looping prefix; calling is disabled via `disable_tool_calls`.
 
 ### Claude / Vertex Claude
 
@@ -123,7 +125,7 @@ When `prompt_cache` is set and the LangChain model is Anthropic or Vertex Claude
 
 1. Bind tools in Anthropic dict form; put `cache_control: {type: ephemeral, ttl: 1h}` on the **last tool**. If there are no tools, skip this breakpoint.
 2. Convert the system message to a content block with the same `cache_control`.
-3. Put `cache_control` on the **last** conversation message (growing-history breakpoint, including tool results).
+3. Put `cache_control` on the **last** conversation message (growing-history breakpoint, including tool results). If the last message is `user` **and** a tool result exists (forced conclusion), put it on that last tool result instead so Claude can read the loop prefix without a 2× write of the conclusion prompt.
 
 Do **not** pass `cache_control` as an invoke/astream kwarg — Vertex Claude 400s that. Use content blocks / additional kwargs on messages and tools.
 
@@ -144,14 +146,21 @@ Keep the LangChain model-instance cache keyed by `(provider, model, api_key_env)
 
 **GPT-5.5 and older** (anything that does not match `gpt-5.` with integer minor ≥ 6, including `gpt-5.2`, `gpt-5`, `gpt-5-mini`): automatic prefix cache. Extract `cached_tokens` / `cache_write_tokens` if present. Send no `prompt_cache_options`.
 
-**GPT-5.6 and later** (model id matches `gpt-5.` with integer minor **≥ 6**, case-insensitive, including dated/variant suffixes such as `gpt-5.6-sol`). Built-in `openai-default` is GPT-5.6 and therefore takes this path when `prompt_cache` is set:
+**GPT-5.6 and later** (model id matches `gpt-5.` with integer minor **≥ 6**, case-insensitive, including dated/variant suffixes such as `gpt-5.6-sol`). Built-in `openai-default` is GPT-5.6.
+
+When `prompt_cache` is false (action, scoring, one-shots, empty `execution_id`, cluster kill switch): bind `prompt_cache_options: {mode: "explicit", ttl: "30m"}` with **no** breakpoints. That is caching off for GPT-5.6+ — no implicit last-message write tax. Include `prompt_cache_key` when `execution_id` is non-empty.
+
+When `prompt_cache` is true (investigation loop and forced conclusion):
 
 1. `prompt_cache_options: {mode: "explicit", ttl: "30m"}` — disables the implicit last-message breakpoint; 30m is the only supported TTL.
-2. `prompt_cache_key: execution_id`. Skip explicit mode if `execution_id` is empty.
-3. `prompt_cache_breakpoint: {mode: "explicit"}` on:
+2. `prompt_cache_key: execution_id`.
+3. `prompt_cache_breakpoint: {mode: "explicit"}` on **only** these (do not restyle other messages):
    - the **last tool** schema (if any tools),
    - the **system** text as an `input_text` block on a developer/system message — OpenAI rejects breakpoints on top-level Responses `instructions`,
-   - the last **non-tool-result** message (walk back past `role=tool` / `function_call_output`).
+   - the **first** `role=user` message (sticky original alert),
+   - the last `role=tool` message, if any (growing history).
+
+Do **not** put a breakpoint on assistant / tool-call-only messages. Forced conclusion keeps the same tool list, sets `disable_tool_calls`, and leaves the conclusion user unmarked.
 
 If the SDK 400s on these fields, retry the call stripped (same dedicated degrade path as Claude).
 

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -125,7 +125,7 @@ Agents are specialized AI-powered components that analyze alerts using domain ex
 - **SingleShotController**: Tool-less single LLM call, parameterized via `SingleShotConfig`. Used for synthesis, executive summary, and compose (amended report after action).
 - **ScoringController**: 2-turn LLM conversation for session quality evaluation. Turn 1 produces an outcome-first score (0–100) with dimension-based analysis and failure tags; Turn 2 produces a tool improvement report (missing tools + existing tool improvements). Runs async after session completion via `ScoringExecutor`.
 
-**Forced Conclusion**: When agents reach their maximum iteration limit, the system forces a conclusion -- one extra LLM call without tools, asking the agent to provide the best analysis with available data. There is no pause/resume mechanism.
+**Forced Conclusion**: When agents reach their maximum iteration limit, the system forces a conclusion -- one extra LLM call with the same tools bound and calling disabled, asking the agent to provide the best analysis with available data. There is no pause/resume mechanism.
 
 **Provider Fallback**: All controller paths (iterating, forced conclusion, single-shot) support automatic fallback to alternative LLM providers when the primary fails. Fallback state is tracked per-execution; each new execution resets to the primary provider.
 
@@ -355,7 +355,7 @@ sequenceDiagram
     end
 
     alt Max iterations reached
-        C->>LLM: Force conclusion (call WITHOUT tools)
+        C->>LLM: Force conclusion (tools bound, calling disabled)
         Note over C,LLM: "Provide your best analysis<br/>with the data collected so far"
         LLM-->>C: Forced final answer
     end
@@ -363,7 +363,7 @@ sequenceDiagram
 
 ### Forced Conclusion at Max Iterations
 
-When an agent reaches its configured `max_iterations` limit, the system forces a conclusion rather than leaving the investigation incomplete. The controller makes one extra LLM call **without tool bindings**, asking the agent to synthesize everything it has learned into a final analysis. This ensures every investigation produces actionable output.
+When an agent reaches its configured `max_iterations` limit, the system forces a conclusion rather than leaving the investigation incomplete. The controller makes one extra LLM call with the **same tool list bound** and calling disabled, asking the agent to synthesize everything it has learned into a final analysis. This keeps the looping prompt-cache prefix stable and ensures every investigation produces actionable output.
 
 **Hierarchical iteration configuration** allows fine-grained control:
 - **System defaults** (e.g., `max_iterations: 20`)

--- a/docs/functional-areas-design.md
+++ b/docs/functional-areas-design.md
@@ -476,9 +476,9 @@ Multi-turn iterating controller that loops: LLM call → tool execution → LLM 
    - Call LLM with streaming AND tool bindings (structured function calling)
    - If **tool calls** in response: execute each tool, append results, continue
    - If **no tool calls**: this is the final answer -- create `final_analysis` event, return
-4. If max iterations reached: `forceConclusion()` -- call LLM WITHOUT tools to force text-only response
+4. If max iterations reached: `forceConclusion()` -- same tools bound, `disable_tool_calls` so the model must answer in text
 
-Investigation / chat / orchestrator / sub-agent loops (`AgentTypeDefault`) set `PromptCache` on the iterating Generate so Python can attach Claude `cache_control` / GPT-5.6+ OpenAI breakpoints. Action loops and forced conclusion leave it off. See [ADR-0026: Prompt Caching](adr/0026-prompt-caching.md).
+Investigation / chat / orchestrator / sub-agent loops (`AgentTypeDefault`) set `PromptCache` on the iterating Generate so Python can attach Claude `cache_control` / GPT-5.6+ OpenAI breakpoints. Forced conclusion uses the same eligibility so the looping prefix can be **read**; action loops leave it off. GPT-5.6+ ineligible calls still send explicit mode with no breakpoints (no implicit write tax). See [ADR-0026: Prompt Caching](adr/0026-prompt-caching.md).
 
 #### SingleShotController — single-shot (`pkg/agent/controller/single_shot.go`)
 
@@ -594,7 +594,7 @@ This auto-injection pattern means custom agents with sub-agents or `type: action
 
 #### Forced Conclusion
 
-At max iterations, `forceConclusion()` makes one extra LLM call without tools, asking for the best conclusion with available data. Every investigation produces actionable output.
+At max iterations, `forceConclusion()` makes one extra LLM call with the same tools bound and calling disabled, asking for the best conclusion with available data. Every investigation produces actionable output.
 
 #### Provider Fallback
 
@@ -812,7 +812,7 @@ type LLMClient interface {
 
 Chunk types: `TextChunk`, `ThinkingChunk`, `ToolCallChunk`, `CodeExecutionChunk`, `UsageChunk`, `ErrorChunk`, `GroundingChunk`.
 
-**GenerateInput** carries: `SessionID`, `ExecutionID`, `Messages`, `Config` (LLMProviderConfig), `Tools`, `Backend`, `PromptCache` (eligible looping investigation-style calls; AND-ed with `system.prompt_caching.enabled` before gRPC).
+**GenerateInput** carries: `SessionID`, `ExecutionID`, `Messages`, `Config` (LLMProviderConfig), `Tools`, `Backend`, `PromptCache` (eligible looping investigation-style calls and forced conclusion; AND-ed with `system.prompt_caching.enabled` before gRPC), `DisableToolCalls` (keep tool schemas, forbid calling).
 
 #### Python Side: Provider Routing
 
@@ -833,7 +833,7 @@ Each provider uses up to 3 total attempts for the same Generate when no chunks h
 
 **LangChainProvider** (`llm/providers/langchain_provider.py`):
 - Multi-provider: OpenAI (`ChatOpenAI`), Anthropic (`ChatAnthropic`), xAI (`ChatXAI`), Google (`ChatGoogleGenerativeAI`), VertexAI
-- Model caching by `(provider, model, api_key_env)` tuple (cache policy is **not** on the shared instance; Claude `cache_control` / OpenAI `prompt_cache_options` are per-request when `prompt_cache` is true)
+- Model caching by `(provider, model, api_key_env)` tuple (cache policy is **not** on the shared instance; Claude `cache_control` / OpenAI breakpoints are per-request when `prompt_cache` is true; GPT-5.6+ ineligible calls still bind `prompt_cache_options` with no breakpoints)
 - `bind_tools()` for structured function calling
 - Streaming via `astream()` with thinking content extraction
 
@@ -849,7 +849,7 @@ Shared convention between Go and Python:
 
 - **RPC**: `Generate(GenerateRequest) returns (stream GenerateResponse)`
 - **LLMConfig**: `backend`, `provider`, `model`, `api_key_env`, `base_url`, `native_tools`
-- **GenerateRequest flags**: `clear_cache` (signals provider switch mid-execution — Google Native clears `_model_contents` cache to avoid stale thought signatures); `prompt_cache` (Claude `cache_control` / GPT-5.6+ OpenAI explicit breakpoints — Go ANDs eligibility with `system.prompt_caching.enabled`)
+- **GenerateRequest flags**: `clear_cache` (signals provider switch mid-execution — Google Native clears `_model_contents` cache to avoid stale thought signatures); `prompt_cache` (Claude `cache_control` / GPT-5.6+ OpenAI explicit breakpoints — Go ANDs eligibility with `system.prompt_caching.enabled`); `disable_tool_calls` (keep tool schemas, forbid calling — forced conclusion)
 - **UsageInfo**: `input_tokens` is **uncached** billed input; `cache_read_tokens` / `cache_creation_tokens` persisted when > 0. Python normalizes provider-inclusive counts before streaming usage.
 - **Response streaming**: `TextDelta`, `ThinkingDelta`, `ToolCallDelta`, `UsageInfo`, `ErrorInfo`, `CodeExecutionDelta`, `GroundingDelta`
 

--- a/llm-service/llm/providers/google_native.py
+++ b/llm-service/llm/providers/google_native.py
@@ -380,7 +380,18 @@ class GoogleNativeProvider(LLMProvider):
                 t.google_search or t.url_context or t.code_execution
                 for t in tools
             )
-            if has_func_decls and has_native:
+            if request.disable_tool_calls and has_func_decls:
+                # Keep MCP declarations (prefix stability) but forbid calling them.
+                # Native google_search / url_context stay enabled for grounding.
+                tool_config_kwargs = {
+                    "function_calling_config": genai_types.FunctionCallingConfig(
+                        mode=genai_types.FunctionCallingConfigMode.NONE,
+                    ),
+                }
+                if has_native:
+                    tool_config_kwargs["include_server_side_tool_invocations"] = True
+                gen_config.tool_config = genai_types.ToolConfig(**tool_config_kwargs)
+            elif has_func_decls and has_native:
                 gen_config.tool_config = genai_types.ToolConfig(
                     include_server_side_tool_invocations=True,
                 )

--- a/llm-service/llm/providers/google_native.py
+++ b/llm-service/llm/providers/google_native.py
@@ -382,15 +382,13 @@ class GoogleNativeProvider(LLMProvider):
             )
             if request.disable_tool_calls and has_func_decls:
                 # Keep MCP declarations (prefix stability) but forbid calling them.
-                # Native google_search / url_context stay enabled for grounding.
-                tool_config_kwargs = {
-                    "function_calling_config": genai_types.FunctionCallingConfig(
+                # Do not set include_server_side_tool_invocations: that flag
+                # re-enables google_search / url_context / code_execution.
+                gen_config.tool_config = genai_types.ToolConfig(
+                    function_calling_config=genai_types.FunctionCallingConfig(
                         mode=genai_types.FunctionCallingConfigMode.NONE,
                     ),
-                }
-                if has_native:
-                    tool_config_kwargs["include_server_side_tool_invocations"] = True
-                gen_config.tool_config = genai_types.ToolConfig(**tool_config_kwargs)
+                )
             elif has_func_decls and has_native:
                 gen_config.tool_config = genai_types.ToolConfig(
                     include_server_side_tool_invocations=True,

--- a/llm-service/llm/providers/langchain_provider.py
+++ b/llm-service/llm/providers/langchain_provider.py
@@ -78,6 +78,7 @@ class LangChainProvider(LLMProvider):
         cache_kind: str = prompt_cache.NONE,
         strip_ttl: bool = False,
         execution_id: str = "",
+        disable_tool_calls: bool = False,
     ):
         """Get or create a cached LangChain chat model, with tools bound if provided.
 
@@ -95,12 +96,20 @@ class LangChainProvider(LLMProvider):
                     len(tools), config.model,
                 )
             else:
-                model = self._bind_tools(model, list(tools), cache_kind, strip_ttl)
-        if cache_kind == prompt_cache.OPENAI_EXPLICIT:
-            model = model.bind(
-                prompt_cache_options=prompt_cache.openai_prompt_cache_options(strip_ttl),
-                prompt_cache_key=execution_id,
-            )
+                model = self._bind_tools(
+                    model, list(tools), cache_kind, strip_ttl,
+                    disable_tool_calls=disable_tool_calls,
+                )
+        if cache_kind in (
+            prompt_cache.OPENAI_EXPLICIT,
+            prompt_cache.OPENAI_EXPLICIT_DISABLE,
+        ):
+            bind_kwargs = {
+                "prompt_cache_options": prompt_cache.openai_prompt_cache_options(strip_ttl),
+            }
+            if execution_id:
+                bind_kwargs["prompt_cache_key"] = execution_id
+            model = model.bind(**bind_kwargs)
         return model
 
     # ── Reasoning/thinking configuration per provider ──────────────────
@@ -358,8 +367,19 @@ class LangChainProvider(LLMProvider):
         for i, proto in enumerate(proto_messages):
             if proto.role == "system":
                 out[i] = self._with_cache_marker(out[i], "cache_control", control)
-        if proto_messages and proto_messages[-1].role != "system":
-            out[-1] = self._with_cache_marker(out[-1], "cache_control", control)
+        if not proto_messages or proto_messages[-1].role == "system":
+            return out
+        # Forced conclusion appends a user prompt after tool results. Mark the
+        # last tool so Claude can read the looping prefix without a 2× write of
+        # the conclusion text. Loop turns already end on a tool result.
+        if proto_messages[-1].role == "user":
+            tool_idx = prompt_cache.last_tool_index(proto_messages)
+            if tool_idx >= 0:
+                out[tool_idx] = self._with_cache_marker(
+                    out[tool_idx], "cache_control", control,
+                )
+                return out
+        out[-1] = self._with_cache_marker(out[-1], "cache_control", control)
         return out
 
     def _mark_openai_cache(
@@ -372,10 +392,15 @@ class LangChainProvider(LLMProvider):
         for i, proto in enumerate(proto_messages):
             if proto.role == "system":
                 out[i] = self._with_cache_marker(out[i], "prompt_cache_breakpoint", breakpoint)
-        idx = prompt_cache.last_non_tool_index(proto_messages)
-        if idx >= 0 and proto_messages[idx].role != "system":
-            out[idx] = self._with_cache_marker(
-                out[idx], "prompt_cache_breakpoint", breakpoint,
+        user_idx = prompt_cache.first_user_index(proto_messages)
+        if user_idx >= 0:
+            out[user_idx] = self._with_cache_marker(
+                out[user_idx], "prompt_cache_breakpoint", breakpoint,
+            )
+        tool_idx = prompt_cache.last_tool_index(proto_messages)
+        if tool_idx >= 0:
+            out[tool_idx] = self._with_cache_marker(
+                out[tool_idx], "prompt_cache_breakpoint", breakpoint,
             )
         return out
 
@@ -385,6 +410,7 @@ class LangChainProvider(LLMProvider):
         tools: List[pb.ToolDefinition],
         cache_kind: str = prompt_cache.NONE,
         strip_ttl: bool = False,
+        disable_tool_calls: bool = False,
     ):
         """Bind MCP tools to the model via LangChain's bind_tools()."""
         langchain_tools = []
@@ -416,7 +442,10 @@ class LangChainProvider(LLMProvider):
                     item["prompt_cache_breakpoint"] = dict(prompt_cache.PROMPT_CACHE_BREAKPOINT)
                 langchain_tools.append(item)
         if langchain_tools:
-            return model.bind_tools(langchain_tools)
+            bind_kwargs = {}
+            if disable_tool_calls:
+                bind_kwargs["tool_choice"] = "none"
+            return model.bind_tools(langchain_tools, **bind_kwargs)
         return model
 
     async def generate(
@@ -442,6 +471,7 @@ class LangChainProvider(LLMProvider):
             try:
                 model = self._get_or_create_model(
                     config, list(request.tools), kind, strip_ttl, request.execution_id,
+                    disable_tool_calls=request.disable_tool_calls,
                 )
                 messages = self._convert_messages(list(request.messages), kind, strip_ttl)
             except (ValueError, ImportError) as e:

--- a/llm-service/llm/providers/prompt_cache.py
+++ b/llm-service/llm/providers/prompt_cache.py
@@ -14,6 +14,7 @@ from llm_proto import llm_service_pb2 as pb
 NONE = "none"
 ANTHROPIC = "anthropic"
 OPENAI_EXPLICIT = "openai_explicit"
+OPENAI_EXPLICIT_DISABLE = "openai_explicit_disable"
 
 _GPT56_RE = re.compile(r"^gpt-5\.(\d+)", re.IGNORECASE)
 
@@ -39,15 +40,15 @@ def is_openai_explicit_cache_model(model: str) -> bool:
 
 
 def classify_cache(config: pb.LLMConfig, prompt_cache: bool, execution_id: str) -> str:
+    provider = (config.provider or "").lower()
+    if provider == "openai" and is_openai_explicit_cache_model(config.model):
+        if prompt_cache and execution_id:
+            return OPENAI_EXPLICIT
+        return OPENAI_EXPLICIT_DISABLE
     if not prompt_cache:
         return NONE
     if is_anthropic_claude(config):
         return ANTHROPIC
-    provider = (config.provider or "").lower()
-    if provider == "openai" and is_openai_explicit_cache_model(config.model):
-        if not execution_id:
-            return NONE
-        return OPENAI_EXPLICIT
     return NONE
 
 
@@ -62,10 +63,18 @@ def openai_prompt_cache_options(strip_ttl: bool) -> dict:
     return options
 
 
-def last_non_tool_index(messages: List[pb.ConversationMessage]) -> int:
-    """Index of the last non-tool-result message, or -1 if none."""
+def first_user_index(messages: List[pb.ConversationMessage]) -> int:
+    """Index of the first user message, or -1 if none."""
+    for i, msg in enumerate(messages):
+        if msg.role == "user":
+            return i
+    return -1
+
+
+def last_tool_index(messages: List[pb.ConversationMessage]) -> int:
+    """Index of the last tool-result message, or -1 if none."""
     for i in range(len(messages) - 1, -1, -1):
-        if messages[i].role != "tool":
+        if messages[i].role == "tool":
             return i
     return -1
 

--- a/llm-service/llm_proto/llm_service_pb2.py
+++ b/llm-service/llm_proto/llm_service_pb2.py
@@ -24,7 +24,7 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x11llm_service.proto\x12\x06llm.v1\"\xe3\x01\n\x0fGenerateRequest\x12\x12\n\nsession_id\x18\x01 \x01(\t\x12-\n\x08messages\x18\x02 \x03(\x0b\x32\x1b.llm.v1.ConversationMessage\x12%\n\nllm_config\x18\x03 \x01(\x0b\x32\x11.llm.v1.LLMConfig\x12%\n\x05tools\x18\x04 \x03(\x0b\x32\x16.llm.v1.ToolDefinition\x12\x14\n\x0c\x65xecution_id\x18\x05 \x01(\t\x12\x13\n\x0b\x63lear_cache\x18\x06 \x01(\x08\x12\x14\n\x0cprompt_cache\x18\x07 \x01(\x08\"\xd4\x02\n\x10GenerateResponse\x12!\n\x04text\x18\x01 \x01(\x0b\x32\x11.llm.v1.TextDeltaH\x00\x12)\n\x08thinking\x18\x02 \x01(\x0b\x32\x15.llm.v1.ThinkingDeltaH\x00\x12*\n\ttool_call\x18\x03 \x01(\x0b\x32\x15.llm.v1.ToolCallDeltaH\x00\x12\"\n\x05usage\x18\x04 \x01(\x0b\x32\x11.llm.v1.UsageInfoH\x00\x12\"\n\x05\x65rror\x18\x05 \x01(\x0b\x32\x11.llm.v1.ErrorInfoH\x00\x12\x34\n\x0e\x63ode_execution\x18\x06 \x01(\x0b\x32\x1a.llm.v1.CodeExecutionDeltaH\x00\x12+\n\tgrounding\x18\x07 \x01(\x0b\x32\x16.llm.v1.GroundingDeltaH\x00\x12\x10\n\x08is_final\x18\n \x01(\x08\x42\t\n\x07\x63ontent\"\x83\x01\n\x13\x43onversationMessage\x12\x0c\n\x04role\x18\x01 \x01(\t\x12\x0f\n\x07\x63ontent\x18\x02 \x01(\t\x12$\n\ntool_calls\x18\x03 \x03(\x0b\x32\x10.llm.v1.ToolCall\x12\x14\n\x0ctool_call_id\x18\x04 \x01(\t\x12\x11\n\ttool_name\x18\x05 \x01(\t\"N\n\x0eToolDefinition\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x12\x19\n\x11parameters_schema\x18\x03 \x01(\t\"7\n\x08ToolCall\x12\n\n\x02id\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x11\n\targuments\x18\x03 \x01(\t\"\x1c\n\tTextDelta\x12\x0f\n\x07\x63ontent\x18\x01 \x01(\t\" \n\rThinkingDelta\x12\x0f\n\x07\x63ontent\x18\x01 \x01(\t\"A\n\rToolCallDelta\x12\x0f\n\x07\x63\x61ll_id\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x11\n\targuments\x18\x03 \x01(\t\"2\n\x12\x43odeExecutionDelta\x12\x0c\n\x04\x63ode\x18\x01 \x01(\t\x12\x0e\n\x06result\x18\x02 \x01(\t\"\xb9\x01\n\x0eGroundingDelta\x12\x1a\n\x12web_search_queries\x18\x01 \x03(\t\x12\x34\n\x10grounding_chunks\x18\x02 \x03(\x0b\x32\x1a.llm.v1.GroundingChunkInfo\x12\x34\n\x12grounding_supports\x18\x03 \x03(\x0b\x32\x18.llm.v1.GroundingSupport\x12\x1f\n\x17search_entry_point_html\x18\x04 \x01(\t\"0\n\x12GroundingChunkInfo\x12\x0b\n\x03uri\x18\x01 \x01(\t\x12\r\n\x05title\x18\x02 \x01(\t\"i\n\x10GroundingSupport\x12\x13\n\x0bstart_index\x18\x01 \x01(\x05\x12\x11\n\tend_index\x18\x02 \x01(\x05\x12\x0c\n\x04text\x18\x03 \x01(\t\x12\x1f\n\x17grounding_chunk_indices\x18\x04 \x03(\x05\"\xa1\x01\n\tUsageInfo\x12\x14\n\x0cinput_tokens\x18\x01 \x01(\x05\x12\x15\n\routput_tokens\x18\x02 \x01(\x05\x12\x14\n\x0ctotal_tokens\x18\x03 \x01(\x05\x12\x17\n\x0fthinking_tokens\x18\x04 \x01(\x05\x12\x19\n\x11\x63\x61\x63he_read_tokens\x18\x05 \x01(\x05\x12\x1d\n\x15\x63\x61\x63he_creation_tokens\x18\x06 \x01(\x05\"=\n\tErrorInfo\x12\x0f\n\x07message\x18\x01 \x01(\t\x12\x0c\n\x04\x63ode\x18\x02 \x01(\t\x12\x11\n\tretryable\x18\x03 \x01(\x08\"\xac\x02\n\tLLMConfig\x12\x10\n\x08provider\x18\x01 \x01(\t\x12\r\n\x05model\x18\x02 \x01(\t\x12\x13\n\x0b\x61pi_key_env\x18\x03 \x01(\t\x12\x17\n\x0f\x63redentials_env\x18\x04 \x01(\t\x12\x10\n\x08\x62\x61se_url\x18\x05 \x01(\t\x12\x38\n\x0cnative_tools\x18\x07 \x03(\x0b\x32\".llm.v1.LLMConfig.NativeToolsEntry\x12\x0f\n\x07project\x18\x08 \x01(\t\x12\x10\n\x08location\x18\t \x01(\t\x12\x0f\n\x07\x62\x61\x63kend\x18\n \x01(\t\x1a\x32\n\x10NativeToolsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x08:\x02\x38\x01J\x04\x08\x06\x10\x07R\x16max_tool_result_tokens2M\n\nLLMService\x12?\n\x08Generate\x12\x17.llm.v1.GenerateRequest\x1a\x18.llm.v1.GenerateResponse0\x01\x42\x32Z0github.com/codeready-toolchain/tarsy/proto;llmv1b\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x11llm_service.proto\x12\x06llm.v1\"\xff\x01\n\x0fGenerateRequest\x12\x12\n\nsession_id\x18\x01 \x01(\t\x12-\n\x08messages\x18\x02 \x03(\x0b\x32\x1b.llm.v1.ConversationMessage\x12%\n\nllm_config\x18\x03 \x01(\x0b\x32\x11.llm.v1.LLMConfig\x12%\n\x05tools\x18\x04 \x03(\x0b\x32\x16.llm.v1.ToolDefinition\x12\x14\n\x0c\x65xecution_id\x18\x05 \x01(\t\x12\x13\n\x0b\x63lear_cache\x18\x06 \x01(\x08\x12\x14\n\x0cprompt_cache\x18\x07 \x01(\x08\x12\x1a\n\x12\x64isable_tool_calls\x18\x08 \x01(\x08\"\xd4\x02\n\x10GenerateResponse\x12!\n\x04text\x18\x01 \x01(\x0b\x32\x11.llm.v1.TextDeltaH\x00\x12)\n\x08thinking\x18\x02 \x01(\x0b\x32\x15.llm.v1.ThinkingDeltaH\x00\x12*\n\ttool_call\x18\x03 \x01(\x0b\x32\x15.llm.v1.ToolCallDeltaH\x00\x12\"\n\x05usage\x18\x04 \x01(\x0b\x32\x11.llm.v1.UsageInfoH\x00\x12\"\n\x05\x65rror\x18\x05 \x01(\x0b\x32\x11.llm.v1.ErrorInfoH\x00\x12\x34\n\x0e\x63ode_execution\x18\x06 \x01(\x0b\x32\x1a.llm.v1.CodeExecutionDeltaH\x00\x12+\n\tgrounding\x18\x07 \x01(\x0b\x32\x16.llm.v1.GroundingDeltaH\x00\x12\x10\n\x08is_final\x18\n \x01(\x08\x42\t\n\x07\x63ontent\"\x83\x01\n\x13\x43onversationMessage\x12\x0c\n\x04role\x18\x01 \x01(\t\x12\x0f\n\x07\x63ontent\x18\x02 \x01(\t\x12$\n\ntool_calls\x18\x03 \x03(\x0b\x32\x10.llm.v1.ToolCall\x12\x14\n\x0ctool_call_id\x18\x04 \x01(\t\x12\x11\n\ttool_name\x18\x05 \x01(\t\"N\n\x0eToolDefinition\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x12\x19\n\x11parameters_schema\x18\x03 \x01(\t\"7\n\x08ToolCall\x12\n\n\x02id\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x11\n\targuments\x18\x03 \x01(\t\"\x1c\n\tTextDelta\x12\x0f\n\x07\x63ontent\x18\x01 \x01(\t\" \n\rThinkingDelta\x12\x0f\n\x07\x63ontent\x18\x01 \x01(\t\"A\n\rToolCallDelta\x12\x0f\n\x07\x63\x61ll_id\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x11\n\targuments\x18\x03 \x01(\t\"2\n\x12\x43odeExecutionDelta\x12\x0c\n\x04\x63ode\x18\x01 \x01(\t\x12\x0e\n\x06result\x18\x02 \x01(\t\"\xb9\x01\n\x0eGroundingDelta\x12\x1a\n\x12web_search_queries\x18\x01 \x03(\t\x12\x34\n\x10grounding_chunks\x18\x02 \x03(\x0b\x32\x1a.llm.v1.GroundingChunkInfo\x12\x34\n\x12grounding_supports\x18\x03 \x03(\x0b\x32\x18.llm.v1.GroundingSupport\x12\x1f\n\x17search_entry_point_html\x18\x04 \x01(\t\"0\n\x12GroundingChunkInfo\x12\x0b\n\x03uri\x18\x01 \x01(\t\x12\r\n\x05title\x18\x02 \x01(\t\"i\n\x10GroundingSupport\x12\x13\n\x0bstart_index\x18\x01 \x01(\x05\x12\x11\n\tend_index\x18\x02 \x01(\x05\x12\x0c\n\x04text\x18\x03 \x01(\t\x12\x1f\n\x17grounding_chunk_indices\x18\x04 \x03(\x05\"\xa1\x01\n\tUsageInfo\x12\x14\n\x0cinput_tokens\x18\x01 \x01(\x05\x12\x15\n\routput_tokens\x18\x02 \x01(\x05\x12\x14\n\x0ctotal_tokens\x18\x03 \x01(\x05\x12\x17\n\x0fthinking_tokens\x18\x04 \x01(\x05\x12\x19\n\x11\x63\x61\x63he_read_tokens\x18\x05 \x01(\x05\x12\x1d\n\x15\x63\x61\x63he_creation_tokens\x18\x06 \x01(\x05\"=\n\tErrorInfo\x12\x0f\n\x07message\x18\x01 \x01(\t\x12\x0c\n\x04\x63ode\x18\x02 \x01(\t\x12\x11\n\tretryable\x18\x03 \x01(\x08\"\xac\x02\n\tLLMConfig\x12\x10\n\x08provider\x18\x01 \x01(\t\x12\r\n\x05model\x18\x02 \x01(\t\x12\x13\n\x0b\x61pi_key_env\x18\x03 \x01(\t\x12\x17\n\x0f\x63redentials_env\x18\x04 \x01(\t\x12\x10\n\x08\x62\x61se_url\x18\x05 \x01(\t\x12\x38\n\x0cnative_tools\x18\x07 \x03(\x0b\x32\".llm.v1.LLMConfig.NativeToolsEntry\x12\x0f\n\x07project\x18\x08 \x01(\t\x12\x10\n\x08location\x18\t \x01(\t\x12\x0f\n\x07\x62\x61\x63kend\x18\n \x01(\t\x1a\x32\n\x10NativeToolsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x08:\x02\x38\x01J\x04\x08\x06\x10\x07R\x16max_tool_result_tokens2M\n\nLLMService\x12?\n\x08Generate\x12\x17.llm.v1.GenerateRequest\x1a\x18.llm.v1.GenerateResponse0\x01\x42\x32Z0github.com/codeready-toolchain/tarsy/proto;llmv1b\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -35,37 +35,37 @@ if not _descriptor._USE_C_DESCRIPTORS:
   _globals['_LLMCONFIG_NATIVETOOLSENTRY']._loaded_options = None
   _globals['_LLMCONFIG_NATIVETOOLSENTRY']._serialized_options = b'8\001'
   _globals['_GENERATEREQUEST']._serialized_start=30
-  _globals['_GENERATEREQUEST']._serialized_end=257
-  _globals['_GENERATERESPONSE']._serialized_start=260
-  _globals['_GENERATERESPONSE']._serialized_end=600
-  _globals['_CONVERSATIONMESSAGE']._serialized_start=603
-  _globals['_CONVERSATIONMESSAGE']._serialized_end=734
-  _globals['_TOOLDEFINITION']._serialized_start=736
-  _globals['_TOOLDEFINITION']._serialized_end=814
-  _globals['_TOOLCALL']._serialized_start=816
-  _globals['_TOOLCALL']._serialized_end=871
-  _globals['_TEXTDELTA']._serialized_start=873
-  _globals['_TEXTDELTA']._serialized_end=901
-  _globals['_THINKINGDELTA']._serialized_start=903
-  _globals['_THINKINGDELTA']._serialized_end=935
-  _globals['_TOOLCALLDELTA']._serialized_start=937
-  _globals['_TOOLCALLDELTA']._serialized_end=1002
-  _globals['_CODEEXECUTIONDELTA']._serialized_start=1004
-  _globals['_CODEEXECUTIONDELTA']._serialized_end=1054
-  _globals['_GROUNDINGDELTA']._serialized_start=1057
-  _globals['_GROUNDINGDELTA']._serialized_end=1242
-  _globals['_GROUNDINGCHUNKINFO']._serialized_start=1244
-  _globals['_GROUNDINGCHUNKINFO']._serialized_end=1292
-  _globals['_GROUNDINGSUPPORT']._serialized_start=1294
-  _globals['_GROUNDINGSUPPORT']._serialized_end=1399
-  _globals['_USAGEINFO']._serialized_start=1402
-  _globals['_USAGEINFO']._serialized_end=1563
-  _globals['_ERRORINFO']._serialized_start=1565
-  _globals['_ERRORINFO']._serialized_end=1626
-  _globals['_LLMCONFIG']._serialized_start=1629
-  _globals['_LLMCONFIG']._serialized_end=1929
-  _globals['_LLMCONFIG_NATIVETOOLSENTRY']._serialized_start=1849
-  _globals['_LLMCONFIG_NATIVETOOLSENTRY']._serialized_end=1899
-  _globals['_LLMSERVICE']._serialized_start=1931
-  _globals['_LLMSERVICE']._serialized_end=2008
+  _globals['_GENERATEREQUEST']._serialized_end=285
+  _globals['_GENERATERESPONSE']._serialized_start=288
+  _globals['_GENERATERESPONSE']._serialized_end=628
+  _globals['_CONVERSATIONMESSAGE']._serialized_start=631
+  _globals['_CONVERSATIONMESSAGE']._serialized_end=762
+  _globals['_TOOLDEFINITION']._serialized_start=764
+  _globals['_TOOLDEFINITION']._serialized_end=842
+  _globals['_TOOLCALL']._serialized_start=844
+  _globals['_TOOLCALL']._serialized_end=899
+  _globals['_TEXTDELTA']._serialized_start=901
+  _globals['_TEXTDELTA']._serialized_end=929
+  _globals['_THINKINGDELTA']._serialized_start=931
+  _globals['_THINKINGDELTA']._serialized_end=963
+  _globals['_TOOLCALLDELTA']._serialized_start=965
+  _globals['_TOOLCALLDELTA']._serialized_end=1030
+  _globals['_CODEEXECUTIONDELTA']._serialized_start=1032
+  _globals['_CODEEXECUTIONDELTA']._serialized_end=1082
+  _globals['_GROUNDINGDELTA']._serialized_start=1085
+  _globals['_GROUNDINGDELTA']._serialized_end=1270
+  _globals['_GROUNDINGCHUNKINFO']._serialized_start=1272
+  _globals['_GROUNDINGCHUNKINFO']._serialized_end=1320
+  _globals['_GROUNDINGSUPPORT']._serialized_start=1322
+  _globals['_GROUNDINGSUPPORT']._serialized_end=1427
+  _globals['_USAGEINFO']._serialized_start=1430
+  _globals['_USAGEINFO']._serialized_end=1591
+  _globals['_ERRORINFO']._serialized_start=1593
+  _globals['_ERRORINFO']._serialized_end=1654
+  _globals['_LLMCONFIG']._serialized_start=1657
+  _globals['_LLMCONFIG']._serialized_end=1957
+  _globals['_LLMCONFIG_NATIVETOOLSENTRY']._serialized_start=1877
+  _globals['_LLMCONFIG_NATIVETOOLSENTRY']._serialized_end=1927
+  _globals['_LLMSERVICE']._serialized_start=1959
+  _globals['_LLMSERVICE']._serialized_end=2036
 # @@protoc_insertion_point(module_scope)

--- a/llm-service/llm_proto/llm_service_pb2.pyi
+++ b/llm-service/llm_proto/llm_service_pb2.pyi
@@ -7,7 +7,7 @@ from typing import ClassVar as _ClassVar, Optional as _Optional, Union as _Union
 DESCRIPTOR: _descriptor.FileDescriptor
 
 class GenerateRequest(_message.Message):
-    __slots__ = ("session_id", "messages", "llm_config", "tools", "execution_id", "clear_cache", "prompt_cache")
+    __slots__ = ("session_id", "messages", "llm_config", "tools", "execution_id", "clear_cache", "prompt_cache", "disable_tool_calls")
     SESSION_ID_FIELD_NUMBER: _ClassVar[int]
     MESSAGES_FIELD_NUMBER: _ClassVar[int]
     LLM_CONFIG_FIELD_NUMBER: _ClassVar[int]
@@ -15,6 +15,7 @@ class GenerateRequest(_message.Message):
     EXECUTION_ID_FIELD_NUMBER: _ClassVar[int]
     CLEAR_CACHE_FIELD_NUMBER: _ClassVar[int]
     PROMPT_CACHE_FIELD_NUMBER: _ClassVar[int]
+    DISABLE_TOOL_CALLS_FIELD_NUMBER: _ClassVar[int]
     session_id: str
     messages: _containers.RepeatedCompositeFieldContainer[ConversationMessage]
     llm_config: LLMConfig
@@ -22,7 +23,8 @@ class GenerateRequest(_message.Message):
     execution_id: str
     clear_cache: bool
     prompt_cache: bool
-    def __init__(self, session_id: _Optional[str] = ..., messages: _Optional[_Iterable[_Union[ConversationMessage, _Mapping]]] = ..., llm_config: _Optional[_Union[LLMConfig, _Mapping]] = ..., tools: _Optional[_Iterable[_Union[ToolDefinition, _Mapping]]] = ..., execution_id: _Optional[str] = ..., clear_cache: _Optional[bool] = ..., prompt_cache: _Optional[bool] = ...) -> None: ...
+    disable_tool_calls: bool
+    def __init__(self, session_id: _Optional[str] = ..., messages: _Optional[_Iterable[_Union[ConversationMessage, _Mapping]]] = ..., llm_config: _Optional[_Union[LLMConfig, _Mapping]] = ..., tools: _Optional[_Iterable[_Union[ToolDefinition, _Mapping]]] = ..., execution_id: _Optional[str] = ..., clear_cache: _Optional[bool] = ..., prompt_cache: _Optional[bool] = ..., disable_tool_calls: _Optional[bool] = ...) -> None: ...
 
 class GenerateResponse(_message.Message):
     __slots__ = ("text", "thinking", "tool_call", "usage", "error", "code_execution", "grounding", "is_final")

--- a/llm-service/tests/test_google_native.py
+++ b/llm-service/tests/test_google_native.py
@@ -1301,6 +1301,7 @@ class TestGoogleNativeProvider:
                 backend="google-native",
                 model="gemini-2.5-pro",
                 api_key_env="TEST_API_KEY",
+                native_tools={"google_search": True, "code_execution": True},
             ),
             messages=[pb.ConversationMessage(role="user", content="Hi")],
             tools=[
@@ -1315,12 +1316,20 @@ class TestGoogleNativeProvider:
             pass
         config = mock_client.aio.models.generate_content_stream.call_args.kwargs["config"]
         assert config.tools
-        assert config.tools[0].function_declarations
-        assert config.tools[0].function_declarations[0].name == "k8s__get_pods"
+        decls = [
+            d
+            for t in config.tools
+            if t.function_declarations
+            for d in t.function_declarations
+        ]
+        assert decls[0].name == "k8s__get_pods"
+        assert any(t.google_search for t in config.tools)
+        assert any(t.code_execution for t in config.tools)
         assert (
             config.tool_config.function_calling_config.mode
             == genai_types.FunctionCallingConfigMode.NONE
         )
+        assert not config.tool_config.include_server_side_tool_invocations
 
 
 class TestStreamPartTypes:

--- a/llm-service/tests/test_google_native.py
+++ b/llm-service/tests/test_google_native.py
@@ -1280,6 +1280,48 @@ class TestGoogleNativeProvider:
 
         assert call_count["n"] == 1
 
+    @pytest.mark.asyncio
+    @patch.dict(os.environ, {"TEST_API_KEY": "test-key-123"})
+    @patch("llm.providers.google_native.genai.Client")
+    async def test_disable_tool_calls_keeps_decls_sets_mode_none(
+        self, mock_client_class, provider,
+    ):
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+
+        async def mock_stream():
+            yield self._text_chunk("done")
+
+        mock_client.aio.models.generate_content_stream = AsyncMock(return_value=mock_stream())
+        request = pb.GenerateRequest(
+            session_id="sess-1",
+            execution_id="exec-1",
+            disable_tool_calls=True,
+            llm_config=pb.LLMConfig(
+                backend="google-native",
+                model="gemini-2.5-pro",
+                api_key_env="TEST_API_KEY",
+            ),
+            messages=[pb.ConversationMessage(role="user", content="Hi")],
+            tools=[
+                pb.ToolDefinition(
+                    name="k8s.get_pods",
+                    description="List pods",
+                    parameters_schema='{"type": "object"}',
+                ),
+            ],
+        )
+        async for _ in provider.generate(request):
+            pass
+        config = mock_client.aio.models.generate_content_stream.call_args.kwargs["config"]
+        assert config.tools
+        assert config.tools[0].function_declarations
+        assert config.tools[0].function_declarations[0].name == "k8s__get_pods"
+        assert (
+            config.tool_config.function_calling_config.mode
+            == genai_types.FunctionCallingConfigMode.NONE
+        )
+
 
 class TestStreamPartTypes:
     """Test that _stream_with_timeout handles all Gemini part types."""

--- a/llm-service/tests/test_langchain_provider.py
+++ b/llm-service/tests/test_langchain_provider.py
@@ -1106,7 +1106,7 @@ class TestLangChainProviderGenerate:
         attempt = {"n": 0}
         exc = self._http_exc(status_code=404, message="Publisher model not found")
 
-        def fake_get(config, tools, cache_kind=prompt_cache.NONE, strip_ttl=False, execution_id=""):
+        def fake_get(config, tools, cache_kind=prompt_cache.NONE, strip_ttl=False, execution_id="", disable_tool_calls=False):
             kinds.append((cache_kind, strip_ttl))
 
             class Model:
@@ -1266,6 +1266,16 @@ def _sample_tools():
     ]
 
 
+def _has_openai_breakpoint(msg) -> bool:
+    extra = getattr(msg, "additional_kwargs", None) or {}
+    if extra.get("prompt_cache_breakpoint") == {"mode": "explicit"}:
+        return True
+    content = getattr(msg, "content", None)
+    if isinstance(content, list) and content and isinstance(content[0], dict):
+        return content[0].get("prompt_cache_breakpoint") == {"mode": "explicit"}
+    return False
+
+
 class TestLangChainPromptCacheBreakpoints:
     def test_anthropic_tools_and_messages(self, provider):
         mock_model = MagicMock()
@@ -1294,6 +1304,18 @@ class TestLangChainPromptCacheBreakpoints:
         assert result["tool_use_id"] == "tc1"
         assert result["content"] == "pod-1 Running"
         assert result["cache_control"]["ttl"] == "1h"
+
+    def test_anthropic_forced_conclusion_marks_last_tool_not_user(self, provider):
+        history = _looping_tool_history() + [
+            pb.ConversationMessage(role="user", content="Conclude now."),
+        ]
+        converted = provider._convert_messages(history, prompt_cache.ANTHROPIC)
+        last_user = converted[-1]
+        tool = converted[3]
+        assert isinstance(last_user, HumanMessage)
+        assert isinstance(last_user.content, str)
+        assert last_user.additional_kwargs.get("cache_control") in (None, {})
+        assert tool.additional_kwargs["cache_control"]["ttl"] == "1h"
 
     def test_vertex_tool_result_cache_control_not_nested(self, provider):
         from langchain_google_vertexai._anthropic_utils import _format_messages_anthropic
@@ -1339,17 +1361,15 @@ class TestLangChainPromptCacheBreakpoints:
         assert "cache_control" not in bound[-1]
         assert "prompt_cache_breakpoint" not in bound[-1]
 
-    def test_openai_walk_back_past_tool_result(self, provider):
+    def test_openai_sticky_breakpoints_not_assistant(self, provider):
         converted = provider._convert_messages(
             _looping_tool_history(), prompt_cache.OPENAI_EXPLICIT,
         )
-        system = converted[0]
-        assert system.content[0]["prompt_cache_breakpoint"] == {"mode": "explicit"}
-        assistant = converted[2]
-        assert assistant.content[0]["prompt_cache_breakpoint"] == {"mode": "explicit"}
-        tool = converted[3]
-        assert isinstance(tool, ToolMessage)
-        assert "prompt_cache_breakpoint" not in (tool.additional_kwargs or {})
+        assert _has_openai_breakpoint(converted[0])  # system
+        assert _has_openai_breakpoint(converted[1])  # first user
+        assert not _has_openai_breakpoint(converted[2])  # assistant
+        assert _has_openai_breakpoint(converted[3])  # last tool
+        assert isinstance(converted[3], ToolMessage)
 
         mock_model = MagicMock()
         mock_model.bind_tools.return_value = mock_model
@@ -1360,6 +1380,17 @@ class TestLangChainPromptCacheBreakpoints:
         assert bound[-1]["prompt_cache_breakpoint"] == {"mode": "explicit"}
         assert "prompt_cache_breakpoint" not in bound[0]
 
+    def test_openai_forced_conclusion_user_unmarked(self, provider):
+        history = _looping_tool_history() + [
+            pb.ConversationMessage(role="user", content="Conclude now."),
+        ]
+        converted = provider._convert_messages(history, prompt_cache.OPENAI_EXPLICIT)
+        assert _has_openai_breakpoint(converted[0])
+        assert _has_openai_breakpoint(converted[1])
+        assert not _has_openai_breakpoint(converted[2])
+        assert _has_openai_breakpoint(converted[3])
+        assert not _has_openai_breakpoint(converted[4])
+
     @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"})
     def test_openai_options_not_on_constructor(self, provider):
         captured = {}
@@ -1368,7 +1399,7 @@ class TestLangChainPromptCacheBreakpoints:
             def __init__(self, **kwargs):
                 captured["ctor"] = kwargs
 
-            def bind_tools(self, tools):
+            def bind_tools(self, tools, **kwargs):
                 captured["tools"] = tools
                 return self
 
@@ -1393,6 +1424,73 @@ class TestLangChainPromptCacheBreakpoints:
         }
         assert "max_retries" not in captured["bind"]
 
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"})
+    def test_openai_disable_binds_options_without_breakpoints(self, provider):
+        captured = {}
+
+        class FakeChatOpenAI:
+            def __init__(self, **kwargs):
+                captured["ctor"] = kwargs
+
+            def bind_tools(self, tools, **kwargs):
+                captured["tools"] = tools
+                captured["bind_tools_kwargs"] = kwargs
+                return self
+
+            def bind(self, **kwargs):
+                captured["bind"] = kwargs
+                return self
+
+        with patch("langchain_openai.ChatOpenAI", FakeChatOpenAI):
+            config = pb.LLMConfig(
+                provider="openai", model="gpt-5.6", api_key_env="OPENAI_API_KEY",
+            )
+            kind = prompt_cache.classify_cache(config, False, "exec-99")
+            assert kind == prompt_cache.OPENAI_EXPLICIT_DISABLE
+            provider._get_or_create_model(
+                config, _sample_tools(), kind, False, "exec-99",
+            )
+
+        assert "prompt_cache_options" not in captured["ctor"]
+        assert captured["bind"]["prompt_cache_key"] == "exec-99"
+        assert captured["bind"]["prompt_cache_options"] == {
+            "mode": "explicit", "ttl": "30m",
+        }
+        assert "prompt_cache_breakpoint" not in captured["tools"][-1]
+        converted = provider._convert_messages(
+            _looping_tool_history(), prompt_cache.OPENAI_EXPLICIT_DISABLE,
+        )
+        assert isinstance(converted[0].content, str)
+        assert not any(_has_openai_breakpoint(m) for m in converted)
+
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"})
+    def test_disable_tool_calls_sets_tool_choice_none(self, provider):
+        captured = {}
+
+        class FakeChatOpenAI:
+            def __init__(self, **kwargs):
+                captured["ctor"] = kwargs
+
+            def bind_tools(self, tools, **kwargs):
+                captured["tools"] = tools
+                captured["bind_tools_kwargs"] = kwargs
+                return self
+
+            def bind(self, **kwargs):
+                captured["bind"] = kwargs
+                return self
+
+        with patch("langchain_openai.ChatOpenAI", FakeChatOpenAI):
+            config = pb.LLMConfig(
+                provider="openai", model="gpt-5.6", api_key_env="OPENAI_API_KEY",
+            )
+            provider._get_or_create_model(
+                config, _sample_tools(), prompt_cache.OPENAI_EXPLICIT, False, "exec-99",
+                disable_tool_calls=True,
+            )
+
+        assert captured["bind_tools_kwargs"]["tool_choice"] == "none"
+
     @patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"})
     def test_anthropic_max_retries_on_constructor_not_bind(self, provider):
         captured = {}
@@ -1401,7 +1499,7 @@ class TestLangChainPromptCacheBreakpoints:
             def __init__(self, **kwargs):
                 captured["ctor"] = kwargs
 
-            def bind_tools(self, tools):
+            def bind_tools(self, tools, **kwargs):
                 captured["tools"] = tools
                 return self
 
@@ -1428,7 +1526,7 @@ class TestLangChainPromptCacheBreakpoints:
             def __init__(self, **kwargs):
                 captured["ctor"] = kwargs
 
-            def bind_tools(self, tools):
+            def bind_tools(self, tools, **kwargs):
                 captured["tools"] = tools
                 return self
 
@@ -1461,7 +1559,7 @@ class TestLangChainPromptCacheBreakpoints:
             def __init__(self, **kwargs):
                 captured["ctor"] = kwargs
 
-            def bind_tools(self, tools):
+            def bind_tools(self, tools, **kwargs):
                 return self
 
         with patch("langchain_xai.ChatXAI", FakeChatXAI):
@@ -1482,7 +1580,7 @@ class TestLangChainPromptCacheBreakpoints:
             def __init__(self, **kwargs):
                 captured["ctor"] = kwargs
 
-            def bind_tools(self, tools):
+            def bind_tools(self, tools, **kwargs):
                 return self
 
         with patch("langchain_google_genai.ChatGoogleGenerativeAI", FakeChatGoogle):
@@ -1502,7 +1600,7 @@ class TestLangChainPromptCacheBreakpoints:
             def __init__(self, **kwargs):
                 captured["ctor"] = kwargs
 
-            def bind_tools(self, tools):
+            def bind_tools(self, tools, **kwargs):
                 return self
 
         with patch("langchain_google_genai.ChatGoogleGenerativeAI", FakeChatGoogle):
@@ -1527,7 +1625,7 @@ class TestLangChainPromptCacheBreakpoints:
             def __init__(self, **kwargs):
                 captured["ctor"] = kwargs
 
-            def bind_tools(self, tools):
+            def bind_tools(self, tools, **kwargs):
                 captured["tools"] = tools
                 return self
 
@@ -1565,9 +1663,14 @@ class TestLangChainPromptCacheBreakpoints:
                 idx = call["n"]
                 call["n"] += 1
                 last = messages[-1]
+                if idx == 0:
+                    assert not _has_openai_breakpoint(last)
+                    assert _has_openai_breakpoint(messages[0])
+                    assert _has_openai_breakpoint(messages[1])
                 if idx == 1:
                     assert isinstance(last, ToolMessage)
-                    assert "prompt_cache_breakpoint" not in (last.additional_kwargs or {})
+                    assert _has_openai_breakpoint(last)
+                    assert not _has_openai_breakpoint(messages[2])
 
                 async def gen():
                     chunk = AIMessageChunk(content="ok")
@@ -1605,7 +1708,7 @@ class TestLangChainPromptCacheBreakpoints:
         kinds = []
         attempt = {"n": 0}
 
-        def fake_get(config, tools, cache_kind=prompt_cache.NONE, strip_ttl=False, execution_id=""):
+        def fake_get(config, tools, cache_kind=prompt_cache.NONE, strip_ttl=False, execution_id="", disable_tool_calls=False):
             kinds.append((cache_kind, strip_ttl))
 
             class Model:

--- a/llm-service/tests/test_prompt_cache.py
+++ b/llm-service/tests/test_prompt_cache.py
@@ -42,11 +42,17 @@ class TestClassifyCache:
     def test_openai_gpt56_requires_execution_id(self):
         cfg = pb.LLMConfig(provider="openai", model="gpt-5.6")
         assert prompt_cache.classify_cache(cfg, True, "exec-1") == prompt_cache.OPENAI_EXPLICIT
-        assert prompt_cache.classify_cache(cfg, True, "") == prompt_cache.NONE
+        assert prompt_cache.classify_cache(cfg, True, "") == prompt_cache.OPENAI_EXPLICIT_DISABLE
+
+    def test_openai_gpt56_prompt_cache_off_is_disable(self):
+        cfg = pb.LLMConfig(provider="openai", model="gpt-5.6")
+        assert prompt_cache.classify_cache(cfg, False, "exec-1") == prompt_cache.OPENAI_EXPLICIT_DISABLE
+        assert prompt_cache.classify_cache(cfg, False, "") == prompt_cache.OPENAI_EXPLICIT_DISABLE
 
     def test_openai_older_extract_only(self):
         cfg = pb.LLMConfig(provider="openai", model="gpt-5.2")
         assert prompt_cache.classify_cache(cfg, True, "exec-1") == prompt_cache.NONE
+        assert prompt_cache.classify_cache(cfg, False, "exec-1") == prompt_cache.NONE
 
     def test_flag_off(self):
         cfg = pb.LLMConfig(provider="anthropic", model="claude-sonnet-4-5")
@@ -68,14 +74,24 @@ class TestDegradeAndWalkBack:
             (prompt_cache.NONE, False),
         ]
 
-    def test_last_non_tool_index_walks_back(self):
+        assert prompt_cache.cache_degrade_sequence(prompt_cache.OPENAI_EXPLICIT_DISABLE) == [
+            (prompt_cache.OPENAI_EXPLICIT_DISABLE, False),
+            (prompt_cache.OPENAI_EXPLICIT_DISABLE, True),
+            (prompt_cache.NONE, False),
+        ]
+
+    def test_first_user_and_last_tool_indexes(self):
         messages = [
             pb.ConversationMessage(role="system", content="sys"),
             pb.ConversationMessage(role="user", content="go"),
             pb.ConversationMessage(role="assistant", content=""),
             pb.ConversationMessage(role="tool", content="result", tool_call_id="1"),
+            pb.ConversationMessage(role="user", content="conclude"),
         ]
-        assert prompt_cache.last_non_tool_index(messages) == 2
+        assert prompt_cache.first_user_index(messages) == 1
+        assert prompt_cache.last_tool_index(messages) == 3
+        assert prompt_cache.first_user_index(messages[:1]) == -1
+        assert prompt_cache.last_tool_index(messages[:3]) == -1
 
     def test_is_bad_request(self):
         class Fake400(Exception):

--- a/pkg/agent/controller/iterating.go
+++ b/pkg/agent/controller/iterating.go
@@ -298,15 +298,17 @@ func (c *IteratingController) Run(
 		iterCancel()
 	}
 
-	// Max iterations — force conclusion (call LLM WITHOUT tools)
-	return c.forceConclusion(ctx, execCtx, messages, &totalUsage, state, fbState, &msgSeq, &eventSeq)
+	// Max iterations — force conclusion (same tools, calling disabled)
+	return c.forceConclusion(ctx, execCtx, messages, tools, &totalUsage, state, fbState, &msgSeq, &eventSeq)
 }
 
-// forceConclusion forces the LLM to produce a final answer by calling without tools.
+// forceConclusion forces a text-only final answer while keeping the looping tool
+// list bound so the prompt-cache prefix can still hit.
 func (c *IteratingController) forceConclusion(
 	ctx context.Context,
 	execCtx *agent.ExecutionContext,
 	messages []agent.ConversationMessage,
+	tools []agent.ToolDefinition,
 	totalUsage *agent.TokenUsage,
 	state *agent.IterationState,
 	fbState *FallbackState,
@@ -331,8 +333,8 @@ func (c *IteratingController) forceConclusion(
 		"max_iterations":    state.MaxIterations,
 	}
 
-	// Call LLM WITHOUT tools with streaming — forces text-only response.
-	// Apply LLM call timeout (the parent ctx is the session context here).
+	// Keep the same tools bound and disable calling so the looping prefix can
+	// still cache-hit. Apply LLM call timeout (parent ctx is the session).
 	// On failure, attempt fallback to another provider before giving up.
 	var streamed *StreamedResponse
 	var err error
@@ -348,14 +350,15 @@ func (c *IteratingController) forceConclusion(
 		llmCtx, llmCancel := context.WithTimeout(ctx, execCtx.Config.LLMCallTimeout)
 		llmStart := time.Now()
 		streamed, err = callLLMWithStreaming(llmCtx, execCtx, execCtx.LLMClient, &agent.GenerateInput{
-			SessionID:   execCtx.SessionID,
-			ExecutionID: execCtx.ExecutionID,
-			Messages:    messages,
-			Config:      execCtx.Config.LLMProvider,
-			Tools:       nil, // No tools — force conclusion
-			Backend:     execCtx.Config.LLMBackend,
-			ClearCache:  fbState.consumeClearCache(),
-			PromptCache: false,
+			SessionID:        execCtx.SessionID,
+			ExecutionID:      execCtx.ExecutionID,
+			Messages:         messages,
+			Config:           execCtx.Config.LLMProvider,
+			Tools:            tools,
+			DisableToolCalls: true,
+			Backend:          execCtx.Config.LLMBackend,
+			ClearCache:       fbState.consumeClearCache(),
+			PromptCache:      execCtx.Config.Type != config.AgentTypeAction,
 		}, eventSeq, forcedMeta)
 		llmCancel()
 		metrics.ObserveLLMCall(execCtx.Config.LLMProviderName, execCtx.Config.LLMProvider.Model,

--- a/pkg/agent/controller/iterating_test.go
+++ b/pkg/agent/controller/iterating_test.go
@@ -230,7 +230,7 @@ func TestIteratingController_ForcedConclusion(t *testing.T) {
 			},
 		})
 	}
-	// Forced conclusion response (no tools)
+	// Forced conclusion response (text-only after max iterations)
 	responses = append(responses, mockLLMResponse{
 		chunks: []agent.Chunk{
 			&agent.TextChunk{Content: "Based on investigation: system is healthy."},
@@ -274,8 +274,76 @@ func TestIteratingController_ForcedConclusion(t *testing.T) {
 	require.Len(t, llm.capturedInputs, 4)
 	for i := range 3 {
 		assert.True(t, llm.capturedInputs[i].PromptCache, "loop call %d should request prompt cache", i)
+		assert.False(t, llm.capturedInputs[i].DisableToolCalls, "loop call %d should allow tool calling", i)
 	}
-	assert.False(t, llm.capturedInputs[3].PromptCache, "forced conclusion must not request prompt cache")
+	conclusion := llm.capturedInputs[3]
+	assert.True(t, conclusion.PromptCache, "forced conclusion should request prompt cache reads")
+	assert.True(t, conclusion.DisableToolCalls)
+	require.NotEmpty(t, conclusion.Tools)
+	assert.Equal(t, "k8s.get_pods", conclusion.Tools[0].Name)
+}
+
+func TestIteratingController_ForcedConclusion_Eligibility(t *testing.T) {
+	tests := []struct {
+		name        string
+		mutate      func(*agent.ResolvedAgentConfig)
+		promptCache bool
+	}{
+		{
+			name: "action agent does not request prompt cache",
+			mutate: func(c *agent.ResolvedAgentConfig) {
+				c.Type = config.AgentTypeAction
+			},
+			promptCache: false,
+		},
+		{
+			name: "cluster toggle AND disables prompt cache",
+			mutate: func(c *agent.ResolvedAgentConfig) {
+				c.PromptCachingEnabled = false
+			},
+			promptCache: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			llm := &mockLLMClient{
+				capture: true,
+				responses: []mockLLMResponse{
+					{chunks: []agent.Chunk{
+						&agent.ToolCallChunk{CallID: "call-0", Name: "k8s.get_pods", Arguments: "{}"},
+					}},
+					{chunks: []agent.Chunk{
+						&agent.TextChunk{Content: "Conclusion."},
+					}},
+				},
+			}
+			executor := &mockToolExecutor{
+				tools: []agent.ToolDefinition{{Name: "k8s.get_pods", Description: "Get pods"}},
+				results: map[string]*agent.ToolResult{
+					"k8s.get_pods": {Content: "pod-1 Running"},
+				},
+			}
+			execCtx := newTestExecCtx(t, llm, executor)
+			execCtx.Config.MaxIterations = 1
+			tt.mutate(execCtx.Config)
+			ctrl := NewIteratingController()
+
+			result, err := ctrl.Run(t.Context(), execCtx, "")
+			require.NoError(t, err)
+			require.Equal(t, agent.ExecutionStatusCompleted, result.Status)
+
+			require.Len(t, llm.capturedInputs, 2)
+			loop := llm.capturedInputs[0]
+			conclusion := llm.capturedInputs[1]
+			assert.Equal(t, tt.promptCache, loop.PromptCache)
+			assert.False(t, loop.DisableToolCalls)
+			assert.Equal(t, tt.promptCache, conclusion.PromptCache)
+			assert.True(t, conclusion.DisableToolCalls)
+			require.Equal(t, loop.Tools, conclusion.Tools)
+			require.NotEmpty(t, conclusion.Tools)
+		})
+	}
 }
 
 func TestIteratingController_ThinkingContent(t *testing.T) {
@@ -407,7 +475,7 @@ func TestIteratingController_ForcedConclusionWithFailedLastLLM(t *testing.T) {
 	responses = append(responses, mockLLMResponse{
 		err: fmt.Errorf("connection reset"),
 	})
-	// Forced conclusion response (called without tools after max iterations)
+	// Forced conclusion response (tools bound, calling disabled after max iterations)
 	responses = append(responses, mockLLMResponse{
 		chunks: []agent.Chunk{
 			&agent.TextChunk{Content: "Despite issues, the system appears healthy."},
@@ -905,6 +973,10 @@ func TestIteratingController_ForcedConclusionWithGrounding(t *testing.T) {
 		}
 	}
 	require.True(t, foundSearch, "google_search_result event should be created during forced conclusion")
+	require.NotNil(t, llm.lastInput)
+	assert.True(t, llm.lastInput.DisableToolCalls)
+	require.NotEmpty(t, llm.lastInput.Tools)
+	assert.Equal(t, "k8s.get_pods", llm.lastInput.Tools[0].Name)
 }
 
 // ─── Sub-agent drain/wait tests ─────────────────────────────────────────────
@@ -1264,7 +1336,7 @@ func TestIteratingController_FallbackReplaysToolHistory(t *testing.T) {
 	}
 
 	ctrl := NewIteratingController()
-	result, err := ctrl.Run(t.Context(), execCtx, "")
+	result, err := ctrl.Run(context.Background(), execCtx, "")
 	require.NoError(t, err)
 	require.Equal(t, agent.ExecutionStatusCompleted, result.Status)
 	require.Equal(t, "Healthy after fallback.", result.FinalAnalysis)
@@ -1612,11 +1684,12 @@ func TestIteratingController_PromptCache(t *testing.T) {
 		execCtx := newTestExecCtx(t, llm, &mockToolExecutor{tools: []agent.ToolDefinition{}})
 		ctrl := NewIteratingController()
 
-		result, err := ctrl.Run(context.Background(), execCtx, "")
+		result, err := ctrl.Run(t.Context(), execCtx, "")
 		require.NoError(t, err)
 		require.Equal(t, agent.ExecutionStatusCompleted, result.Status)
 		require.Len(t, llm.capturedInputs, 1)
 		assert.True(t, llm.capturedInputs[0].PromptCache)
+		assert.False(t, llm.capturedInputs[0].DisableToolCalls)
 	})
 
 	t.Run("action loop does not set PromptCache", func(t *testing.T) {
@@ -1628,11 +1701,12 @@ func TestIteratingController_PromptCache(t *testing.T) {
 		execCtx.Config.Type = config.AgentTypeAction
 		ctrl := NewIteratingController()
 
-		result, err := ctrl.Run(context.Background(), execCtx, "")
+		result, err := ctrl.Run(t.Context(), execCtx, "")
 		require.NoError(t, err)
 		require.Equal(t, agent.ExecutionStatusCompleted, result.Status)
 		require.Len(t, llm.capturedInputs, 1)
 		assert.False(t, llm.capturedInputs[0].PromptCache)
+		assert.False(t, llm.capturedInputs[0].DisableToolCalls)
 	})
 
 	t.Run("cluster toggle AND disables PromptCache", func(t *testing.T) {
@@ -1644,11 +1718,12 @@ func TestIteratingController_PromptCache(t *testing.T) {
 		execCtx.Config.PromptCachingEnabled = false
 		ctrl := NewIteratingController()
 
-		result, err := ctrl.Run(context.Background(), execCtx, "")
+		result, err := ctrl.Run(t.Context(), execCtx, "")
 		require.NoError(t, err)
 		require.Equal(t, agent.ExecutionStatusCompleted, result.Status)
 		require.Len(t, llm.capturedInputs, 1)
 		assert.False(t, llm.capturedInputs[0].PromptCache)
+		assert.False(t, llm.capturedInputs[0].DisableToolCalls)
 	})
 }
 

--- a/pkg/agent/controller/streaming_test.go
+++ b/pkg/agent/controller/streaming_test.go
@@ -1112,14 +1112,21 @@ func TestCallLLMWithStreaming_PromptCacheAND(t *testing.T) {
 			if !tt.nilCfg {
 				execCtx.Config = &agent.ResolvedAgentConfig{PromptCachingEnabled: tt.enabled}
 			}
-			input := &agent.GenerateInput{PromptCache: tt.eligible}
+			input := &agent.GenerateInput{
+				PromptCache:      tt.eligible,
+				DisableToolCalls: true,
+				Tools:            []agent.ToolDefinition{{Name: "k8s.get_pods"}},
+			}
 			eventSeq := 0
 
 			_, err := callLLMWithStreaming(t.Context(), execCtx, llm, input, &eventSeq)
 			require.NoError(t, err)
 			require.Len(t, llm.capturedInputs, 1)
 			assert.Equal(t, tt.want, llm.capturedInputs[0].PromptCache)
+			assert.True(t, llm.capturedInputs[0].DisableToolCalls)
+			require.Equal(t, input.Tools, llm.capturedInputs[0].Tools)
 			assert.Equal(t, tt.eligible, input.PromptCache, "caller GenerateInput must not be mutated")
+			assert.True(t, input.DisableToolCalls, "caller GenerateInput must not be mutated")
 		})
 	}
 }

--- a/pkg/agent/llm_client.go
+++ b/pkg/agent/llm_client.go
@@ -20,14 +20,15 @@ type LLMClient interface {
 
 // GenerateInput is the Go-side representation of a Generate request.
 type GenerateInput struct {
-	SessionID   string
-	ExecutionID string
-	Messages    []ConversationMessage
-	Config      *config.LLMProviderConfig
-	Tools       []ToolDefinition  // nil = no tools
-	Backend     config.LLMBackend // see config.LLMBackendNativeGemini, config.LLMBackendLangChain
-	ClearCache  bool              // signal to clear provider content cache (e.g. on fallback provider switch)
-	PromptCache bool              // apply Claude cache_control / OpenAI 5.6+ breakpoints (AND-ed with cluster toggle before gRPC)
+	SessionID        string
+	ExecutionID      string
+	Messages         []ConversationMessage
+	Config           *config.LLMProviderConfig
+	Tools            []ToolDefinition  // nil = no tools
+	Backend          config.LLMBackend // see config.LLMBackendNativeGemini, config.LLMBackendLangChain
+	ClearCache       bool              // signal to clear provider content cache (e.g. on fallback provider switch)
+	PromptCache      bool              // apply Claude cache_control / OpenAI 5.6+ breakpoints (AND-ed with cluster toggle before gRPC)
+	DisableToolCalls bool              // keep tool schemas but forbid calling (forced conclusion)
 }
 
 // Conversation message roles.

--- a/pkg/agent/llm_grpc.go
+++ b/pkg/agent/llm_grpc.go
@@ -80,12 +80,13 @@ func (c *GRPCLLMClient) Close() error {
 
 func toProtoRequest(input *GenerateInput) *llmv1.GenerateRequest {
 	req := &llmv1.GenerateRequest{
-		SessionId:   input.SessionID,
-		ExecutionId: input.ExecutionID,
-		Messages:    toProtoMessages(input.Messages),
-		Tools:       toProtoTools(input.Tools),
-		ClearCache:  input.ClearCache,
-		PromptCache: input.PromptCache,
+		SessionId:        input.SessionID,
+		ExecutionId:      input.ExecutionID,
+		Messages:         toProtoMessages(input.Messages),
+		Tools:            toProtoTools(input.Tools),
+		ClearCache:       input.ClearCache,
+		PromptCache:      input.PromptCache,
+		DisableToolCalls: input.DisableToolCalls,
 	}
 	if input.Config != nil {
 		req.LlmConfig = toProtoLLMConfig(input.Config)

--- a/pkg/agent/llm_grpc_test.go
+++ b/pkg/agent/llm_grpc_test.go
@@ -333,6 +333,55 @@ func TestToProtoRequest_PromptCache(t *testing.T) {
 	})
 }
 
+func TestToProtoRequest_DisableToolCalls(t *testing.T) {
+	t.Run("DisableToolCalls false by default", func(t *testing.T) {
+		input := &GenerateInput{
+			SessionID:   "session-1",
+			ExecutionID: "exec-1",
+			Messages:    []ConversationMessage{{Role: "user", Content: "hello"}},
+			Config:      &config.LLMProviderConfig{Model: "test-model", Type: config.LLMProviderTypeGoogle},
+			Backend:     config.LLMBackendNativeGemini,
+			Tools:       []ToolDefinition{{Name: "k8s.get_pods"}},
+		}
+		req := toProtoRequest(input)
+		assert.False(t, req.DisableToolCalls)
+	})
+
+	t.Run("DisableToolCalls propagated when true", func(t *testing.T) {
+		input := &GenerateInput{
+			SessionID:        "session-1",
+			ExecutionID:      "exec-1",
+			Messages:         []ConversationMessage{{Role: "user", Content: "hello"}},
+			Config:           &config.LLMProviderConfig{Model: "test-model", Type: config.LLMProviderTypeGoogle},
+			Backend:          config.LLMBackendNativeGemini,
+			Tools:            []ToolDefinition{{Name: "k8s.get_pods"}},
+			DisableToolCalls: true,
+		}
+		req := toProtoRequest(input)
+		assert.True(t, req.DisableToolCalls)
+		require.Len(t, req.Tools, 1)
+		assert.Equal(t, "k8s.get_pods", req.Tools[0].Name)
+	})
+
+	t.Run("forced conclusion wire shape keeps tools and cache flag", func(t *testing.T) {
+		input := &GenerateInput{
+			SessionID:        "session-1",
+			ExecutionID:      "exec-1",
+			Messages:         []ConversationMessage{{Role: "user", Content: "conclude"}},
+			Config:           &config.LLMProviderConfig{Model: "gpt-5.6", Type: config.LLMProviderTypeOpenAI},
+			Backend:          config.LLMBackendLangChain,
+			Tools:            []ToolDefinition{{Name: "k8s.get_pods"}},
+			PromptCache:      true,
+			DisableToolCalls: true,
+		}
+		req := toProtoRequest(input)
+		assert.True(t, req.PromptCache)
+		assert.True(t, req.DisableToolCalls)
+		require.Len(t, req.Tools, 1)
+		assert.Equal(t, "k8s.get_pods", req.Tools[0].Name)
+	})
+}
+
 func TestToProtoTools(t *testing.T) {
 	t.Run("nil tools returns nil", func(t *testing.T) {
 		assert.Nil(t, toProtoTools(nil))

--- a/proto/llm_service.pb.go
+++ b/proto/llm_service.pb.go
@@ -24,16 +24,17 @@ const (
 // GenerateRequest is the input for a single LLM call.
 // Go builds the full conversation and sends it each time.
 type GenerateRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	SessionId     string                 `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`        // For logging/tracing
-	Messages      []*ConversationMessage `protobuf:"bytes,2,rep,name=messages,proto3" json:"messages,omitempty"`                           // Full conversation history
-	LlmConfig     *LLMConfig             `protobuf:"bytes,3,opt,name=llm_config,json=llmConfig,proto3" json:"llm_config,omitempty"`        // Provider configuration
-	Tools         []*ToolDefinition      `protobuf:"bytes,4,rep,name=tools,proto3" json:"tools,omitempty"`                                 // Available tools (empty = no tools)
-	ExecutionId   string                 `protobuf:"bytes,5,opt,name=execution_id,json=executionId,proto3" json:"execution_id,omitempty"`  // AgentExecution ID — used by Python for thought signature cache key
-	ClearCache    bool                   `protobuf:"varint,6,opt,name=clear_cache,json=clearCache,proto3" json:"clear_cache,omitempty"`    // Signal to clear provider content cache (e.g., on fallback provider switch)
-	PromptCache   bool                   `protobuf:"varint,7,opt,name=prompt_cache,json=promptCache,proto3" json:"prompt_cache,omitempty"` // Claude cache_control / OpenAI 5.6+ breakpoints; Go ANDs the cluster toggle
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state            protoimpl.MessageState `protogen:"open.v1"`
+	SessionId        string                 `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`                         // For logging/tracing
+	Messages         []*ConversationMessage `protobuf:"bytes,2,rep,name=messages,proto3" json:"messages,omitempty"`                                            // Full conversation history
+	LlmConfig        *LLMConfig             `protobuf:"bytes,3,opt,name=llm_config,json=llmConfig,proto3" json:"llm_config,omitempty"`                         // Provider configuration
+	Tools            []*ToolDefinition      `protobuf:"bytes,4,rep,name=tools,proto3" json:"tools,omitempty"`                                                  // Available tools (empty = no tools)
+	ExecutionId      string                 `protobuf:"bytes,5,opt,name=execution_id,json=executionId,proto3" json:"execution_id,omitempty"`                   // AgentExecution ID — used by Python for thought signature cache key
+	ClearCache       bool                   `protobuf:"varint,6,opt,name=clear_cache,json=clearCache,proto3" json:"clear_cache,omitempty"`                     // Signal to clear provider content cache (e.g., on fallback provider switch)
+	PromptCache      bool                   `protobuf:"varint,7,opt,name=prompt_cache,json=promptCache,proto3" json:"prompt_cache,omitempty"`                  // Claude cache_control / OpenAI 5.6+ breakpoints; Go ANDs the cluster toggle
+	DisableToolCalls bool                   `protobuf:"varint,8,opt,name=disable_tool_calls,json=disableToolCalls,proto3" json:"disable_tool_calls,omitempty"` // Keep tool schemas but forbid calling (forced conclusion)
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *GenerateRequest) Reset() {
@@ -111,6 +112,13 @@ func (x *GenerateRequest) GetClearCache() bool {
 func (x *GenerateRequest) GetPromptCache() bool {
 	if x != nil {
 		return x.PromptCache
+	}
+	return false
+}
+
+func (x *GenerateRequest) GetDisableToolCalls() bool {
+	if x != nil {
+		return x.DisableToolCalls
 	}
 	return false
 }
@@ -1181,7 +1189,7 @@ var File_proto_llm_service_proto protoreflect.FileDescriptor
 
 const file_proto_llm_service_proto_rawDesc = "" +
 	"\n" +
-	"\x17proto/llm_service.proto\x12\x06llm.v1\"\xb0\x02\n" +
+	"\x17proto/llm_service.proto\x12\x06llm.v1\"\xde\x02\n" +
 	"\x0fGenerateRequest\x12\x1d\n" +
 	"\n" +
 	"session_id\x18\x01 \x01(\tR\tsessionId\x127\n" +
@@ -1192,7 +1200,8 @@ const file_proto_llm_service_proto_rawDesc = "" +
 	"\fexecution_id\x18\x05 \x01(\tR\vexecutionId\x12\x1f\n" +
 	"\vclear_cache\x18\x06 \x01(\bR\n" +
 	"clearCache\x12!\n" +
-	"\fprompt_cache\x18\a \x01(\bR\vpromptCache\"\x9f\x03\n" +
+	"\fprompt_cache\x18\a \x01(\bR\vpromptCache\x12,\n" +
+	"\x12disable_tool_calls\x18\b \x01(\bR\x10disableToolCalls\"\x9f\x03\n" +
 	"\x10GenerateResponse\x12'\n" +
 	"\x04text\x18\x01 \x01(\v2\x11.llm.v1.TextDeltaH\x00R\x04text\x123\n" +
 	"\bthinking\x18\x02 \x01(\v2\x15.llm.v1.ThinkingDeltaH\x00R\bthinking\x124\n" +

--- a/proto/llm_service.proto
+++ b/proto/llm_service.proto
@@ -25,6 +25,7 @@ message GenerateRequest {
   string execution_id = 5;                  // AgentExecution ID — used by Python for thought signature cache key
   bool clear_cache = 6;                     // Signal to clear provider content cache (e.g., on fallback provider switch)
   bool prompt_cache = 7;                    // Claude cache_control / OpenAI 5.6+ breakpoints; Go ANDs the cluster toggle
+  bool disable_tool_calls = 8;              // Keep tool schemas but forbid calling (forced conclusion)
 }
 
 // GenerateResponse is a streaming chunk from the LLM.

--- a/test/e2e/pipeline_test.go
+++ b/test/e2e/pipeline_test.go
@@ -130,7 +130,7 @@ func TestE2E_Pipeline(t *testing.T) {
 			&agent.UsageChunk{InputTokens: 80, OutputTokens: 20, TotalTokens: 100},
 		},
 	})
-	// Forced conclusion: called WITHOUT tools after max_iterations exhausted.
+	// Forced conclusion: same tools, calling disabled, after max_iterations exhausted.
 	llm.AddRouted("MetricsValidator", LLMScriptEntry{
 		Chunks: []agent.Chunk{
 			&agent.ThinkingChunk{Content: "SLO is being violated."},


### PR DESCRIPTION
- Send explicit mode with no breakpoints when GPT-5.6+ is ineligible, so one-shots do not pay a 1.25× implicit write
- Keep tools on forced conclusion and disable calling so the looping prefix can still cache-hit
- Stamp sticky OpenAI breakpoints on system, first user, and last tool result instead of a moving last-non-tool mark


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Forced conclusions retain available tool context while preventing tool invocation.
  * Eligible investigation forced-conclusion requests now support prompt caching.
  * AI requests can disable tool calls without removing tool definitions.
  * Google, OpenAI, and Anthropic integrations provide updated prompt-cache handling, including improved cache reuse and explicit cache-disable behavior.

* **Documentation**
  * Updated architecture, functional-area, and prompt-caching documentation to reflect forced-conclusion tool handling and cache eligibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->