### PR TITLE
fix(orchestrator): drop hardcoded 7m sub-agent timeout

### DIFF
--- a/deploy/config/tarsy.yaml.example
+++ b/deploy/config/tarsy.yaml.example
@@ -153,7 +153,7 @@ defaults:
   compose_provider: "google-default"
   
   # Default max iterations (forces conclusion when reached, no pause/resume)
-  max_iterations: 20
+  max_iterations: 40
   
   # Default LLM backend
   llm_backend: "langchain"
@@ -166,8 +166,8 @@ defaults:
   # Ignored when an agent has no resolved sub_agents.
   # orchestrator:
   #   max_concurrent_agents: 5
-  #   agent_timeout: 600s
-  #   max_budget: 30m
+  #   # agent_timeout omitted → remaining parent (session/chat) time
+  #   # agent_timeout: 20m     # optional dedicated cap, still clamped to parent
 
   # LLM provider fallback — ordered list of alternative providers to try when
   # the primary provider fails (after Python-level retries are exhausted).
@@ -639,11 +639,10 @@ agent_chains:
           - name: "KubernetesAgent"
             llm_provider: "gemini-3.1-pro"
             llm_backend: "google-native"
-            # Dispatch limits for sub-agents (optional — defaults applied if omitted)
+            # Dispatch limits for sub-agents (optional — omit agent_timeout to use remaining parent time)
             orchestrator:
               max_concurrent_agents: 5
-              agent_timeout: 420s
-              max_budget: 900s
+              # agent_timeout: 20m     # optional dedicated cap, still clamped to parent
             # Per-sub_agent ref: optional required_skills / skills merge with that agent definition for dispatch only
             # (parent stage required_skills do not apply to sub-agents).
             sub_agents:

--- a/docs/proposals/sub-agent-execution-limits-design.md
+++ b/docs/proposals/sub-agent-execution-limits-design.md
@@ -1,0 +1,311 @@
+# Sub-Agent Execution Limits
+
+**Status:** Final
+**Related:** [Questions document](sub-agent-execution-limits-questions.md)
+
+## Overview
+
+Sub-agents are full iterating agents (LLM loop + MCP tools + `max_iterations` → forced conclusion), but their lifetime is capped by `orchestrator.agent_timeout`, whose hardcoded default is **420s (7 minutes)**. That value is sized like one iteration (6m) plus one tool call (1m), not like an agent run.
+
+When YAML omits `agent_timeout`, the resolver still fills in 420s. A typical investigation cannot finish in 7 minutes, so the kill lands mid-gRPC `Generate` and the orchestrator sees:
+
+```text
+execution interrupted: LLM error: rpc error: code = DeadlineExceeded
+  desc = context deadline exceeded (code: , retryable: false)
+```
+
+`max_iterations` is resolved and honored by the iterating controller, but it never becomes the limiter: dozens of iterations cannot complete in 7 minutes. Forced conclusion only runs after the iteration loop ends; a mid-call deadline returns immediately with no wrap-up.
+
+This design treats sub-agents as agents for budget purposes:
+
+- Omitted `agent_timeout` means remaining **parent** (session/chat) time. No extra 7-minute hammer.
+- Optional YAML `agent_timeout` is a dedicated lower cap, always clamped to remaining parent.
+- Approaching a real deadline wraps up (same path as hitting `max_iterations`) instead of dying mid-thought.
+- Wrap-up applies to **all** iterating agents, not only sub-agents.
+- Built-in `DefaultMaxIterations` rises from 20 to 40. Unused `orchestrator.max_budget` is removed.
+
+## Design Principles
+
+1. **Sub-agents are agents, not fat tool calls.** They already run `IteratingController`. Outer time should not be “one iteration + one tool.”
+2. **`max_iterations` is the primary stop.** Hitting the limit still forces a conclusion. Time is a safety net, not the normal completion path.
+3. **Deadlines wrap up.** If remaining time is at or below the wrap-up reserve, stop iterating and force-conclude while a call can still finish. Hard-cancel mid-stream is last resort (operator cancel, deadline already expired, or wrap-up itself overruns).
+4. **Parent context still wins.** Session timeout (`queue.session_timeout`, default 40m) and chat (same parent in production) remain the hard outer bound. A sub-agent must never outlive its parent.
+5. **Surgical.** No new YAML keys. Per-ref `max_iterations` already exists. Per-ref wall-clock timeouts are out of scope. `max_budget` is removed, not implemented.
+6. **Clear causes.** Extra `agent_timeout` caps use `WithTimeoutCause` so the orchestrator sees “sub-agent timed out after …” rather than a raw gRPC deadline. Session timeout may still be a plain `DeadlineExceeded` (unchanged).
+7. **Product defaults, operator YAML.** Code defaults should be usable without a dedicated `orchestrator:` block. Deployments that want a tighter cap or fewer worker iterations set YAML themselves.
+
+## Decisions
+
+| Topic | Decision |
+|-------|----------|
+| Dedicated wall clock | Omitted `agent_timeout` → remaining parent. If set → `min(configured, remaining parent)`. Never fall back to 420s. |
+| Built-in `agent_timeout` default | None. Q2 skipped. |
+| Approaching deadline | Soft deadline: `wrapUpReserve = min(LLMCallTimeout, 3m)` (constant **3m**). Clamp each iteration so it cannot steal the reserve. Cancel stays fail-fast. |
+| Who wraps up | All iterating agents (investigation, action, chat, sub-agent). Not single-shot or scoring. |
+| Successful wrap-up status | `completed`, same as max-iterations. Metadata reason `max_iterations` vs `time_budget`. Label formatters and dashboard. Wrap-up LLM failure → `timed_out` + `context.Cause`. |
+| `max_iterations` hierarchy | Unchanged: `defaults → agent def → chain → empty stage → ref`. |
+| Sub-agent iteration default | No distinct default. Raise `DefaultMaxIterations` **20 → 40**. |
+| `max_budget` | Remove from config, API, tests, and ADR-0002 table. |
+
+## Architecture / How It Works
+
+### Current timeout stack
+
+```text
+Session / chat context          default 40m  (queue.session_timeout)
+  └─ agent_timeout              7m           ← binding constraint (hardcoded)
+       └─ IterationTimeout      6m
+            ├─ LLMCallTimeout   5m
+            └─ ToolCallTimeout  1m           (MCP tools inside the agent)
+```
+
+`dispatch_agent` is already async: it returns immediately. The 1m `ToolCallTimeout` wraps only the accept call, not the worker. The 7m timer is a second deadline applied in `SubAgentRunner.Dispatch`:
+
+```text
+subCtx, cancel := context.WithTimeout(parentCtx, guardrails.AgentTimeout)
+go runSubAgent(subCtx, ...)
+```
+
+`parentCtx` is the session/chat context. The extra cap is applied on top.
+
+`orchestrator.max_budget` (default 900s in the resolver) is stored on `OrchestratorGuardrails` and **never applied**. The system-config API only emits YAML fields, so omitted `max_budget` does not appear there; the dead default is the resolver. ADR-0002 documents `agent_timeout` default 300s; the code default is 420s. Both are wrong after this work.
+
+### Intended stack
+
+```text
+Session / chat context                         default 40m
+  └─ remaining parent                          (default)
+       or min(agent_timeout, remaining parent) (if YAML sets agent_timeout)
+            └─ IterationTimeout                clamped so wrap-up reserve survives
+                 ├─ LLMCallTimeout             5m
+                 └─ ToolCallTimeout            1m
+```
+
+`OrchestratorGuardrails.AgentTimeout == 0` means no extra cap. Resolver must not fill in 420s when YAML omits the field. Validator: omitted is valid; if set, must be positive (unchanged).
+
+When YAML sets a cap:
+
+```text
+timeout := min(configured, time.Until(parentDeadline))
+subCtx, cancel := context.WithTimeoutCause(parentCtx, timeout,
+    fmt.Errorf("sub-agent %s timed out after %s", name, timeout))
+```
+
+If the parent has no deadline, a configured `agent_timeout` still applies from dispatch start. If remaining parent is shorter than the configured cap, parent wins (never extend past the session/chat).
+
+`/api/system/config` already omits nil YAML pointers. After this work it also drops `max_budget`. Unset `agent_timeout` stays omitted (not `"0s"`).
+
+### Soft deadline (wrap-up)
+
+Constant (not YAML):
+
+```text
+wrapUpReserve = min(LLMCallTimeout, 3m)   # 3m with current 5m LLMCallTimeout
+```
+
+`remaining` is `time.Until(deadline)` when `ctx` has a deadline. **No deadline → no time wrap-up** (unit tests that pass `context.Background()` keep today’s loop).
+
+At the start of each loop iteration, in this order:
+
+1. If `ctx` is `Canceled` → fail-fast, no wrap-up (`cancelled`).
+2. If the parent deadline is already expired (`remaining <= 0`) → `timed_out`, no wrap-up (nothing left for a Generate).
+3. If `remaining <= wrapUpReserve` → `forceConclusion` with reason `time_budget`.
+4. If consecutive LLM/tool timeouts would otherwise abort (`ShouldAbortOnTimeouts`) **and** wrap-up is still possible (`remaining > 0`) → wrap up instead of returning `failed` from consecutive timeouts. Today’s abort remains only when there is still plenty of time (stuck provider, not a budget squeeze).
+5. Otherwise start the iteration with:
+
+```text
+iterTimeout = min(IterationTimeout, remaining - wrapUpReserve)
+```
+
+Tools already run under `iterCtx`, so clamping the iteration also clamps MCP calls.
+
+**`WaitForResult` must use the same clamp.** Today it waits on the parent `ctx`, so a pending-sub-agent wait can consume the wrap-up reserve. Bound that wait with `min(remaining - wrapUpReserve, …)` (or the iteration context). If the wait hits that bound and agents are still pending, treat it like “time to wrap up”: non-blocking drain, then `forceConclusion` with `time_budget`. Do **not** block wrap-up on pending workers — same as today’s max-iterations path.
+
+Wrap-up’s Generate uses leftover parent time, nested under `LLMCallTimeout` (the earlier deadline wins). If wrap-up overruns, return `timed_out` using `context.Cause(ctx)` when present, not the raw gRPC `DeadlineExceeded` string.
+
+A **child** `iterCtx`/`llmCtx` deadline while the parent still has reserve is not a session timeout. Do not return `execution interrupted` from `StatusFromContextErr(parent)`. Record the failure and continue the loop so the next start-of-iteration check can wrap up. Combined with step 4, two clamped timeouts near the reserve wrap up instead of `aborted after 2 consecutive timeouts`.
+
+Examples:
+
+- YAML `agent_timeout: 20m`, dispatched at session start → work **0–17m**, wrap-up **17–20m**.
+- No YAML cap, 40m session → wrap-up when **3m of session** remain.
+- 5m remaining parent, no YAML cap → wrap-up immediately (remaining ≤ reserve).
+- Parent deadline ≤ reserve at first iteration (e.g. 2s test session) → wrap-up immediately. If wrap-up’s LLM also blocks until cancel, status is `timed_out` (overrun).
+
+This lives in `IteratingController`, so investigation, action, chat, and sub-agent runs all wrap up. Single-shot stages (synthesis, executive summary, compose) and scoring are unchanged.
+
+**Later stages share leftover parent time.** Wrap-up is sized for one text-only Generate of the agent that is running, not for the rest of the chain. If the last iterating stage wraps up in the final 3m of the **session**, synthesis / compose / executive summary run on whatever is left (often little). Synthesis is fail-fast; compose and executive summary are fail-open. Sub-agent wrap-up against a dedicated `agent_timeout` does not have this problem: the orchestrator’s session budget is separate.
+
+### Max iterations
+
+`SubAgentRunner.Dispatch` already calls `ResolveAgentConfig` and passes `ref.MaxIterations`. The iterating controller already loops to `MaxIterations` then `forceConclusion`. That path works when time remains.
+
+Resolution stays:
+
+```text
+defaults → agent definition → chain → stage (always empty for sub-agents) → sub-agent ref
+```
+
+Chain-level `max_iterations` meant for the orchestrator still leaks to workers. Operators who want a different worker cap set it on the agent definition or the `sub_agents:` ref. No second resolution path.
+
+`DefaultMaxIterations` changes from 20 to 40. YAML `defaults.max_iterations: 40` is redundant but valid.
+
+### Forced-conclusion contract
+
+Successful wrap-up (iteration limit **or** time budget):
+
+| Surface | Behavior |
+|---------|----------|
+| Execution status | `completed` |
+| `ExecutionResult` | Carry wrap-up reason (`max_iterations` \| `time_budget`) so callers do not read the DB. Empty when the agent finished normally. |
+| `SubAgentResult` | Copy that reason. `FormatSubAgentResult` uses it. |
+| Timeline metadata | `forced_conclusion: true`, `iterations_used`, `max_iterations`, **`reason`**: `max_iterations` \| `time_budget` |
+| Forced-conclusion prompt | Iteration-limit wording today; time-budget wording when reason is `time_budget`. `PromptBuilder` gains a reason (interface + mocks). |
+| Investigation formatter (synthesis / exec summary / scoring) | Read `final_analysis` event metadata; e.g. `**Final Analysis (forced conclusion — time budget):**` |
+| Orchestrator injection (`FormatSubAgentResult`) | Mention wrap-up, e.g. `[Sub-agent completed — forced conclusion (time budget)]` |
+| Dashboard | Generic “forced conclusion”, not hardcoded “Max Iterations” |
+
+Wrap-up LLM **failure** (including overrun):
+
+- Status `timed_out`
+- Error from `context.Cause` when the context deadline fired
+- Orchestrator injects `Error` (existing non-`completed` path)
+
+Operator cancel stays fail-fast: `cancelled`, no wrap-up.
+
+### Error path (today vs proposed)
+
+Today, deadline during `Generate`:
+
+1. gRPC `Recv` returns `DeadlineExceeded`
+2. `ErrorChunk{Message: err.Error(), Code: ""}`  ← empty code, `retryable: false`
+3. Iterating controller sees `ctx.Err()` and returns immediately: `execution interrupted: LLM error: rpc error: …`
+4. Orchestrator injects `[Sub-agent timed_out] …: execution interrupted: LLM error: …`
+5. No forced conclusion, no partial report
+
+Proposed:
+
+1. Optional extra cap uses `context.WithTimeoutCause`
+2. Approaching deadline → force-conclude with reason `time_budget`
+3. If the **parent** context still dies mid-call, `context.Cause(ctx)` is the timeout message; do not surface the raw gRPC string as the primary error
+4. If only a **child** iteration/LLM context died, continue the loop (see Soft deadline)
+
+### `max_budget`
+
+Remove `MaxBudget` from `OrchestratorConfig`, `OrchestratorGuardrails`, the resolver, the validator, `/api/system/config`, tests, example YAML, and the ADR-0002 guardrail table. YAML that still sets `max_budget` is ignored by `yaml.Unmarshal` (unknown field; this repo does not use `KnownFields`). Do not implement a third nested clock.
+
+### Out of scope
+
+- Per-sub-agent-ref wall-clock timeout. One optional orchestrator-level `agent_timeout` is enough; per-ref `max_iterations` already exists.
+- Changing hardcoded `ToolCallTimeout` (1m). Some MCP servers use a longer HTTP timeout; that mismatch is separate from the 7-minute agent kill.
+- Skipping `ToolCallTimeout` on `dispatch_agent` (already returns in milliseconds).
+- Nesting (depth remains 1).
+- Adding `WithTimeoutCause` to the session/chat parent itself.
+
+## Core Concepts
+
+| Concept | Role |
+|---------|------|
+| Parent context | Session or chat timeout. Always the hard ceiling. |
+| `agent_timeout` | Optional extra per-sub-agent wall clock from dispatch start. Omitted → remaining parent. If set → `min(configured, remaining parent)`. |
+| `max_iterations` | Primary stop. Loop ends → `forceConclusion` (tools bound, calling disabled). Built-in default 40. |
+| Per-call timeouts | Unchanged: 6m iteration / 5m LLM / 1m MCP tool, except the iteration (and pending-result wait) is clamped so the wrap-up reserve survives. |
+| Wrap-up reserve | Constant `min(LLMCallTimeout, 3m)`. Remaining ≤ reserve → force-conclude with reason `time_budget`. No parent deadline → no time wrap-up. |
+| Forced-conclusion reason | `max_iterations` or `time_budget`. Status stays `completed` when wrap-up succeeds. Carried on the result struct, timeline metadata, formatters, and dashboard. |
+
+### Config surface
+
+No new keys. `max_budget` is deleted. `agent_timeout` stays optional.
+
+```yaml
+defaults:
+  max_iterations: 40          # also the new built-in default
+  orchestrator:
+    max_concurrent_agents: 5
+    # agent_timeout omitted → remaining parent (session/chat) time
+    # agent_timeout: 20m     # optional dedicated cap, still clamped to parent
+
+agents:
+  KubernetesAgent:
+    description: "Kubernetes troubleshooting agent"
+    mcp_servers: [kubernetes-server]
+
+agent_chains:
+  kubernetes-investigation-orchestrated:
+    stages:
+      - name: investigation
+        agents:
+          - name: KubernetesAgent
+            sub_agents:
+              - name: KubernetesAgent
+                max_iterations: 12    # already supported; optional per-ref override
+              - name: GeneralWorker
+                max_iterations: 5
+```
+
+### Chat
+
+Chat uses the same `SubAgentRunner`. In production, `cmd/tarsy` sets `ChatMessageExecutorConfig.SessionTimeout` to `queue.session_timeout` (default 40m). Tests may use a shorter chat timeout. Runner and controller changes apply to both paths. `min(agent_timeout, remaining parent)` still holds.
+
+## Implementation Plan
+
+Split so each PR leaves the product working.
+
+### PR 1 — Outer budget, defaults, and config honesty - DONE
+
+**Lands:**
+
+- `SubAgentRunner.Dispatch`: if `AgentTimeout == 0`, use `parentCtx` as-is. If set, `min(configured, remaining parent)` and `context.WithTimeoutCause`. Never apply a hardcoded 420s.
+- Resolver: omit `agent_timeout` → `AgentTimeout` stays 0. Do not fill a default duration.
+- Remove `MaxBudget` from config structs, resolver, validator, system-config API, and tests.
+- Raise `DefaultMaxIterations` from 20 to 40; update tests that assert the constant (controller test helpers that hardcode 20 may stay — they are local fixtures).
+- `deploy/config/tarsy.yaml.example`: drop `max_budget`, stop advertising a 420s/600s `agent_timeout` default, note omit = parent remaining, `max_iterations` default 40.
+
+**Where:** Orchestrator runner, orchestrator guardrails, config resolver/validator, system-config API, example YAML comments.
+
+**Tests in this PR:**
+
+- Dispatch with no `agent_timeout` does not add a shorter deadline than the parent.
+- Dispatch with a short `agent_timeout` still times out; cause string is inspectable.
+- When parent deadline is sooner than `agent_timeout`, parent wins.
+- Existing `TestSubAgentRunner_Dispatch_Timeout` updated for cause and for “omit means parent.”
+- Guardrail / system-config tests no longer expect `max_budget`.
+- Resolver tests for `DefaultMaxIterations == 40`.
+
+**Gap:** Wrap-up not yet implemented — a deadline mid-LLM still looks like a gRPC error until PR 2. Unconfigured deploys already stop dying at 7:00.
+
+### PR 2 — Soft-deadline wrap-up and labeling
+
+**Lands:**
+
+- Iterating controller: wrap-up reserve, iteration clamp, `WaitForResult` clamp, wrap-up **before** consecutive-timeout abort, `forceConclusion` with reason `time_budget` vs `max_iterations`.
+- `ExecutionResult` + `SubAgentResult` carry the reason; `FormatSubAgentResult` uses it.
+- Cancel / expired deadline skip wrap-up.
+- Forced-conclusion prompt distinguishes time budget from iteration limit (`PromptBuilder` interface + mocks).
+- Timeline metadata includes `reason`.
+- Investigation formatter labels forced conclusions from event metadata.
+- Dashboard: generic “forced conclusion” (not hardcoded “Max Iterations”).
+- Mid-call **parent** timeout errors prefer `context.Cause`.
+
+**Where:** Iterating controller, prompt builder, investigation formatter, orchestrator result types/formatting, dashboard `finalAnalysisPresentation` (no test file today — add one).
+
+**Tests in this PR:**
+
+- Unit tests: no deadline → no time wrap-up; remaining ≤ reserve invokes wrap-up; remaining ≤ 0 does not call the LLM; iteration clamp leaves reserve; `WaitForResult` cannot eat the reserve; cancel does not wrap up; wrap-up overrun → `timed_out`; consecutive child timeouts near the reserve wrap up instead of `failed`.
+- Existing max-iterations forced-conclusion tests still pass and gain `reason: max_iterations`.
+- Formatter / `FormatSubAgentResult` tests for wrap-up labels.
+- Dashboard presentation unit tests for generic copy.
+- E2E: `test/e2e/timeout_test.go` uses a 2s session and `BlockUntilCancelled`. First iteration will take the wrap-up path (2s ≤ 3m). If the LLM still blocks until cancel, terminal status can remain `timed_out` (overrun); update assertions if they require an iteration-path event. Other short-timeout e2e/chat tests similarly. Prefer extending that scenario over a new harness. If a dedicated “wrap-up succeeded” e2e is awkward (needs parent > 3m plus a forced squeeze), say so in the PR and rely on unit tests.
+
+**Gap:** None vs the decided contract if the unit tests above land. If a success-path e2e is deferred, unit tests still lock the controller behavior.
+
+### PR 3 — Docs
+
+**Lands:** Update ADR-0002 guardrail table (stale 300s `agent_timeout` and unused `max_budget`), ADR-0015 example YAML if it still lists a 300s default as if required, `docs/architecture-overview.md` (`max_iterations` default 20, `max_budget` mention). State the decided contract; do not copy this proposal verbatim. Example YAML comments already landed in PR 1.
+
+**Tests:** None.
+
+## References
+
+- [ADR-0002: Orchestrator Agent](../adr/0002-orchestrator-impl.md) — guardrails, session-derived sub-agent context
+- [ADR-0015: Implicit Orchestrator](../adr/0015-implicit-orchestrator.md) — orchestration as a capability; `orchestrator:` on any agent

--- a/docs/proposals/sub-agent-execution-limits-questions.md
+++ b/docs/proposals/sub-agent-execution-limits-questions.md
@@ -1,0 +1,155 @@
+# Sub-Agent Execution Limits — Design Questions
+
+**Status:** Closed — all questions decided
+**Related:** [Design document](sub-agent-execution-limits-design.md)
+
+---
+
+## Q1: Should sub-agents have a dedicated wall-clock shorter than the parent session/chat context?
+
+Today every sub-agent gets `context.WithTimeout(parentCtx, 420s)` on top of the session (or chat) context. That extra cap is what kills long-running workers at exactly 7:00. Dispatch is already async; this timer is not the MCP tool timeout.
+
+Dropping the extra cap means a sub-agent can run until the parent expires, bounded by `max_iterations` and per-call timeouts (6m / 5m / 1m). Keeping a cap preserves a runaway-worker guard independent of session length.
+
+### Option A: Parent context only (no extra cap unless configured)
+
+- **Pro:** Sub-agents are timed like stage agents. `max_iterations` becomes the real stop. Matches “treat them as agents, not tool calls.”
+- **Pro:** Simplest: `subCtx = parentCtx` (or `WithTimeout` only when YAML sets `agent_timeout`).
+- **Pro:** No new magic-number default. Unconfigured deploys stop dying at 7:00.
+- **Con:** A stuck sub-agent can consume the rest of the session and block the orchestrator’s wait-for-pending path.
+- **Con:** Concurrent workers (`max_concurrent_agents`) can run that long in parallel — LLM cost, not extra wall clock.
+
+**Semantics:**
+- Omitted `agent_timeout` → no extra timer; use remaining parent (session/chat) time.
+- Set in YAML (`defaults.orchestrator.agent_timeout`, optional per-agent `orchestrator:` override) → `min(configured, remaining parent)`. Never outlive the session.
+- Unset must **not** fall back to hardcoded 420s (today’s bug).
+
+**Decision:** Option A — remaining parent timeout by default; admins may set a dedicated lower `agent_timeout` globally (and per-agent if they want). Always clamp to remaining parent when set.
+
+_Considered and rejected: Option B (always-on dedicated cap with a new built-in default — extra magic number, still two clocks to reason about), Option C (keep 7m — does not fix the incident)._
+
+---
+
+## Q2: If a dedicated cap remains, what should the default `agent_timeout` be?
+
+**Skipped** — Q1 Option A has no extra built-in default. Omitted `agent_timeout` means parent context. There is nothing to pick (15m / 20m / 7m). Deployments that want a lower cap set it in YAML.
+
+---
+
+## Q3: What should happen when the sub-agent deadline approaches?
+
+Today the iterating loop returns immediately on `ctx` deadline: no forced conclusion, error wrapped as an LLM gRPC failure. `max_iterations` wrap-up never runs.
+
+A remaining-time check **only between iterations** is not enough: an iteration can start with just over the reserve left, run up to `IterationTimeout` (6m), and eat the wrap-up window.
+
+### Option B: Soft deadline — reserved slice + iteration clamp
+
+`wrapUpReserve = min(LLMCallTimeout, 3m)` (default: **3m**). Wrap-up is one text-only Generate; it does not need the full 5m iterating LLM budget.
+
+- Before a normal iteration: if remaining ≤ reserve → force-conclude now.
+- Clamp that iteration to `min(IterationTimeout, remaining - reserve)` so in-flight work cannot steal the reserve.
+- Wrap-up’s Generate uses whatever is left (capped by `LLMCallTimeout`).
+- If wrap-up overruns → hard-cancel with `context.Cause`, not a raw gRPC string.
+- Operator **cancel** (`Canceled`) stays fail-fast — no wrap-up.
+
+Example: 20m `agent_timeout`, dispatched at session start → work **0–17m**, wrap-up **17–20m**. No YAML cap → wrap-up when **3m of parent** remain.
+
+- **Pro:** Same wrap-up path as hitting `max_iterations`. Orchestrator (or stage) gets a report.
+- **Pro:** Predictable last-N-minutes window; in-flight iteration cannot consume it.
+- **Con:** 3m may be tight for a huge-context “write the full report” call.
+- **Con:** If wrap-up still overruns, hard-cancel.
+
+**Decision:** Option B — reserved slice of `min(LLMCallTimeout, 3m)`, iteration clamp, cancel stays fail-fast. 3m is a constant, not YAML.
+
+_Considered and rejected: Option A (hard-cancel — discards findings, today’s incident), Option C (return last assistant text — last turn is often a tool call, not a report)._
+
+---
+
+## Q4: Should soft-deadline wrap-up apply only to sub-agents, or to every iterating agent?
+
+The natural implementation is in `IteratingController`. That fires for stage agents near session timeout too.
+
+### Option B: All iterating agents (deadline only, not cancel)
+
+- **Pro:** One helper, no `SubAgent != nil` branch. Session timeout and optional `agent_timeout` wrap up the same way.
+- **Pro:** Regular agents hitting session timeout get a conclusion instead of a gRPC error.
+- **Con:** Stage agents start wrapping up ~3m before session timeout (slightly earlier stop than today).
+
+Not applied to: single-shot (synthesis, exec summary, compose — already one LLM call), scoring (separate timeout after the session).
+
+**Decision:** Option B — every iterating agent (investigation, action, chat, sub-agent). Cancel remains fail-fast. Single-shot and scoring unchanged.
+
+_Considered and rejected: Option A (sub-agents only — special-cases the shared loop; stage agents still die mid-LLM at session timeout)._
+
+---
+
+## Q5: If wrap-up succeeds, what execution status should the sub-agent report?
+
+`FormatSubAgentResult` injects `Result` only when status is `completed`; otherwise it injects `Error`. Max-iterations wrap-up today returns `completed`.
+
+Timeline events already carry `forced_conclusion: true` (plus `iterations_used` / `max_iterations`). The dashboard shows `CONCLUSION (⚠️Max Iterations)`. Downstream LLMs (synthesis, exec summary, scoring, orchestrator injection) currently get **analysis text only** — they do not read that metadata.
+
+### Option A: `completed` + surface wrap-up in downstream context
+
+- Status stays `completed` (same as max-iterations wrap-up). Orchestrator and parallel-stage success policy treat it as a finished analysis.
+- Metadata keeps `forced_conclusion: true` and adds a **reason** (`max_iterations` vs `time_budget`).
+- Formatters that feed later LLMs label it, e.g. `**Final Analysis (forced conclusion — time budget):**`, and orchestrator injection mentions wrap-up. Scoring/synthesis/exec summary can discount a rushed report.
+- Dashboard label becomes generic “forced conclusion”, not hardcoded “Max Iterations”.
+- If wrap-up’s LLM call **fails**, status is `timed_out` with `context.Cause`.
+
+- **Pro:** Reuses the existing forced-conclusion contract; later LLMs actually see the signal (they do not today).
+- **Pro:** Does not mark a useful report as a failed sub-agent.
+- **Con:** Formatters and dashboard copy need a small update.
+
+**Decision:** Option A — `completed` plus explicit wrap-up labeling in timeline context, orchestrator injection, and dashboard. Reason in metadata (`max_iterations` vs `time_budget`). Wrap-up LLM failure stays `timed_out`.
+
+_Considered and rejected: Option B (`timed_out` with Result — fights success policy; orchestrator treats a real report as failure), Option C (prefix only on sub-agent injection — misses synthesis/scoring/exec summary)._
+
+---
+
+## Q6: How should `max_iterations` resolve for sub-agents?
+
+Today: `defaults → agent def → chain → empty stage → ref`. If a chain later sets `max_iterations` for the orchestrator, workers inherit it because `Dispatch` passes the parent chain and an empty stage.
+
+### Option A: Keep the current hierarchy
+
+- **Pro:** No code change. Per-ref override already works (`max_iterations` on `sub_agents:` entries).
+- **Con:** Chain-level `max_iterations` meant for the orchestrator leaks to workers.
+
+**Decision:** Option A — keep `defaults → agent def → chain → stage (empty) → ref`. Per-ref/per-agent YAML remains the way to give workers a different cap.
+
+_Considered and rejected: Option B (skip chain/stage — extra resolution path for a leak operators can already override per ref), Option C (apply orchestrator stage max_iterations to workers)._
+
+---
+
+## Q7: Should sub-agents have a distinct built-in `max_iterations` default (lower than 20/40)?
+
+Code `DefaultMaxIterations` is 20. Focused workers (a single lookup, a narrow cluster check) rarely need 40 turns. A new default would affect every deployment.
+
+### Option A: No new sub-agent default — raise the global code default to 40
+
+Same hierarchy as today (Q6). No second implicit number for workers. Raise TARSy `DefaultMaxIterations` from **20 → 40** so unconfigured deploys can finish a realistic iterating investigation. Per-ref/per-agent YAML still lowers a worker if needed. Time wrap-up (Q3) still stops a runaway loop.
+
+- **Pro:** One default everywhere; YAML `defaults.max_iterations: 40` becomes redundant but harmless.
+- **Con:** Deployments that relied on the code default of 20 get more iterations (capped by time wrap-up / session timeout).
+
+**Decision:** Option A — no distinct sub-agent default. Change TARSy `DefaultMaxIterations` from 20 to 40.
+
+_Considered and rejected: Option B (built-in sub-agent default of ~10 — extra magic number; a focused lookup and a full investigation would share it unless every ref overrides)._
+
+---
+
+## Q8: What should we do with unused `orchestrator.max_budget`?
+
+It is validated, merged, shown in system config, default 900s, and never read by the runner. ADR-0002 says it is “total orchestrator budget.”
+
+### Option B: Remove it (config, API view, tests, ADR)
+
+Drop `MaxBudget` from `OrchestratorConfig`, guardrails, `/api/system/config`, tests, example YAML, and the ADR-0002 guardrail table. Existing YAML that still sets `max_budget` is ignored by normal YAML unmarshal (unknown field). No third nested clock.
+
+- **Pro:** Honest config surface; no dead knob next to the real `agent_timeout`.
+- **Con:** Docs/examples that mentioned `max_budget` need a pass. Anyone who set it in YAML keeps a no-op key until they delete it.
+
+**Decision:** Option B — remove `max_budget`. Do not implement it in this work.
+
+_Considered and rejected: Option A (leave unused — keeps lying in API/docs), Option C (implement as orchestrator wall clock — three nested deadlines, easy to recreate a short hammer)._

--- a/pkg/agent/config_resolver.go
+++ b/pkg/agent/config_resolver.go
@@ -10,7 +10,7 @@ import (
 	"github.com/codeready-toolchain/tarsy/pkg/config"
 )
 
-const DefaultMaxIterations = 20
+const DefaultMaxIterations = 40
 
 // DefaultLLMBackend is the fallback when no level in the config hierarchy
 // specifies an LLM backend. LangChain is the general-purpose multi-provider

--- a/pkg/agent/config_resolver_test.go
+++ b/pkg/agent/config_resolver_test.go
@@ -142,6 +142,26 @@ func TestResolveAgentConfig(t *testing.T) {
 		assert.Equal(t, config.AgentTypeAction, resolved.Type)
 	})
 
+	t.Run("falls back to DefaultMaxIterations when no level sets max_iterations", func(t *testing.T) {
+		noIterCfg := &config.Config{
+			Defaults: &config.Defaults{
+				LLMProvider: "google-default",
+			},
+			AgentRegistry: config.NewAgentRegistry(map[string]*config.AgentConfig{
+				"PlainAgent": {},
+			}),
+			LLMProviderRegistry: cfg.LLMProviderRegistry,
+		}
+		chain := &config.ChainConfig{}
+		stageConfig := config.StageConfig{}
+		agentConfig := config.StageAgentConfig{Name: "PlainAgent"}
+
+		resolved, err := ResolveAgentConfig(noIterCfg, chain, stageConfig, agentConfig)
+		require.NoError(t, err)
+		assert.Equal(t, DefaultMaxIterations, resolved.MaxIterations)
+		assert.Equal(t, 40, resolved.MaxIterations)
+	})
+
 	t.Run("falls back to DefaultLLMBackend when no level sets backend", func(t *testing.T) {
 		noBackendCfg := &config.Config{
 			Defaults: &config.Defaults{

--- a/pkg/agent/orchestrator/runner.go
+++ b/pkg/agent/orchestrator/runner.go
@@ -210,7 +210,7 @@ func (r *SubAgentRunner) Dispatch(ctx context.Context, name, task string) (strin
 		}
 	}
 
-	subCtx, cancel := context.WithTimeout(r.parentCtx, r.guardrails.AgentTimeout)
+	subCtx, cancel := subAgentContext(r.parentCtx, r.guardrails.AgentTimeout, name)
 
 	subExec := &subAgentExecution{
 		executionID: executionID,
@@ -546,6 +546,23 @@ func mapToEntStatus(status agent.ExecutionStatus) agentexecution.Status {
 	default:
 		return agentexecution.StatusFailed
 	}
+}
+
+// subAgentContext derives the context for a dispatched sub-agent.
+// timeout == 0 means no extra cap (remaining parent time). A configured cap
+// applies only when it is strictly shorter than remaining parent; otherwise
+// the parent deadline wins and session timeout stays a plain DeadlineExceeded.
+func subAgentContext(parent context.Context, timeout time.Duration, name string) (context.Context, context.CancelFunc) {
+	if timeout <= 0 {
+		return context.WithCancel(parent)
+	}
+	if deadline, ok := parent.Deadline(); ok {
+		if time.Until(deadline) <= timeout {
+			return context.WithCancel(parent)
+		}
+	}
+	return context.WithTimeoutCause(parent, timeout,
+		fmt.Errorf("sub-agent %s timed out after %s", name, timeout))
 }
 
 func subAgentDefaultSummarization(cfg *config.Config) *config.SummarizationConfig {

--- a/pkg/agent/orchestrator/runner_test.go
+++ b/pkg/agent/orchestrator/runner_test.go
@@ -186,7 +186,7 @@ func TestSubAgentRunner_OverridesMap(t *testing.T) {
 		runner := NewSubAgentRunner(
 			context.Background(), &SubAgentDeps{},
 			"parent", "sess", "stg", registry,
-			&OrchestratorGuardrails{MaxConcurrentAgents: 5, AgentTimeout: time.Minute, MaxBudget: time.Minute},
+			&OrchestratorGuardrails{MaxConcurrentAgents: 5, AgentTimeout: time.Minute},
 			nil,
 		)
 		assert.Empty(t, runner.overrides)
@@ -200,7 +200,7 @@ func TestSubAgentRunner_OverridesMap(t *testing.T) {
 		runner := NewSubAgentRunner(
 			context.Background(), &SubAgentDeps{},
 			"parent", "sess", "stg", registry,
-			&OrchestratorGuardrails{MaxConcurrentAgents: 5, AgentTimeout: time.Minute, MaxBudget: time.Minute},
+			&OrchestratorGuardrails{MaxConcurrentAgents: 5, AgentTimeout: time.Minute},
 			refs,
 		)
 		require.Len(t, runner.overrides, 2)
@@ -214,7 +214,7 @@ func TestSubAgentRunner_OverridesMap(t *testing.T) {
 		runner := NewSubAgentRunner(
 			context.Background(), &SubAgentDeps{},
 			"parent", "sess", "stg", registry,
-			&OrchestratorGuardrails{MaxConcurrentAgents: 5, AgentTimeout: time.Minute, MaxBudget: time.Minute},
+			&OrchestratorGuardrails{MaxConcurrentAgents: 5, AgentTimeout: time.Minute},
 			nil,
 		)
 		ref := runner.overrides["NonExistent"]
@@ -284,10 +284,127 @@ func TestSubAgentRunner_Dispatch_AgentError(t *testing.T) {
 	assert.Contains(t, result.Error, "infrastructure failure")
 }
 
+func TestSubAgentContext(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no extra cap inherits parent deadline", func(t *testing.T) {
+		t.Parallel()
+		parent, cancel := context.WithTimeout(t.Context(), time.Minute)
+		t.Cleanup(cancel)
+		parentDeadline, ok := parent.Deadline()
+		require.True(t, ok)
+
+		child, childCancel := subAgentContext(parent, 0, "Worker")
+		t.Cleanup(childCancel)
+
+		childDeadline, ok := child.Deadline()
+		require.True(t, ok)
+		assert.Equal(t, parentDeadline, childDeadline)
+	})
+
+	t.Run("no extra cap and no parent deadline has no deadline", func(t *testing.T) {
+		t.Parallel()
+		child, cancel := subAgentContext(t.Context(), 0, "Worker")
+		t.Cleanup(cancel)
+
+		_, ok := child.Deadline()
+		assert.False(t, ok)
+	})
+
+	t.Run("short cap without parent deadline times out with cause", func(t *testing.T) {
+		t.Parallel()
+		child, cancel := subAgentContext(t.Context(), 20*time.Millisecond, "Worker")
+		t.Cleanup(cancel)
+
+		select {
+		case <-child.Done():
+		case <-time.After(time.Second):
+			t.Fatal("child context did not time out")
+		}
+		assert.ErrorIs(t, child.Err(), context.DeadlineExceeded)
+		assert.Equal(t, "sub-agent Worker timed out after 20ms", context.Cause(child).Error())
+	})
+
+	t.Run("parent sooner than cap wins without sub-agent cause", func(t *testing.T) {
+		t.Parallel()
+		parent, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
+		t.Cleanup(cancel)
+		parentDeadline, ok := parent.Deadline()
+		require.True(t, ok)
+
+		child, childCancel := subAgentContext(parent, time.Hour, "Worker")
+		t.Cleanup(childCancel)
+
+		childDeadline, ok := child.Deadline()
+		require.True(t, ok)
+		assert.Equal(t, parentDeadline, childDeadline)
+
+		select {
+		case <-child.Done():
+		case <-time.After(time.Second):
+			t.Fatal("child context did not inherit parent timeout")
+		}
+		assert.ErrorIs(t, child.Err(), context.DeadlineExceeded)
+		assert.Equal(t, context.DeadlineExceeded, context.Cause(child))
+	})
+
+	t.Run("expired parent is inherited not wrapped", func(t *testing.T) {
+		t.Parallel()
+		parent, cancel := context.WithTimeout(t.Context(), time.Nanosecond)
+		t.Cleanup(cancel)
+		<-parent.Done()
+
+		child, childCancel := subAgentContext(parent, time.Hour, "Worker")
+		t.Cleanup(childCancel)
+
+		require.Error(t, child.Err())
+		assert.Equal(t, context.Cause(parent), context.Cause(child))
+		assert.NotEqual(t, "sub-agent Worker timed out after 1h0m0s", context.Cause(child).Error())
+	})
+
+	t.Run("cap shorter than remaining parent applies extra timeout with cause", func(t *testing.T) {
+		t.Parallel()
+		parent, cancel := context.WithTimeout(t.Context(), time.Hour)
+		t.Cleanup(cancel)
+		parentDeadline, ok := parent.Deadline()
+		require.True(t, ok)
+
+		child, childCancel := subAgentContext(parent, 20*time.Millisecond, "Worker")
+		t.Cleanup(childCancel)
+
+		childDeadline, ok := child.Deadline()
+		require.True(t, ok)
+		assert.True(t, childDeadline.Before(parentDeadline))
+
+		select {
+		case <-child.Done():
+		case <-time.After(time.Second):
+			t.Fatal("child context did not time out")
+		}
+		assert.ErrorIs(t, child.Err(), context.DeadlineExceeded)
+		assert.Equal(t, "sub-agent Worker timed out after 20ms", context.Cause(child).Error())
+		assert.NoError(t, parent.Err())
+	})
+
+	t.Run("child cancel does not cancel parent", func(t *testing.T) {
+		t.Parallel()
+		parent, parentCancel := context.WithCancel(t.Context())
+		t.Cleanup(parentCancel)
+
+		child, childCancel := subAgentContext(parent, 0, "Worker")
+		childCancel()
+
+		assert.ErrorIs(t, child.Err(), context.Canceled)
+		assert.NoError(t, parent.Err())
+	})
+}
+
 func TestSubAgentRunner_Dispatch_Timeout(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
+	var cause atomic.Value
 	runner, cleanup := setupIntegrationRunner(t, func(runCtx context.Context) (*agent.ExecutionResult, error) {
-		<-runCtx.Done() // blocks until timeout
+		<-runCtx.Done()
+		cause.Store(context.Cause(runCtx))
 		return nil, runCtx.Err()
 	})
 	defer cleanup()
@@ -298,12 +415,68 @@ func TestSubAgentRunner_Dispatch_Timeout(t *testing.T) {
 
 	result, err := runner.WaitForNext(ctx)
 	require.NoError(t, err)
-	// The agent sees DeadlineExceeded and maps to TimedOut or Cancelled
-	assert.Contains(t, []agent.ExecutionStatus{
-		agent.ExecutionStatusTimedOut,
-		agent.ExecutionStatusCancelled,
-		agent.ExecutionStatusFailed,
-	}, result.Status)
+	assert.Equal(t, agent.ExecutionStatusTimedOut, result.Status)
+	gotCause, ok := cause.Load().(error)
+	require.True(t, ok)
+	assert.Equal(t, "sub-agent TestAgent timed out after 200ms", gotCause.Error())
+}
+
+func TestSubAgentRunner_Dispatch_NoExtraTimeoutInheritsParent(t *testing.T) {
+	parent, cancel := context.WithTimeout(t.Context(), time.Minute)
+	t.Cleanup(cancel)
+	parentDeadline, ok := parent.Deadline()
+	require.True(t, ok)
+
+	var gotDeadline atomic.Value
+	runner, cleanup := setupIntegrationRunner(t, func(runCtx context.Context) (*agent.ExecutionResult, error) {
+		if dl, ok := runCtx.Deadline(); ok {
+			gotDeadline.Store(dl)
+		}
+		return &agent.ExecutionResult{
+			Status:        agent.ExecutionStatusCompleted,
+			FinalAnalysis: "ok",
+		}, nil
+	})
+	defer cleanup()
+	runner.parentCtx = parent
+	runner.guardrails.AgentTimeout = 0
+
+	_, err := runner.Dispatch(t.Context(), "TestAgent", "task")
+	require.NoError(t, err)
+
+	result, err := runner.WaitForNext(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, agent.ExecutionStatusCompleted, result.Status)
+
+	got, ok := gotDeadline.Load().(time.Time)
+	require.True(t, ok, "sub-agent context should inherit the parent deadline")
+	assert.Equal(t, parentDeadline, got)
+}
+
+func TestSubAgentRunner_Dispatch_ParentDeadlineWins(t *testing.T) {
+	parent, cancel := context.WithTimeout(t.Context(), 200*time.Millisecond)
+	t.Cleanup(cancel)
+
+	var cause atomic.Value
+	runner, cleanup := setupIntegrationRunner(t, func(runCtx context.Context) (*agent.ExecutionResult, error) {
+		<-runCtx.Done()
+		cause.Store(context.Cause(runCtx))
+		return nil, runCtx.Err()
+	})
+	defer cleanup()
+	runner.parentCtx = parent
+	runner.guardrails.AgentTimeout = time.Hour
+
+	_, err := runner.Dispatch(t.Context(), "TestAgent", "slow task")
+	require.NoError(t, err)
+
+	result, err := runner.WaitForNext(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, agent.ExecutionStatusTimedOut, result.Status)
+
+	gotCause, ok := cause.Load().(error)
+	require.True(t, ok)
+	assert.Equal(t, context.DeadlineExceeded, gotCause)
 }
 
 func TestSubAgentRunner_Cancel_RunningAgent(t *testing.T) {
@@ -742,7 +915,6 @@ func newMinimalRunner(maxConcurrent int) *SubAgentRunner {
 		&OrchestratorGuardrails{
 			MaxConcurrentAgents: maxConcurrent,
 			AgentTimeout:        5 * time.Minute,
-			MaxBudget:           10 * time.Minute,
 		},
 		nil,
 	)
@@ -1013,7 +1185,6 @@ func setupIntegrationRunner(
 		&OrchestratorGuardrails{
 			MaxConcurrentAgents: 5,
 			AgentTimeout:        30 * time.Second,
-			MaxBudget:           60 * time.Second,
 		},
 		nil,
 	)

--- a/pkg/agent/orchestrator/types.go
+++ b/pkg/agent/orchestrator/types.go
@@ -53,8 +53,7 @@ type SubAgentDeps struct {
 // (defaults.orchestrator merged with per-agent orchestrator config).
 type OrchestratorGuardrails struct {
 	MaxConcurrentAgents int
-	AgentTimeout        time.Duration
-	MaxBudget           time.Duration
+	AgentTimeout        time.Duration // 0 = no extra cap; use remaining parent time
 }
 
 // SubAgentResult is the outcome of a completed sub-agent execution.

--- a/pkg/api/system_config.go
+++ b/pkg/api/system_config.go
@@ -73,7 +73,6 @@ type AgentView struct {
 type OrchestratorView struct {
 	MaxConcurrentAgents *int    `json:"max_concurrent_agents,omitempty"`
 	AgentTimeout        *string `json:"agent_timeout,omitempty"`
-	MaxBudget           *string `json:"max_budget,omitempty"`
 }
 
 // ChainView is the chain config view.
@@ -632,10 +631,6 @@ func buildOrchestratorView(o *config.OrchestratorConfig) *OrchestratorView {
 	if o.AgentTimeout != nil {
 		s := durationString(*o.AgentTimeout)
 		view.AgentTimeout = &s
-	}
-	if o.MaxBudget != nil {
-		s := durationString(*o.MaxBudget)
-		view.MaxBudget = &s
 	}
 	return view
 }

--- a/pkg/api/system_config_test.go
+++ b/pkg/api/system_config_test.go
@@ -429,7 +429,6 @@ func TestSystemConfigHandler(t *testing.T) {
 		maxIter := 10
 		maxConcurrent := 3
 		agentTimeout := 2 * time.Minute
-		maxBudget := 30 * time.Minute
 		emptySkills := []string{}
 
 		s := &Server{
@@ -456,7 +455,6 @@ func TestSystemConfigHandler(t *testing.T) {
 					Orchestrator: &config.OrchestratorConfig{
 						MaxConcurrentAgents: &maxConcurrent,
 						AgentTimeout:        &agentTimeout,
-						MaxBudget:           &maxBudget,
 					},
 				},
 				AgentRegistry: config.NewAgentRegistry(map[string]*config.AgentConfig{
@@ -532,8 +530,6 @@ func TestSystemConfigHandler(t *testing.T) {
 		require.NotNil(t, resp.Defaults.Orchestrator)
 		require.NotNil(t, resp.Defaults.Orchestrator.AgentTimeout)
 		assert.Equal(t, "2m", *resp.Defaults.Orchestrator.AgentTimeout)
-		require.NotNil(t, resp.Defaults.Orchestrator.MaxBudget)
-		assert.Equal(t, "30m", *resp.Defaults.Orchestrator.MaxBudget)
 
 		assert.Equal(t, []string{"alpha-chain", "zeta-chain"}, sortedKeys(resp.Chains))
 		alpha := resp.Chains["alpha-chain"]
@@ -641,6 +637,44 @@ func TestSanitizeURL(t *testing.T) {
 			assert.Equal(t, tt.want, sanitizeURL(tt.in))
 		})
 	}
+}
+
+func TestBuildOrchestratorView(t *testing.T) {
+	t.Parallel()
+
+	maxConcurrent := 5
+	timeout := 2 * time.Minute
+
+	t.Run("omits unset agent_timeout and has no max_budget", func(t *testing.T) {
+		t.Parallel()
+		view := buildOrchestratorView(&config.OrchestratorConfig{
+			MaxConcurrentAgents: &maxConcurrent,
+		})
+		require.NotNil(t, view)
+		assert.Equal(t, 5, *view.MaxConcurrentAgents)
+		assert.Nil(t, view.AgentTimeout)
+
+		raw, err := json.Marshal(view)
+		require.NoError(t, err)
+		assert.NotContains(t, string(raw), "agent_timeout")
+		assert.NotContains(t, string(raw), "max_budget")
+	})
+
+	t.Run("emits set agent_timeout", func(t *testing.T) {
+		t.Parallel()
+		view := buildOrchestratorView(&config.OrchestratorConfig{
+			MaxConcurrentAgents: &maxConcurrent,
+			AgentTimeout:        &timeout,
+		})
+		require.NotNil(t, view)
+		require.NotNil(t, view.AgentTimeout)
+		assert.Equal(t, "2m", *view.AgentTimeout)
+	})
+
+	t.Run("nil config yields nil view", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, buildOrchestratorView(nil))
+	})
 }
 
 func TestSystemConfigSkillHandler(t *testing.T) {

--- a/pkg/config/agent.go
+++ b/pkg/config/agent.go
@@ -55,7 +55,6 @@ type AgentConfig struct {
 type OrchestratorConfig struct {
 	MaxConcurrentAgents *int           `yaml:"max_concurrent_agents,omitempty"`
 	AgentTimeout        *time.Duration `yaml:"agent_timeout,omitempty"`
-	MaxBudget           *time.Duration `yaml:"max_budget,omitempty"`
 }
 
 // AgentRegistry stores agent configurations in memory with thread-safe access

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -168,7 +168,7 @@ defaults:
   orchestrator:
     max_concurrent_agents: 5
     agent_timeout: 5m
-    max_budget: 30m
+    max_budget: 30m  # unknown field; ignored by yaml.Unmarshal
 
 agents:
   worker-agent:
@@ -214,7 +214,6 @@ agent_chains:
 	require.NotNil(t, cfg.Defaults.Orchestrator)
 	assert.Equal(t, 5, *cfg.Defaults.Orchestrator.MaxConcurrentAgents)
 	assert.Equal(t, 5*time.Minute, *cfg.Defaults.Orchestrator.AgentTimeout)
-	assert.Equal(t, 30*time.Minute, *cfg.Defaults.Orchestrator.MaxBudget)
 
 	// Agent orchestrator config (orchestrator block is valid on any agent type)
 	orch := cfg.Agents["orch-agent"]
@@ -222,7 +221,6 @@ agent_chains:
 	require.NotNil(t, orch.Orchestrator)
 	assert.Equal(t, 3, *orch.Orchestrator.MaxConcurrentAgents)
 	assert.Equal(t, 2*time.Minute, *orch.Orchestrator.AgentTimeout)
-	assert.Nil(t, orch.Orchestrator.MaxBudget)
 
 	// Chain-level sub_agents
 	chain := cfg.AgentChains["test-chain"]

--- a/pkg/config/validator.go
+++ b/pkg/config/validator.go
@@ -884,9 +884,6 @@ func (v *Validator) validateOrchestratorConfig(oc *OrchestratorConfig, section, 
 	if oc.AgentTimeout != nil && *oc.AgentTimeout <= 0 {
 		return NewValidationError(section, name, "orchestrator.agent_timeout", fmt.Errorf("must be positive"))
 	}
-	if oc.MaxBudget != nil && *oc.MaxBudget <= 0 {
-		return NewValidationError(section, name, "orchestrator.max_budget", fmt.Errorf("must be positive"))
-	}
 	return nil
 }
 

--- a/pkg/config/validator_test.go
+++ b/pkg/config/validator_test.go
@@ -187,17 +187,6 @@ func TestValidateAgents(t *testing.T) {
 			errMsg:  "must be positive",
 		},
 		{
-			name: "orchestrator config with zero max_budget",
-			agents: map[string]*AgentConfig{
-				"orch": {
-					Orchestrator: &OrchestratorConfig{MaxBudget: durPtr(0)},
-				},
-			},
-			servers: map[string]*MCPServerConfig{},
-			wantErr: true,
-			errMsg:  "must be positive",
-		},
-		{
 			name: "action agent type is valid",
 			agents: map[string]*AgentConfig{
 				"remediation": {Type: AgentTypeAction},
@@ -3356,6 +3345,11 @@ func TestValidateOrchestratorDefaults(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name:    "omitted agent_timeout is valid",
+			orch:    &OrchestratorConfig{MaxConcurrentAgents: intPtr(5)},
+			wantErr: false,
+		},
+		{
 			name:    "zero max_concurrent_agents",
 			orch:    &OrchestratorConfig{MaxConcurrentAgents: intPtr(0)},
 			wantErr: true,
@@ -3364,12 +3358,6 @@ func TestValidateOrchestratorDefaults(t *testing.T) {
 		{
 			name:    "negative agent_timeout",
 			orch:    &OrchestratorConfig{AgentTimeout: durPtr(-5 * time.Second)},
-			wantErr: true,
-			errMsg:  "must be positive",
-		},
-		{
-			name:    "zero max_budget",
-			orch:    &OrchestratorConfig{MaxBudget: durPtr(0)},
 			wantErr: true,
 			errMsg:  "must be positive",
 		},

--- a/pkg/queue/executor_helpers.go
+++ b/pkg/queue/executor_helpers.go
@@ -484,20 +484,15 @@ func (e *RealSessionExecutor) resolvedSuccessPolicy(input executeStageInput) con
 // Orchestrator resolution
 // ────────────────────────────────────────────────────────────
 
-// resolveOrchestratorGuardrails merges hardcoded fallbacks < defaults.orchestrator < per-agent orchestrator config.
-// The config validator (pkg/config/validator.go) rejects invalid values at load
-// time, but we clamp here as defense-in-depth for programmatic construction.
+// resolveOrchestratorGuardrails merges built-in fallbacks < defaults.orchestrator < per-agent orchestrator config.
+// Omitted agent_timeout stays 0 (remaining parent time). The config validator
+// rejects invalid values at load time; MaxConcurrentAgents is still clamped
+// here as defense-in-depth for programmatic construction.
 func resolveOrchestratorGuardrails(cfg *config.Config, agentDef *config.AgentConfig) *orchestrator.OrchestratorGuardrails {
-	const (
-		defaultMaxConcurrent = 5
-		defaultAgentTimeout  = 420 * time.Second
-		defaultMaxBudget     = 900 * time.Second
-	)
+	const defaultMaxConcurrent = 5
 
 	g := &orchestrator.OrchestratorGuardrails{
 		MaxConcurrentAgents: defaultMaxConcurrent,
-		AgentTimeout:        defaultAgentTimeout,
-		MaxBudget:           defaultMaxBudget,
 	}
 	if cfg.Defaults != nil && cfg.Defaults.Orchestrator != nil {
 		applyOrchestratorConfig(g, cfg.Defaults.Orchestrator)
@@ -509,12 +504,6 @@ func resolveOrchestratorGuardrails(cfg *config.Config, agentDef *config.AgentCon
 	if g.MaxConcurrentAgents < 1 {
 		g.MaxConcurrentAgents = defaultMaxConcurrent
 	}
-	if g.AgentTimeout <= 0 {
-		g.AgentTimeout = defaultAgentTimeout
-	}
-	if g.MaxBudget <= 0 {
-		g.MaxBudget = defaultMaxBudget
-	}
 	return g
 }
 
@@ -524,9 +513,6 @@ func applyOrchestratorConfig(g *orchestrator.OrchestratorGuardrails, oc *config.
 	}
 	if oc.AgentTimeout != nil {
 		g.AgentTimeout = *oc.AgentTimeout
-	}
-	if oc.MaxBudget != nil {
-		g.MaxBudget = *oc.MaxBudget
 	}
 }
 

--- a/pkg/queue/executor_test.go
+++ b/pkg/queue/executor_test.go
@@ -683,8 +683,20 @@ func TestResolveOrchestratorGuardrails(t *testing.T) {
 			agentDef: &config.AgentConfig{},
 			want: &orchestrator.OrchestratorGuardrails{
 				MaxConcurrentAgents: 5,
-				AgentTimeout:        420 * time.Second,
-				MaxBudget:           900 * time.Second,
+			},
+		},
+		{
+			name: "defaults without agent_timeout leave timeout zero",
+			cfg: &config.Config{
+				Defaults: &config.Defaults{
+					Orchestrator: &config.OrchestratorConfig{
+						MaxConcurrentAgents: intPtr(10),
+					},
+				},
+			},
+			agentDef: &config.AgentConfig{},
+			want: &orchestrator.OrchestratorGuardrails{
+				MaxConcurrentAgents: 10,
 			},
 		},
 		{
@@ -701,7 +713,6 @@ func TestResolveOrchestratorGuardrails(t *testing.T) {
 			want: &orchestrator.OrchestratorGuardrails{
 				MaxConcurrentAgents: 10,
 				AgentTimeout:        60 * time.Second,
-				MaxBudget:           900 * time.Second,
 			},
 		},
 		{
@@ -711,7 +722,6 @@ func TestResolveOrchestratorGuardrails(t *testing.T) {
 					Orchestrator: &config.OrchestratorConfig{
 						MaxConcurrentAgents: intPtr(10),
 						AgentTimeout:        dur(60 * time.Second),
-						MaxBudget:           dur(120 * time.Second),
 					},
 				},
 			},
@@ -723,7 +733,6 @@ func TestResolveOrchestratorGuardrails(t *testing.T) {
 			want: &orchestrator.OrchestratorGuardrails{
 				MaxConcurrentAgents: 3,
 				AgentTimeout:        60 * time.Second,
-				MaxBudget:           120 * time.Second,
 			},
 		},
 		{
@@ -731,29 +740,24 @@ func TestResolveOrchestratorGuardrails(t *testing.T) {
 			cfg:  &config.Config{},
 			agentDef: &config.AgentConfig{
 				Orchestrator: &config.OrchestratorConfig{
-					MaxBudget: dur(30 * time.Second),
+					AgentTimeout: dur(30 * time.Second),
 				},
 			},
 			want: &orchestrator.OrchestratorGuardrails{
 				MaxConcurrentAgents: 5,
-				AgentTimeout:        420 * time.Second,
-				MaxBudget:           30 * time.Second,
+				AgentTimeout:        30 * time.Second,
 			},
 		},
 		{
-			name: "zero or negative values are clamped to defaults",
+			name: "zero max_concurrent_agents is clamped; omitted agent_timeout stays zero",
 			cfg:  &config.Config{},
 			agentDef: &config.AgentConfig{
 				Orchestrator: &config.OrchestratorConfig{
 					MaxConcurrentAgents: intPtr(0),
-					AgentTimeout:        dur(-1 * time.Second),
-					MaxBudget:           dur(0),
 				},
 			},
 			want: &orchestrator.OrchestratorGuardrails{
 				MaxConcurrentAgents: 5,
-				AgentTimeout:        420 * time.Second,
-				MaxBudget:           900 * time.Second,
 			},
 		},
 	}


### PR DESCRIPTION
- Omitted agent_timeout now uses remaining parent (session/chat) time
- Optional YAML cap uses WithTimeoutCause and never extends past parent
- Remove unused max_budget from config, API, and validator
- Raise DefaultMaxIterations from 20 to 40


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration**
  - Increased the default maximum iterations from 20 to 40.
  - `agent_timeout` is now optional; sub-agents use remaining parent time when unspecified, while configured limits cannot exceed the parent deadline.
  - Removed the unsupported `max_budget` orchestrator setting from configuration and responses.

- **Documentation**
  - Added design documentation covering execution limits, deadline handling, wrap-up behavior, and configuration decisions.

- **Reliability**
  - Improved timeout and cancellation handling so parent deadlines and timeout causes are reflected consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->