### PR TITLE
feat(config): add named fallback list catalog

### DIFF
--- a/docs/proposals/named-fallback-lists-design.md
+++ b/docs/proposals/named-fallback-lists-design.md
@@ -1,0 +1,421 @@
+# Named Fallback Lists
+
+**Status:** Final
+**Related:** [Questions document](named-fallback-lists-questions.md)
+
+**Amends:** [ADR-0003](../adr/0003-llm-provider-fallback.md), [ADR-0017](../adr/0017-native-tool-fallback-safety.md), [ADR-0024](../adr/0024-tool-summarization-provider.md) Q4 (adds the summarization-local list ADR-0024 rejected for v1)
+
+## Overview
+
+TARSy already has an ordered LLM fallback list ([ADR-0003](../adr/0003-llm-provider-fallback.md)). On failure it walks that list, skips names already attempted in the execution, skips native-tool-incompatible backends ([ADR-0017](../adr/0017-native-tool-fallback-safety.md)), and sticks for the rest of the execution.
+
+That list is **one ordered preference**. Operators can replace it at chain / stage / stage-agent, but there is no way to **name and reuse** several preferences. In practice deployments keep a single `defaults.fallback_providers` list and every execution walks it.
+
+That is the wrong shape once primaries differ in cost and quality. Dev Sandbox is the concrete case:
+
+| Work | Typical primary | Desired fallback |
+|------|-----------------|------------------|
+| Parallel investigation / orchestrator / synthesis | Claude Opus (or Gemini Pro) | Other frontier models, then mid-tier |
+| Remediation, scoring, exec summary, compose | Claude Sonnet | Other cheap/mid models — **not** Opus |
+| WebResearcher / CodeExecutor | `google-default` + `google-native` | Other Gemini native models |
+| Tool summarization | Flash / `google-default` | Other cheap Gemini — **not** the investigator's Opus list |
+
+Today a Sonnet remediator whose primary fails tries `vertexai-claude-opus-4-8` first, because that is the head of the shared list. Attempted-name skip only drops the current name; it does not keep the walk inside a cost band.
+
+This design adds **named fallback lists** and a **`fallback_list` selector** so each execution binds one list. Runtime fallback (triggers, stickiness, native-tool skip, summarization-local walk) does not change — only **which list** is resolved onto the execution.
+
+## Design Principles
+
+1. **A fallback list is a cost/quality preference, not a global ranking.** Different work may prefer “stay expensive” vs “stay cheap” vs “stay google-native.”
+2. **Reuse by name.** Lists live in a catalog. Call sites pick a name. After migration, one-offs are extra catalog entries, not inline slices.
+3. **Zero migration for current YAML, except the native-tool primary pair.** `fallback_providers` still loads (deprecated, startup warning). Configs that never define `fallback_lists` keep today’s fallback *walks*. PR 2 still sets builtin WebResearcher / CodeExecutor `llm_provider: google-default` so short-form native-tool agents stop pairing defaults Opus with `google-native`.
+4. **Resolution only.** Controllers, Python retries, and timeline events are unchanged. The resolver still produces `ResolvedFallbackProviders`.
+5. **Fail at load for real mistakes.** Unknown list names, invalid entries, and both selector + inline on the same node are startup errors. Unused lists may omit credentials (same as unused providers); unknown providers/backends in any catalog entry still fail.
+6. **Operator order is still law.** The system does not re-rank by price or quality ([ADR-0003](../adr/0003-llm-provider-fallback.md) principle 3).
+7. **Provider and backend are a pair** at every pairing site (defaults, `defaults.agents.<name>` for any registered agent, job knobs, chain / stage / ref). Identity (`agents:` / builtins) keeps `llm_backend` and tools; it does **not** gain YAML `llm_provider` / `fallback_list`. Global pair for an agent — builtin (explicit or implicit) or custom — lives under `defaults`. A chain/stage/ref that names that agent overrides when set. Omitted backend still means langchain at a pairing node that names a provider.
+
+## Decisions
+
+| # | Decision | Choice | Rationale |
+|---|----------|--------|-----------|
+| Q1 | Mechanism | Named catalog + `fallback_list` selector | Copy-paste inline lists drift; no tier model |
+| Q2 | Catalog location | Top-level `fallback_lists` in `tarsy.yaml` | Named registry, like agents / MCP servers |
+| Q3 | Legacy field | `defaults.fallback_list` is the default; `fallback_providers` deprecated | Happy path is names only; existing YAML keeps working |
+| Q4 | Both fields on one node | Load-time error | Mixing new + old is a migration mistake |
+| Q5 | Selector sites | `fallback_list` on every primary-model site + stage; `fallback_providers` only where it already exists | New surfaces must not grow the deprecated field |
+| Q6 | Builtin native-tool pair | Go sets `google-default` + `google-native`; no pairing on `agents:` YAML | Short-form primary is safe; identity map stays identity (Q13) |
+| Q7 | Side-path selectors | Skipped (Q5) | Already covered |
+| Q8 | Summarization | Optional `defaults.summarization.fallback_list`; no per-server overlay | Flash stays in a cheap/native band; ADR-0024 walk otherwise |
+| Q9 | Inheritance + implicit jobs | Inherit defaults → chain when unset; job knobs for scoring / compose / exec summary / summarization | Dedicated knobs beat investigation `premium`; chain/stage override when set |
+| Q10 | List includes | Flat lists | No cycles; copied Gemini tails are cheap |
+| Q11 | Unused catalog lists | Structure-validate all; credentials only if referenced | Typos fail; spare lists without keys do not |
+| Q12 | Config viewer | Catalog + raw selectors as written | ADR-0019 snapshot, not a resolved agent graph |
+| Q13 | Named-agent global pairing | `defaults.agents.<name>` for any registered agent | Not `agents:` identity (would replace builtins). Chain/stage/ref that names the agent wins when set |
+
+## Architecture / How It Works
+
+### What exists today
+
+```
+defaults.fallback_providers
+    ↑ last non-nil wins (explicit empty slice clears)
+chain.fallback_providers
+stage.fallback_providers
+stage-agent.fallback_providers     ← stage agents only
+```
+
+Then the resolver looks up each entry and stores `ResolvedFallbackProviders` on the execution. `tryFallback()` walks that slice.
+
+Gaps that made the single-list problem worse:
+
+- **Sub-agent refs** have `llm_provider` / `llm_backend` but **no** fallback field. Dispatched sub-agents call `ResolveAgentConfig` with an **empty stage** and the ref mapped onto `StageAgentConfig`, so they get defaults → chain only (not the parent orchestrator’s stage-agent list).
+- **Chat and scoring** use dedicated resolvers (`ResolveChatAgentConfig` / `ResolveScoringConfig`) and inherit defaults → chain only. Existing tests: stage fallback must not leak into chat/scoring.
+- **Exec summary** at runtime also uses `ResolveAgentConfig`, but the executor passes a **zero `StageConfig`**, so it does not inherit a stage list. The dedicated `ResolveExecSummaryConfig` helper is used in tests, not by the session executor.
+- **Compose** at runtime uses `ResolveAgentConfig` with the **action stage** that just completed. If that stage sets `fallback_providers`, compose inherits it today — unlike `ResolveComposeConfig` (tests only), which is defaults → chain. This design treats the test helper as the intended contract and **fixes the runtime path**.
+- **Synthesis** reuses the investigation stage via `ResolveAgentConfig` (provider/backend copied from `stage.synthesis` onto a synthetic stage-agent). A stage-level investigation list therefore applies unless `stage.synthesis` sets its own list.
+- **Summarization** walks the **calling agent’s** resolved list ([ADR-0024](../adr/0024-tool-summarization-provider.md) Q4). The reflector reuses the scoring execution context, so it walks scoring’s list.
+- **Exec summary** has no `defaults.*` knob. **Compose** has `compose_provider` with no sibling backend.
+- **Agent definitions** have `llm_backend` but not `llm_provider`, so short-form WebResearcher can resolve to Opus + `google-native`.
+- **Native-tool startup warning** only inspects stage agents and **chain-level** `sub_agents`. Stage / stage-agent / chat refs are not warned today.
+
+```
+Alert / chat / scoring / compose / exec-summary / tool summarization
+        │
+        ▼
+  ResolveAgentConfig / Resolve*Config
+        │  binds one []FallbackProviderEntry
+        ▼
+  ResolvedFallbackProviders on the execution
+        │
+        ├─ iterating / single-shot tryFallback()   (sticky, native-tool skip)
+        └─ summarization-local walk                (does not mutate investigator)
+```
+
+### Named lists + selector
+
+Top-level catalog next to `agents` / `mcp_servers`. `defaults.fallback_list` selects the default. Each other layer may name a list or inherit.
+
+```yaml
+fallback_lists:
+  premium:
+    - provider: vertexai-claude-opus-4-8
+    - provider: vertexai-claude-opus-4-6
+    - provider: vertexai-claude-opus
+    - provider: gpt-5.6-sol
+    - provider: google-default
+      backend: google-native
+  mid:
+    - provider: vertexai-claude-sonnet
+    - provider: gemini-3.7-flash
+      backend: google-native
+    - provider: gemini-3.1-pro
+      backend: google-native
+  google-native:
+    - provider: google-default
+      backend: google-native
+    - provider: gemini-3.7-flash
+      backend: google-native
+    - provider: gemini-3.1-pro
+      backend: google-native
+
+defaults:
+  llm_provider: vertexai-claude-opus
+  llm_backend: langchain
+  fallback_list: premium
+  scoring:
+    llm_provider: vertexai-claude-sonnet
+    llm_backend: langchain
+    fallback_list: mid
+  compose_provider: vertexai-claude-sonnet
+  compose_backend: langchain          # omit → langchain
+  compose_fallback_list: mid
+  executive_summary_provider: vertexai-claude-sonnet
+  executive_summary_backend: langchain
+  executive_summary_fallback_list: mid
+  summarization:
+    llm_provider: google-default
+    llm_backend: google-native
+    fallback_list: google-native
+  agents:
+    WebResearcher:
+      llm_provider: google-default      # omit → builtin google-default
+      llm_backend: google-native
+      fallback_list: google-native
+    CodeExecutor:
+      fallback_list: google-native
+    ChatAgent:
+      llm_provider: vertexai-claude-sonnet
+      fallback_list: mid
+    MyCustomKubeAgent:
+      llm_provider: vertexai-claude-opus
+      fallback_list: premium
+```
+
+Builtin WebResearcher / CodeExecutor set `llm_provider: google-default` and `llm_backend: google-native` **in Go**. Catalog names stay out of builtins. List names are independent of backend enum values — a catalog key `google-native` is allowed and is not the backend `google-native`.
+
+`defaults.agents` is pair + list only, keyed by registry name (explicit builtins, implicit named agents, custom). It does **not** replace identity. Do not put `llm_provider` / `fallback_list` on the `agents:` map (`mergeAgents` would replace a builtin of the same name). Unset `defaults.agents.<name>` inherits global `defaults` (and the Go builtin pair for WebResearcher / CodeExecutor). A chain/stage/ref that names the agent overrides when set.
+
+Short-form sub-agent (parent orchestrator is Opus; WebResearcher is not overridden by that):
+
+```yaml
+- name: SecurityInvestigationOrchestrator
+  llm_provider: vertexai-claude-opus
+  llm_backend: langchain
+  sub_agents:
+    - name: MyCustomKubeAgent          # omit pair → defaults.agents.MyCustomKubeAgent
+    - name: SecurityInvestigationAgent
+      llm_provider: vertexai-claude-sonnet
+      fallback_list: mid               # chain ref wins over defaults.agents
+    - name: WebResearcher              # google-default + google-native + defaults.agents list
+```
+
+The orchestrator’s `llm_provider` / `fallback_list` on the **stage-agent or parent ref** does **not** leak to dispatched sub-agents (empty stage; ref is its own layer). `defaults.agents.<name>` beats the investigation **chain** global list (so `chain.fallback_list: premium` does not poison WebResearcher). Stage-agent / ref / `chain.chat` / `stage.synthesis` still win when set. Do not set a chain-level list *instead of* `defaults.agents` if named agents need a different walk — set both.
+
+Deprecated `fallback_providers` still loads on defaults / chain / stage / stage-agent. Startup warns. A fully migrated config never mentions it.
+
+### Binding a list to an execution
+
+Each YAML node that can choose a list has **at most one** of:
+
+| Field | Meaning |
+|-------|---------|
+| `fallback_list: <name>` | Use that catalog entry |
+| `fallback_providers: [...]` | Deprecated inline list (existing four layers only) |
+| neither | Inherit the next less-specific layer |
+
+Both set on the same node is a **load-time error**.
+
+Per-node resolution: non-empty `fallback_list` → expand catalog; else deprecated `fallback_providers` (including explicit empty slice); else inherit. Omitted or empty-string `fallback_list` inherits. “No fallback” is deprecated `fallback_providers: []` or a catalog entry whose list is empty.
+
+Investigation / dispatched-agent hierarchy (last non-nil slice wins), after expanding names:
+
+```
+defaults (fallback_list or deprecated inline)
+  → chain (fallback_list or deprecated inline)
+  → defaults.agents.<resolved agent name>
+  → stage                          (investigation stages; does not leak to chat/scoring/exec summary)
+  → stage-agent / sub-agent ref
+```
+
+Go builtin `llm_provider` / `llm_backend` is the pairing layer under `defaults.agents` when that map omits the name (same slot as today’s agent-def backend overlay).
+
+Side paths inherit **defaults → chain** when their own selector is unset (stage lists still do not leak into chat/scoring/exec summary). Dedicated knobs override when set:
+
+```
+defaults.fallback_list / deprecated inline
+  → chain.fallback_list / deprecated inline
+  → defaults.agents.<name>            # ChatAgent, SynthesisAgent, …
+  → defaults.<job> selector           # scoring.fallback_list, compose_fallback_list, …
+  → chain/stage job selector          # chain.chat, chain.scoring, stage.synthesis
+```
+
+`defaults.agents.ChatAgent` applies when the chat agent name is `ChatAgent` (or `defaults.agents.<chain.chat.agent>` when chat names a custom agent). `chain.chat` wins when set. There is no separate `defaults.chat` block.
+
+This fallback order is **not** the same as scoring’s *provider* order. `chain.llm_provider` still beats `defaults.scoring.llm_provider` (existing). Dedicated `defaults.scoring.fallback_list` still beats an investigation `chain.fallback_list` / `defaults.fallback_list`. That divergence is intentional: the new knobs exist so Sonnet scoring does not walk `premium`.
+
+Compose/exec-summary *provider* order already matches this shape (`defaults.compose_provider` beats `chain.llm_provider`).
+
+Summarization: if `defaults.summarization.fallback_list` is set, the summarization-local walk uses that catalog list (resolved onto the execution context **separately** from the investigator’s `ResolvedFallbackProviders`). Unset → calling agent’s effective list (ADR-0024). Still does not mutate the investigator; still no native-tool skip. A per-server Opus overlay still walks this same global summarization list (no per-server `fallback_list` in v1).
+
+Explicit empty deprecated `fallback_providers: []` still means “no fallback.” A `fallback_list` that names an empty catalog entry is the same.
+
+The controller never sees list names. After resolve, `ResolvedFallbackProviders` is a flat slice, same as today. Each YAML layer is expanded to a slice-or-nil **before** last-non-nil (a named list is a non-nil slice even when empty).
+
+```
+YAML node
+  ├─ fallback_list: "mid"
+  │     → lookup fallback_lists["mid"]
+  │     → []FallbackProviderEntry
+  └─ fallback_providers: [...]          # deprecated; existing four layers only
+        → []FallbackProviderEntry
+            │
+            ▼
+  last non-nil layer
+            │
+            ▼
+  resolveFullFallbackEntries()  (unchanged)
+            │
+            ▼
+  tryFallback() / summarization-local walk  (unchanged)
+```
+
+## Core Concepts
+
+### Fallback list (catalog entry)
+
+A named, ordered `[]FallbackProviderEntry`. Same entry schema as today: required `provider`, optional `backend` (omitted → langchain). Lists are **flat** — no include of other lists.
+
+### List selector (`fallback_list`)
+
+A string naming a catalog entry. Expanded at resolve/validate time. Unknown names fail startup. This is the first-class default (`defaults.fallback_list`) and the override at every other layer.
+
+### Deprecated inline list (`fallback_providers`)
+
+Today’s field, kept on defaults / chain / stage / stage-agent only. Startup warns. Do not add it to new sites. Remove in a later change.
+
+### Effective list
+
+The concrete slice bound to one execution after hierarchy + expansion. Native-tool startup warnings and `tryFallback()` use this. The config viewer shows catalog + raw selectors, not the expanded per-agent walk.
+
+### Named-agent pairing (`defaults.agents`)
+
+A map of registry name → pair + list. Global setting for **any** named agent: explicit builtins (`WebResearcher`), implicit named agents (`ChatAgent`, optionally `SynthesisAgent`), and custom agents (`MyCustomKubeAgent`). Not for jobs that are not an agent you dispatch (summarization, scoring, compose, exec-summary field names). Identity stays in `agents:` / Go builtins. Override at the chain/stage/ref that names the agent.
+
+### Implicit jobs
+
+Scoring, compose, exec summary, and summarization keep **job** knobs under `defaults` (`scoring`, `compose_*`, `executive_summary_*`, `summarization`). Chat global pairing is `defaults.agents.ChatAgent` (or the custom chat agent name); `chain.chat` wins. Memory reflector reuses the scoring execution context, so it walks scoring’s effective list with no extra knob.
+
+## Configuration (user-facing contract)
+
+### Catalog
+
+```yaml
+fallback_lists:
+  <list-name>:
+    - provider: <registered provider>
+      backend: langchain | google-native   # optional; omit → langchain
+```
+
+List names are non-empty YAML mapping keys. Duplicate names cannot exist (YAML map). Every catalog entry is structure-validated (provider exists, backend valid, `google-native` only with a Google provider). Credentials are required only for **referenced** lists.
+
+**Referenced** means every `fallback_list` / `*_fallback_list` string that appears in YAML (including `defaults.fallback_list` and `defaults.summarization.fallback_list`), plus every deprecated `fallback_providers` entry (today’s rule). It is not a full per-execution resolve: a default list named in YAML is credential-checked even if every chain overrides it. Unnamed catalog entries are structure-only.
+
+Also treat as referenced LLM providers (existing collector, extended): defaults/chain/stage-agent/sub-agent/side-path `llm_provider` fields, including **`executive_summary_provider`** (missing from the collector today — add it here), `defaults.agents.*.llm_provider`, and new compose/exec-summary names. Do not credential-check builtin WebResearcher’s `google-default` merely because the builtin exists; do check it when `defaults.agents.WebResearcher` (or a reachable ref) names it or when the builtin pair is used because the agent can run.
+
+### Selector and pairing sites
+
+| Site | `fallback_list` | `fallback_providers` | Provider / backend |
+|------|-----------------|----------------------|--------------------|
+| `defaults` | yes | keep (deprecated) | existing `llm_provider` / `llm_backend` |
+| `defaults.agents.<name>` | yes | **not added** | `llm_provider` / `llm_backend` (pair + list only) |
+| `agent_chains.<id>` | yes | keep (deprecated) | existing |
+| `stages[]` | yes | keep (deprecated) | none (no stage `llm_provider`) |
+| `stages[].agents[]` | yes | keep (deprecated) | existing |
+| `agents.<name>` (identity) | **not added** | **not added** | existing `llm_backend` only |
+| `sub_agents[]` | yes | **not added** | existing |
+| `defaults.scoring` / `chain.scoring` | yes | **not added** | existing |
+| `chain.chat` | yes | **not added** | existing; global pairing is `defaults.agents.ChatAgent` (or custom chat agent name) |
+| `stage.synthesis` | yes | **not added** | existing; optional global `defaults.agents.SynthesisAgent` |
+| compose | `compose_fallback_list` | **not added** | existing `compose_provider` + **`compose_backend`** (defaults and chain) |
+| exec summary | `executive_summary_fallback_list` | **not added** | **`executive_summary_provider`** + **`executive_summary_backend`** (defaults and chain) |
+| `defaults.summarization` | yes | **not added** | existing; **no** per-MCP-server `fallback_list`; **not** `defaults.agents` |
+
+Keep current names (`compose_provider`, `executive_summary_provider`). Do not nest them into a new mapping that would migrate existing YAML.
+
+Omitted `*_backend` / `llm_backend` still means langchain. Adding sibling backend on compose and exec summary **amends** ADR-0003’s “those provider fields have no sibling backend.”
+
+Sub-agent short-form (`sub_agents: [WebResearcher]`) has no ref overlay. Effective list is last non-nil among defaults → chain → `defaults.agents.WebResearcher` → empty stage. Long-form objects may set `fallback_list` and the provider pair; those must be copied from `SubAgentRef` onto `StageAgentConfig` in the orchestrator runner (and `subAgentRefAllowedKeys` must allow `fallback_list` or long-form YAML fails parse).
+
+### Inheritance that must not surprise
+
+- **Stage-level fallback does not leak into chat, scoring, or exec summary** (chat/scoring: dedicated resolvers; exec summary: zero stage at runtime). Compose must match that: do not pass the action stage into resolve.
+- **Parent orchestrator `llm_provider` / stage-agent `fallback_list` does not leak to sub-agents** (existing empty-stage dispatch).
+- **`defaults.agents.<name>` beats chain-global list** so investigation `premium` does not poison WebResearcher. **Ref / stage-agent / `chain.chat` / `stage.synthesis` still win** when set.
+- Synthesis uses `stage.synthesis.fallback_list` when set (copy onto the synthetic stage-agent, same as provider/backend today); otherwise `defaults.agents.SynthesisAgent` if set, else the investigation stage list after defaults → chain.
+
+## Runtime behavior (unchanged)
+
+All of the following stay as specified in ADR-0003 / 0017 / 0027 / 0028:
+
+- Python identical retries, then Go fallback
+- Sticky for the rest of the execution; new executions resolve fresh
+- Skip already-attempted provider names
+- Skip non-`google-native` entries when `RequiresNativeTools`
+- Summarization-local walk does not mutate the investigator and does not apply native-tool skip
+- Timeline `provider_fallback` events, execution `original_llm_*` columns, dashboard chips
+
+Native-tool startup **warning** uses the **effective** list after named-list expansion, including `defaults.agents` and **all** `SubAgentRefs` sites (chain, stage, stage-agent, chat — not only chain-level refs as today).
+
+## Observability and config viewer
+
+- Timeline / metrics: no new event types. Provider names in existing fallback events already identify what was used.
+- Config viewer (`GET /api/v1/system/config`): emit the `fallback_lists` catalog, `defaults.agents`, and the raw `fallback_list` / deprecated `fallback_providers` / `*_fallback_list` fields as written. Do not compute per-agent expanded walks in v1. Do **not** add `llm_provider` / `fallback_list` to `AgentView` (identity has no pairing YAML).
+- Startup: warn on any use of `fallback_providers`.
+
+## Out of scope
+
+- Auto-sorting fallbacks by cost or by “tier”
+- `include` of other named lists
+- Per-MCP-server summarization `fallback_list`
+- Process-wide provider cooldown / probe-unstick (ADR-0027 later)
+- Changing retry counts, stickiness, or native-tool skip rules
+- Removing `fallback_providers` in this change (deprecation only)
+- Editing Sandbox YAML in this repository (separate `sandbox-sre` change once the product lands)
+- Computed `effective_fallback_providers` in the config viewer
+
+## Implementation Plan
+
+Split so each PR leaves TARSy working. PR 1: configs without `fallback_lists` / `fallback_list` behave as today (aside from a deprecation warning if they already set `fallback_providers`). PR 2’s builtin `llm_provider: google-default` on native-tool agents is the documented exception.
+
+### PR 1 — Catalog, existing four layers, deprecation
+
+**Lands**
+
+- Top-level `fallback_lists` on `TarsyYAMLConfig` **and** a field on in-memory `Config` (resolver / validator / viewer read `Config`, not the YAML struct)
+- `fallback_list` on defaults, chain, stage, stage-agent
+- Per-node expand-then-last-non-nil helper (name → copy of catalog slice; else deprecated inline; else nil)
+- Load-time error if `fallback_list` and `fallback_providers` are both set on one node
+- Startup warning on `fallback_providers` (including explicit empty slice)
+- Validator: unknown list name; structure-validate every catalog entry (no credential check); credential-check referenced lists only (split today’s `validateFallbackProviders`); `collectReferencedLLMProviders` includes entries from referenced lists
+- Native-tool warning uses expanded effective lists for those four layers
+
+**Tests in this PR**
+
+- Loader: catalog + selectors parse; omitted catalog is fine
+- Validator: unknown list name, typo in an unused list, missing creds only on a referenced list, both fields on one node, empty named list
+- Resolver: `fallback_list` at defaults / chain / stage / **stage-agent**; deprecated inline still works when `fallback_list` is unset; existing tests stay green
+
+**Deferred:** `defaults.agents`, sub-agents, job knobs, builtin `llm_provider`, config viewer.
+
+**Temporary gap:** operators can name lists and attach them to stage agents, but sub-agents and Sonnet side paths still inherit the default/chain list until PR 2. That matches today’s gap; it does not regress.
+
+### PR 2 — `defaults.agents`, sub-agents, implicit jobs, summarization
+
+**Lands**
+
+- `defaults.agents` map (pair + list only) for any registered agent name. Unknown names fail load. Not added to `AgentConfig` / `agents:` YAML
+- `BuiltinAgentConfig` gains `LLMProvider`; `mergeAgents` copies it. Builtin WebResearcher / CodeExecutor: `llm_provider: google-default` (keep `llm_backend: google-native`). **This changes short-form native-tool primaries** even when the operator never adopts named lists
+- `SubAgentRef.fallback_list` + `subAgentRefAllowedKeys`; copy provider/backend/list in the orchestrator runner (investigation and chat share this path)
+- Scoring / compose / exec summary: `fallback_list` (and compose/exec-summary sibling backend; new `defaults.executive_summary_*`). Chat: `defaults.agents.ChatAgent` + `chain.chat.fallback_list` (chain.chat wins). Synthesis: `defaults.agents.SynthesisAgent` optional + `stage.synthesis.fallback_list`
+- **Runtime wiring, not only helpers:** session executor compose/exec-summary today call `ResolveAgentConfig`, not `ResolveComposeConfig` / `ResolveExecSummaryConfig`. Bind the new knobs on that path (or switch those stages to the dedicated resolvers). Compose must pass an empty stage so the action stage list does not leak. Synthesis copies `stage.synthesis.fallback_list` onto the synthetic stage-agent the same way it already copies provider/backend. Failed-exec best-effort `ResolveLLMPair` in `executeAgent` should include the builtin / `defaults.agents` layer
+- `defaults.summarization.fallback_list`; store a resolved summarization list on the execution context; summarization-local walk uses it when set
+- Hierarchy: defaults → chain → `defaults.agents.<name>` → stage → ref; job knobs after chain global; `chain.chat` / `stage.synthesis` / scoring/compose/exec-summary knobs last on those paths
+- Native-tool warning covers `defaults.agents` and all `SubAgentRefs` sites
+- `collectReferencedLLMProviders`: `defaults.agents`; `executive_summary_provider`; new side-path names; catalog entries from referenced lists
+
+**Tests in this PR**
+
+- Short-form WebResearcher under an Opus orchestrator (no chain `llm_provider`) resolves to `google-default` + `google-native`; with `defaults.agents.WebResearcher.fallback_list` walks that list even if `defaults.fallback_list` / `chain.fallback_list` is `premium`
+- Custom `defaults.agents.MyCustomKubeAgent` applies when the chain/stage/ref omits a pair; a ref-level pair / list wins
+- `chain.chat.fallback_list` beats `defaults.agents.ChatAgent`; custom `chain.chat.agent` uses `defaults.agents.<that name>`
+- Sub-agent ref-level list is used, not the parent orchestrator’s stage-agent list
+- Scoring/chat/compose/exec-summary do not inherit stage lists; `defaults.scoring.fallback_list` beats investigation `premium`
+- Compose/exec-summary omit-backend still langchain; explicit `*_backend` works
+- Summarization uses `defaults.summarization.fallback_list` when set; otherwise the agent list
+- `agents.WebResearcher:` in user YAML still **replaces** the builtin (unchanged `mergeAgents`); pairing belongs in `defaults.agents`
+- ADR-0017 warning cases with named lists, including a chat/stage sub-agent ref
+- Long-form `sub_agents: [{name: WebResearcher, fallback_list: google-native}]` parses (`unknown field` must not fire)
+
+**Deferred:** dashboard. e2e not required — fallback is already unit-tested at the controller; this PR is config binding.
+
+### PR 3 — Config viewer + dashboard types
+
+**Lands**
+
+- API DTO: `fallback_lists` catalog + `defaults.agents` + raw selectors / deprecated inline / `*_fallback_list` on the same nodes as today’s config
+- Dashboard TypeScript types and Config tab display (structured + YAML/JSON secondary views)
+
+**Tests in this PR**
+
+- `system_config` builder tests for the new fields
+- Dashboard types compile; no visual redesign beyond showing the new keys
+
+**Deferred:** none for the product feature. Sandbox YAML update is a separate repo PR after this ships.
+
+## References
+
+- [ADR-0003: LLM Provider Fallback](../adr/0003-llm-provider-fallback.md)
+- [ADR-0017: Native Tool Fallback Safety](../adr/0017-native-tool-fallback-safety.md)
+- [ADR-0024: Tool Summarization Provider](../adr/0024-tool-summarization-provider.md)
+- [ADR-0027: Transient LLM Outage Handling](../adr/0027-llm-transient-outage.md)
+- [ADR-0019: Read-Only Configuration Viewer](../adr/0019-config-viewer.md)

--- a/docs/proposals/named-fallback-lists-questions.md
+++ b/docs/proposals/named-fallback-lists-questions.md
@@ -1,0 +1,297 @@
+# Named Fallback Lists — Design Questions
+
+**Status:** All decisions made
+**Related:** [Design document](named-fallback-lists-design.md)
+
+---
+
+## Q1: Named reusable lists vs only expanding inline lists
+
+ADR-0003 already allows replacing `fallback_providers` at chain / stage / stage-agent. The Sandbox problem is not “you cannot set a different list” — it is that **one ordered list is shared**, and copying an 8-entry list onto every Opus agent, Sonnet remediator, and Gemini sub-agent is how that sharing survives. Sub-agents, scoring, chat, compose, and exec summary cannot even set a list today.
+
+### Option A: Named catalog + selector (`fallback_lists` + `fallback_list`)
+
+- **Pro:** Define `premium` / `mid` / `google-native` once; every agent names the preference it wants.
+- **Pro:** Matches how operators already think (“investigation stays on frontier models”).
+- **Pro:** Named lists stay maintainable; missing selector sites (sub-agents, scoring, …) still need fields either way.
+- **Con:** New config concept and validation (unknown names, unused lists).
+- **Con:** Slightly more YAML surface than “just add the missing inline fields.”
+
+**Decision:** Option A — named reusable lists plus a selector. Missing inline fields are necessary but not enough; multiple lists stay maintainable only if they are named and reused.
+
+_Considered and rejected: Option B (copy-paste inline lists drift), Option C (invents a tier model and fights operator-ordered walks)._
+
+---
+
+## Q2: Where is the catalog defined?
+
+### Option A: Top-level `fallback_lists` in `tarsy.yaml`
+
+Sibling of `agents`, `mcp_servers`, `agent_chains`, `defaults`.
+
+- **Pro:** Lists are a named registry, like agents and MCP servers — not a “default value.”
+- **Pro:** Easy to find; not buried under `defaults`.
+- **Con:** Another root key.
+
+**Decision:** Option A — catalog at the root of `tarsy.yaml`. `defaults` only selects a list (or keeps an inline default).
+
+_Considered and rejected: Option B (a catalog is not a default and looks inheritable), Option C (fallback order is orchestration, not a provider property)._
+
+---
+
+## Q3: What happens to today’s `defaults.fallback_providers`?
+
+### Option A: First-class default is `fallback_list`; `fallback_providers` is deprecated compatibility
+
+The new default list is a **name**, not a second anonymous list.
+
+Happy path (no deprecated fields):
+
+```yaml
+fallback_lists:
+  premium: [...]
+  mid: [...]
+
+defaults:
+  fallback_list: premium
+```
+
+`defaults.fallback_list` is the same selector every other layer uses. The catalog holds the lists; `defaults` only points at one. No reserved catalog name (`default`). One-offs after migration are extra named catalog entries, not inline slices.
+
+Deprecated path: `fallback_providers` still loads at any layer with today’s meaning. Startup warns. A config that never defines `fallback_lists` keeps working. A fully migrated config never mentions `fallback_providers`. Removal is a later change, not this design.
+
+Per node: `fallback_list` → expand catalog; else `fallback_providers` → inline slice; else inherit. Both set is Q4.
+
+- **Pro:** Clean new contract (`fallback_lists` + `fallback_list`) with no anonymous list in the happy path.
+- **Pro:** Zero migration; existing YAML keeps working until operators opt in.
+- **Pro:** No magic rewrite into `fallback_lists.default`.
+- **Con:** Two spellings exist until the deprecated field is removed.
+- **Con:** Startup warning and later removal need a follow-up.
+
+**Decision:** Option A — `defaults.fallback_list` is the real default; `fallback_providers` is deprecated compatibility (warn, still honor, remove later). Mixing both on one node is Q4.
+
+_Considered and rejected: Option B (rewrite inline lists into a reserved `default` catalog name — collisions and magic), Option C (require named lists immediately — breaks every current config)._
+
+---
+
+## Q4: Both `fallback_list` and `fallback_providers` on the same YAML node
+
+### Option A: Load-time error
+
+- **Pro:** One way to set a layer; no hidden precedence.
+- **Pro:** Catches copy-paste leftovers.
+- **Con:** Slightly stricter YAML.
+
+**Decision:** Option A — each node inherits, names a list, or (deprecated) inlines a list. Mixing new + old on the same node is a migration mistake, not precedence.
+
+_Considered and rejected: Option B (silent ignore of `fallback_list` is hard to debug), Option C (hidden compose/append semantics)._
+
+---
+
+## Q5: Which layers get a selector in v1?
+
+### Option A: `fallback_list` on every primary-model site; deprecated `fallback_providers` only where it already exists
+
+`fallback_list` is added wherever a primary is chosen (`llm_provider`, `compose_provider`, `executive_summary_provider`), plus **stage** (has fallback today, no `llm_provider`). Summarization is Q8. Named-agent global pairing is Q13 (`defaults.agents.<name>` for any registered agent — explicit builtin, implicit, or custom). Not the `agents:` identity map. Builtin Go still sets WebResearcher / CodeExecutor `llm_provider` + `llm_backend` (Q6).
+
+Deprecated `fallback_providers` is **not** added to new sites.
+
+| Site | `fallback_list` | `fallback_providers` |
+|------|-----------------|----------------------|
+| defaults, chain, stage, stage-agent | yes | keep (deprecated) |
+| sub-agent, scoring, chat, synthesis, compose, exec summary | yes | not added |
+
+- **Pro:** Anywhere you pick a primary, you can pick the walk that matches it.
+- **Pro:** Solves Sandbox in one design: Opus clones, Sonnet remediator, Gemini native tools, scoring.
+- **Pro:** New surfaces never grow the field we are deprecating.
+- **Con:** More fields to thread through structs, validator, config viewer, and tests.
+
+**Decision:** Option A — `fallback_list` on all primary-model sites (and stage); `fallback_providers` stays only on defaults / chain / stage / stage-agent.
+
+_Considered and rejected: Option B (four layers only — leaves sub-agents and scoring on the investigation walk), Option C (four layers + sub-agents only — scoring/compose/exec summary still fall up to Opus)._
+
+---
+
+## Q6: Selector (and optional model pair) on agent definitions (`agents.<name>`)?
+
+Agent definitions already have `llm_backend` and native tools, but **not** `llm_provider`. Primaries are chosen at chain/stage/ref. Short-form `WebResearcher` can resolve to defaults Opus plus agent-def `google-native` — a bad pair. The parent orchestrator’s `llm_provider` does **not** leak to sub-agents; chain-level provider would.
+
+### Option A: Agent definition is a pairing layer — `llm_provider` + `llm_backend` + `fallback_list`
+
+Hierarchy (last non-empty wins), same slot as today’s agent-def backend:
+
+```
+defaults → agent definition → chain → stage → stage-agent / sub-agent ref
+```
+
+`llm_provider` and `llm_backend` are one pairing layer, like every other YAML node ([ADR-0003](../adr/0003-llm-provider-fallback.md)): a node that names a provider without a sibling backend resolves backend to `langchain`. Omitted provider with a backend still overlays backend only (today’s WebResearcher). Builtin WebResearcher / CodeExecutor set **both** (`google-default` + `google-native`) so native tools stay on Gemini.
+
+`fallback_list` is allowed on the definition (new site → no deprecated `fallback_providers`). Catalog names stay out of builtins — overlays add `fallback_list: google-native`. `llm_provider: google-default` on builtins is fine (`google-default` is a builtin provider).
+
+- **Pro:** Short-form `WebResearcher` in a chain whose orchestrator is Opus still uses Gemini + the agent’s named list.
+- **Pro:** One overlay line for `fallback_list` instead of every `sub_agents` entry.
+- **Pro:** Provider and backend stay a pair; no new pairing rule.
+- **Con:** Chain-level `llm_provider` / `fallback_list` still overrides the definition (explicit layer, not parent-orchestrator leak). Sandbox should keep using per-agent/ref primaries if it wants short-form native-tool agents.
+- **Con:** User overlays that set `fallback_list` must define that name in the catalog.
+
+**Decision (amended by Q13):** Builtin WebResearcher / CodeExecutor set `llm_provider: google-default` + `llm_backend: google-native` **in Go** so short-form refs get a safe primary without YAML. Catalog names stay out of builtins. **Do not** add `llm_provider` / `fallback_list` on the `agents:` identity map — not for builtins and not for custom agents. Global pairing for any named agent is `defaults.agents.<name>` (Q13). A chain/stage/ref that names the agent wins when set.
+
+_Considered and rejected: Option B (no definition-level selector — would keep repeating Gemini + list on every WebResearcher ref). Q13 is the YAML “set once” path instead of pairing on `agents:`._
+
+---
+
+## Q7: Side-path selectors (scoring, chat, compose, exec summary, synthesis)
+
+**Skipped — moot after Q5.** Q5 already puts `fallback_list` (and not `fallback_providers`) on scoring, chat, synthesis, compose, and exec summary. Inheritance of chain lists into those paths is Q9.
+
+---
+
+## Q8: Does tool summarization get its own list?
+
+[ADR-0024](../adr/0024-tool-summarization-provider.md) Q4 **rejected** a dedicated summarization fallback list: walk the investigator’s `fallback_providers` locally so a dead Flash still tries the next family member. In Sandbox that walk is Opus-first, so a Flash summarizer fails into Sonnet then Opus — the expensive outcome ADR-0024 wanted to avoid by *having* a walk at all.
+
+### Option A: Optional `defaults.summarization.fallback_list` only (no per-server overlay)
+
+Unset → keep today’s “use the calling agent’s effective list.” Set → summarization-local walk uses that named list (still does not mutate the investigator, still no native-tool skip). No `fallback_list` on per-MCP-server summarization blocks in v1.
+
+- **Pro:** Flash can stay in the cheap/native band without a second catalog type.
+- **Pro:** Opt-in; current deployments unchanged.
+- **Pro:** One global cheap walk covers kubectl and security dumps; a server that needs Opus summarization already names an Opus `llm_provider` and can leave this unset.
+- **Con:** Revisits an ADR-0024 decision.
+- **Con:** Cannot pick a different summarization walk per MCP server until a later overlay.
+
+**Decision:** Option A — `defaults.summarization.fallback_list` only; no per-server overlay in v1.
+
+_Considered and rejected: Option B (agent list unchanged — premium investigation lists make Flash fail into Opus), Option C (required named list — breaks configs with no catalog)._
+
+---
+
+## Q9: Should a chain/stage investigation list apply to scoring, chat, compose, and exec summary?
+
+Today: **yes for chain** (defaults → chain), **no for stage** (tests: stage fallback must not leak into chat/scoring). Compose and exec summary follow the same defaults → chain resolve as scoring/chat. Exec summary has **no** `defaults.*` knob (only `chain.executive_summary_provider`). Compose has `compose_provider` with **no sibling backend**.
+
+### Option A: Keep inheriting when unset; give every implicit builtin a `defaults.*` pair + list, overridable on the chain
+
+Inheritance stays as today if a side path does not set its own list. Dedicated selectors override when set (including `defaults.scoring.fallback_list` beating an investigation `premium` list).
+
+Fill the missing knobs for builtins that operators do not put under `agents:`:
+
+| Builtin | `defaults.*` (new or extend) | Chain override |
+|---------|------------------------------|----------------|
+| Scoring | existing `scoring.llm_provider` / `llm_backend` + `fallback_list` | existing `scoring.*` + `fallback_list` |
+| Summarization | Q8: `summarization.fallback_list` | none (Q8) |
+| Compose | existing `compose_provider` + **`compose_backend`** + **`compose_fallback_list`** | same three fields (provider already exists) |
+| Exec summary | **`executive_summary_provider`** + **`executive_summary_backend`** + **`executive_summary_fallback_list`** | same three (provider already exists) |
+| Chat | **`defaults.agents.ChatAgent`** (or `defaults.agents.<chain.chat.agent>`) | existing `chain.chat.*` + `fallback_list` (wins) |
+| Synthesis | **`defaults.agents.SynthesisAgent`** (optional) | stage `synthesis.*` already has provider/backend; add `fallback_list` |
+
+Omitted `*_backend` still means langchain (same pairing as ADR-0003). Adding a sibling backend **amends** “compose/exec-summary provider has no sibling backend” — the field exists now; omit is still langchain.
+
+Keep current names (`compose_provider`, `executive_summary_provider`); do not nest them into a new mapping that would migrate existing YAML.
+
+- **Pro:** Sandbox can set Sonnet + `mid` once under `defaults` for scoring, compose, and exec summary; chains only override when needed.
+- **Pro:** Provider, backend, and list stay a pair on every implicit builtin.
+- **Pro:** Unset still inherits investigation defaults/chain (no silent behavior change).
+- **Con:** More `defaults.*` keys. Chat/synthesis defaults are unused if every chain already sets them.
+
+**Decision:** Option A — inherit when unset; add `defaults` + chain (or stage, for synthesis) provider / backend / `fallback_list` for compose and exec summary; scoring and summarization only gain `fallback_list` on blocks they already have. Chat global pairing is `defaults.agents.ChatAgent` (Q13), not a separate `defaults.chat` block; `chain.chat` wins when set. Synthesis global pairing may use `defaults.agents.SynthesisAgent`; `stage.synthesis` wins.
+
+_Considered and rejected: Option B (stop inheriting chain lists — behavior change for existing chain `fallback_providers`), Option C (chat inherits chain, others do not — three stories)._
+
+---
+
+## Q10: May a named list include other lists?
+
+### Option A: No — lists are flat
+
+- **Pro:** Trivial validation, no cycles, obvious order.
+- **Pro:** Sandbox’s three lists (`premium`, `mid`, `google-native`) do not need includes.
+- **Con:** Shared tails (all lists end with the same two Gemini entries) are copied.
+
+**Decision:** Option A — lists are flat. Revisit includes if catalogs grow large.
+
+_Considered and rejected: Option B (`include` — cycles, diamonds, prepend vs append)._
+
+---
+
+## Q11: Validate catalog entries that no execution references?
+
+Unused LLM providers already skip credential checks until referenced. Fallback entries on the live default list are always referenced.
+
+### Option B: Structure-validate all lists; credential-check only referenced lists
+
+Referenced = default list + every `fallback_list` name that appears on a reachable execution (including scoring/chat/compose/sub-agents).
+
+- **Pro:** Same as unused providers: labs can keep a spare list in YAML without wiring keys.
+- **Con:** A list that is only referenced after a config edit can fail on the next boot — still load-time, not mid-session.
+
+**Decision:** Option B — unknown providers/backends fail in any catalog entry (typos). Credentials required only for lists some resolved execution can walk.
+
+_Considered and rejected: Option A (unused lists with missing keys fail boot), Option C (ignore unused lists entirely — typos hide until selected)._
+
+---
+
+## Q12: What should the config viewer show?
+
+### Option A: Catalog + raw selectors (`fallback_list` name and/or inline entries) as written
+
+- **Pro:** Matches “effective YAML” elsewhere ([ADR-0019](../adr/0019-config-viewer.md) is post-merge config, not fully resolved agent snapshots).
+- **Pro:** Small DTO change.
+- **Con:** Operator must mentally expand `fallback_list: mid`.
+
+**Decision:** Option A — catalog + raw selectors. Per-agent expansion is a follow-up if names are not enough.
+
+_Considered and rejected: Option B (computed effective lists in the snapshot — resolver-shaped DTO, easy to drift), Option C (catalog only — new selectors invisible)._
+
+---
+
+## Q13: How to set a global pair + list on a named agent without replacing the builtin
+
+Q6’s “one overlay line” under `agents.WebResearcher` is the wrong map: `agents:` is identity, and `mergeAgents` **replaces** a builtin of the same name. Operators need a global pairing site that does not touch tools or instructions.
+
+### Option D: `defaults.agents.<name>` pair + list (any registered agent)
+
+Identity stays in Go builtins / `agents:` YAML (`llm_backend`, native tools, instructions). Global pairing for **any** named agent — explicit builtin, implicit (`ChatAgent`), or custom — lives under `defaults.agents`. Override at the chain/stage/ref that names the agent. Job-type pairing stays on existing job blocks (scoring, summarization, compose, exec summary).
+
+```yaml
+defaults:
+  llm_provider: vertexai-claude-opus
+  fallback_list: premium
+  scoring:
+    llm_provider: vertexai-claude-sonnet
+    fallback_list: mid
+  summarization:
+    llm_provider: google-default
+    llm_backend: google-native
+    fallback_list: google-native
+  compose_provider: vertexai-claude-sonnet
+  compose_fallback_list: mid
+  executive_summary_provider: vertexai-claude-sonnet
+  executive_summary_fallback_list: mid
+  agents:
+    WebResearcher:
+      llm_provider: google-default   # omit → builtin google-default
+      llm_backend: google-native
+      fallback_list: google-native
+    CodeExecutor:
+      fallback_list: google-native
+    ChatAgent:
+      llm_provider: vertexai-claude-sonnet
+      fallback_list: mid
+    MyCustomKubeAgent:
+      llm_provider: vertexai-claude-opus
+      fallback_list: premium
+```
+
+`defaults.agents` is pair + list only (not `AgentConfig`). Unknown names fail at load. `agents:` YAML does **not** gain `llm_provider` / `fallback_list`.
+
+Chat: `defaults.agents.ChatAgent` (or `defaults.agents.<chain.chat.agent>` if chat uses a custom agent). `chain.chat` wins when set. No separate `defaults.chat` block.
+
+- **Pro:** One `defaults` section holds global pairing for every named agent; identity is never replaced.
+- **Pro:** Same rule for explicit builtins, implicit named agents, and custom agents. Chain/stage/ref overrides when set.
+- **Pro:** No `mergeAgents` change. MCP overlays stay replace.
+- **Con:** Scoring/compose/exec-summary/summarization stay as job keys (they are jobs, not “add this agent to a chain”). Pairing for those is not under `defaults.agents`.
+
+**Decision:** Option D — `defaults.agents.<name>` for any registered agent; no pairing fields on `agents:` identity; job knobs unchanged except chat uses `defaults.agents.ChatAgent` instead of `defaults.chat`.
+
+_Considered and rejected: Option A (full replace of builtin identity), Option B (field-merge on `agents:` — wrong map, `skills: []` vs omit), Option C (magic catalog name on the builtin)._

--- a/pkg/agent/config_resolver.go
+++ b/pkg/agent/config_resolver.go
@@ -98,10 +98,15 @@ func ResolveAgentConfig(
 	}
 
 	// Resolve fallback providers (defaults → chain → stage → agentConfig)
-	fallbackProviders := resolveFallbackProviders(
-		defaults.FallbackProviders, chain.FallbackProviders,
-		stageConfig.FallbackProviders, agentConfig.FallbackProviders,
+	fallbackProviders, err := config.ResolveFallbackLayers(cfg.FallbackLists,
+		config.FallbackLayer{ListName: defaults.FallbackList, Inline: defaults.FallbackProviders},
+		config.FallbackLayer{ListName: chain.FallbackList, Inline: chain.FallbackProviders},
+		config.FallbackLayer{ListName: stageConfig.FallbackList, Inline: stageConfig.FallbackProviders},
+		config.FallbackLayer{ListName: agentConfig.FallbackList, Inline: agentConfig.FallbackProviders},
 	)
+	if err != nil {
+		return nil, err
+	}
 
 	// Apply agent-level native tools override (provider → agent merge)
 	resolvedProvider := applyAgentNativeTools(provider, agentDef.NativeTools)
@@ -226,9 +231,13 @@ func ResolveChatAgentConfig(
 	}
 
 	// Resolve fallback providers (defaults → chain; chatCfg has no fallback field)
-	fallbackProviders := resolveFallbackProviders(
-		defaults.FallbackProviders, chain.FallbackProviders,
+	fallbackProviders, err := config.ResolveFallbackLayers(cfg.FallbackLists,
+		config.FallbackLayer{ListName: defaults.FallbackList, Inline: defaults.FallbackProviders},
+		config.FallbackLayer{ListName: chain.FallbackList, Inline: chain.FallbackProviders},
 	)
+	if err != nil {
+		return nil, err
+	}
 
 	// Apply agent-level native tools override (provider → agent merge)
 	resolvedProvider := applyAgentNativeTools(provider, agentDef.NativeTools)
@@ -345,9 +354,13 @@ func ResolveScoringConfig(
 	}
 
 	// Resolve fallback providers (defaults → chain; scoringCfg has no fallback field)
-	fallbackProviders := resolveFallbackProviders(
-		defaults.FallbackProviders, chain.FallbackProviders,
+	fallbackProviders, err := config.ResolveFallbackLayers(cfg.FallbackLists,
+		config.FallbackLayer{ListName: defaults.FallbackList, Inline: defaults.FallbackProviders},
+		config.FallbackLayer{ListName: chain.FallbackList, Inline: chain.FallbackProviders},
 	)
+	if err != nil {
+		return nil, err
+	}
 
 	// Apply agent-level native tools override (provider → agent merge)
 	resolvedProvider := applyAgentNativeTools(provider, agentDef.NativeTools)
@@ -415,9 +428,13 @@ func ResolveExecSummaryConfig(
 	)
 
 	// Resolve fallback providers (defaults → chain).
-	fallbackProviders := resolveFallbackProviders(
-		defaults.FallbackProviders, chain.FallbackProviders,
+	fallbackProviders, err := config.ResolveFallbackLayers(cfg.FallbackLists,
+		config.FallbackLayer{ListName: defaults.FallbackList, Inline: defaults.FallbackProviders},
+		config.FallbackLayer{ListName: chain.FallbackList, Inline: chain.FallbackProviders},
 	)
+	if err != nil {
+		return nil, err
+	}
 
 	// Apply agent-level native tools override (provider → agent merge)
 	resolvedProvider := applyAgentNativeTools(provider, agentDef.NativeTools)
@@ -482,9 +499,13 @@ func ResolveComposeConfig(
 		defaults.MaxIterations, agentDef.MaxIterations, chain.MaxIterations, nil,
 	)
 
-	fallbackProviders := resolveFallbackProviders(
-		defaults.FallbackProviders, chain.FallbackProviders,
+	fallbackProviders, err := config.ResolveFallbackLayers(cfg.FallbackLists,
+		config.FallbackLayer{ListName: defaults.FallbackList, Inline: defaults.FallbackProviders},
+		config.FallbackLayer{ListName: chain.FallbackList, Inline: chain.FallbackProviders},
 	)
+	if err != nil {
+		return nil, err
+	}
 
 	resolvedProvider := applyAgentNativeTools(provider, agentDef.NativeTools)
 	resolvedFallback := resolveFullFallbackEntries(cfg, fallbackProviders, agentDef.NativeTools)
@@ -585,28 +606,6 @@ func ResolveLLMPair(cfg *config.Config, layers ...LLMLayer) (*config.LLMProvider
 		return nil, name, backend, fmt.Errorf("LLM provider %q not found: %w", name, err)
 	}
 	return provider, name, backend, nil
-}
-
-// resolveFallbackProviders returns the last non-nil fallback list from the
-// given overrides, listed in lowest-to-highest precedence order.
-// A non-nil empty slice is an explicit override that clears inherited values.
-// Returns nil when no override provides a value.
-func resolveFallbackProviders(overrides ...[]config.FallbackProviderEntry) []config.FallbackProviderEntry {
-	var result []config.FallbackProviderEntry
-	found := false
-	for _, o := range overrides {
-		if o != nil {
-			result = o
-			found = true
-		}
-	}
-	if !found {
-		return nil
-	}
-	if len(result) == 0 {
-		return make([]config.FallbackProviderEntry, 0)
-	}
-	return append([]config.FallbackProviderEntry(nil), result...)
 }
 
 // resolveFullFallbackEntries looks up the full LLMProviderConfig for each

--- a/pkg/agent/config_resolver_test.go
+++ b/pkg/agent/config_resolver_test.go
@@ -1485,6 +1485,222 @@ func TestResolveFallbackProviders(t *testing.T) {
 	})
 }
 
+func TestResolveFallbackList(t *testing.T) {
+	googleProvider := &config.LLMProviderConfig{
+		Type:      config.LLMProviderTypeGoogle,
+		Model:     "gemini-2.5-pro",
+		APIKeyEnv: "GOOGLE_API_KEY",
+	}
+	premium := []config.FallbackProviderEntry{
+		{Provider: "opus-fb", Backend: config.LLMBackendLangChain},
+	}
+	mid := []config.FallbackProviderEntry{
+		{Provider: "sonnet-fb", Backend: config.LLMBackendLangChain},
+	}
+	empty := []config.FallbackProviderEntry{}
+
+	baseCfg := &config.Config{
+		Defaults: &config.Defaults{
+			LLMProvider: "google-default",
+		},
+		FallbackLists: map[string][]config.FallbackProviderEntry{
+			"premium": premium,
+			"mid":     mid,
+			"empty":   empty,
+		},
+		AgentRegistry: config.NewAgentRegistry(map[string]*config.AgentConfig{
+			"TestAgent":                 {},
+			config.AgentNameScoring:     {Type: config.AgentTypeScoring},
+			config.AgentNameChat:        {},
+			config.AgentNameCompose:     {Type: config.AgentTypeCompose},
+			config.AgentNameExecSummary: {Type: config.AgentTypeExecSummary},
+		}),
+		LLMProviderRegistry: config.NewLLMProviderRegistry(map[string]*config.LLMProviderConfig{
+			"google-default": googleProvider,
+		}),
+	}
+
+	t.Run("defaults fallback_list", func(t *testing.T) {
+		cfg := *baseCfg
+		cfg.Defaults = &config.Defaults{
+			LLMProvider:  "google-default",
+			FallbackList: "premium",
+		}
+		resolved, err := ResolveAgentConfig(&cfg,
+			&config.ChainConfig{},
+			config.StageConfig{},
+			config.StageAgentConfig{Name: "TestAgent"},
+		)
+		require.NoError(t, err)
+		assert.Equal(t, premium, resolved.FallbackProviders)
+	})
+
+	t.Run("chain fallback_list overrides defaults", func(t *testing.T) {
+		cfg := *baseCfg
+		cfg.Defaults = &config.Defaults{
+			LLMProvider:  "google-default",
+			FallbackList: "premium",
+		}
+		resolved, err := ResolveAgentConfig(&cfg,
+			&config.ChainConfig{FallbackList: "mid"},
+			config.StageConfig{},
+			config.StageAgentConfig{Name: "TestAgent"},
+		)
+		require.NoError(t, err)
+		assert.Equal(t, mid, resolved.FallbackProviders)
+	})
+
+	t.Run("stage fallback_list overrides chain", func(t *testing.T) {
+		cfg := *baseCfg
+		cfg.Defaults = &config.Defaults{
+			LLMProvider:  "google-default",
+			FallbackList: "premium",
+		}
+		resolved, err := ResolveAgentConfig(&cfg,
+			&config.ChainConfig{FallbackList: "mid"},
+			config.StageConfig{FallbackList: "premium"},
+			config.StageAgentConfig{Name: "TestAgent"},
+		)
+		require.NoError(t, err)
+		assert.Equal(t, premium, resolved.FallbackProviders)
+	})
+
+	t.Run("stage-agent fallback_list overrides stage", func(t *testing.T) {
+		cfg := *baseCfg
+		cfg.Defaults = &config.Defaults{
+			LLMProvider:  "google-default",
+			FallbackList: "premium",
+		}
+		resolved, err := ResolveAgentConfig(&cfg,
+			&config.ChainConfig{FallbackList: "premium"},
+			config.StageConfig{FallbackList: "premium"},
+			config.StageAgentConfig{Name: "TestAgent", FallbackList: "mid"},
+		)
+		require.NoError(t, err)
+		assert.Equal(t, mid, resolved.FallbackProviders)
+	})
+
+	t.Run("deprecated inline still works when fallback_list is unset", func(t *testing.T) {
+		cfg := *baseCfg
+		cfg.Defaults = &config.Defaults{
+			LLMProvider:       "google-default",
+			FallbackProviders: premium,
+		}
+		resolved, err := ResolveAgentConfig(&cfg,
+			&config.ChainConfig{FallbackProviders: mid},
+			config.StageConfig{},
+			config.StageAgentConfig{Name: "TestAgent"},
+		)
+		require.NoError(t, err)
+		assert.Equal(t, mid, resolved.FallbackProviders)
+	})
+
+	t.Run("named empty list clears inherited", func(t *testing.T) {
+		cfg := *baseCfg
+		cfg.Defaults = &config.Defaults{
+			LLMProvider:  "google-default",
+			FallbackList: "premium",
+		}
+		resolved, err := ResolveAgentConfig(&cfg,
+			&config.ChainConfig{FallbackList: "empty"},
+			config.StageConfig{},
+			config.StageAgentConfig{Name: "TestAgent"},
+		)
+		require.NoError(t, err)
+		assert.NotNil(t, resolved.FallbackProviders)
+		assert.Empty(t, resolved.FallbackProviders)
+	})
+
+	t.Run("chat inherits defaults.fallback_list", func(t *testing.T) {
+		cfg := *baseCfg
+		cfg.Defaults = &config.Defaults{
+			LLMProvider:  "google-default",
+			FallbackList: "premium",
+		}
+		resolved, err := ResolveChatAgentConfig(&cfg, &config.ChainConfig{}, nil)
+		require.NoError(t, err)
+		assert.Equal(t, premium, resolved.FallbackProviders)
+	})
+
+	t.Run("scoring inherits chain.fallback_list over defaults", func(t *testing.T) {
+		cfg := *baseCfg
+		cfg.Defaults = &config.Defaults{
+			LLMProvider:  "google-default",
+			FallbackList: "premium",
+		}
+		resolved, err := ResolveScoringConfig(&cfg, &config.ChainConfig{FallbackList: "mid"}, nil)
+		require.NoError(t, err)
+		assert.Equal(t, mid, resolved.FallbackProviders)
+	})
+
+	t.Run("unknown list name errors", func(t *testing.T) {
+		cfg := *baseCfg
+		cfg.Defaults = &config.Defaults{
+			LLMProvider:  "google-default",
+			FallbackList: "ghost",
+		}
+		_, err := ResolveAgentConfig(&cfg,
+			&config.ChainConfig{},
+			config.StageConfig{},
+			config.StageAgentConfig{Name: "TestAgent"},
+		)
+		require.Error(t, err)
+		assert.Equal(t, `unknown fallback list "ghost"`, err.Error())
+	})
+
+	t.Run("chain inline beats defaults named list", func(t *testing.T) {
+		cfg := *baseCfg
+		cfg.Defaults = &config.Defaults{
+			LLMProvider:  "google-default",
+			FallbackList: "premium",
+		}
+		resolved, err := ResolveAgentConfig(&cfg,
+			&config.ChainConfig{FallbackProviders: mid},
+			config.StageConfig{},
+			config.StageAgentConfig{Name: "TestAgent"},
+		)
+		require.NoError(t, err)
+		assert.Equal(t, mid, resolved.FallbackProviders)
+	})
+
+	t.Run("chain named list beats defaults inline", func(t *testing.T) {
+		cfg := *baseCfg
+		cfg.Defaults = &config.Defaults{
+			LLMProvider:       "google-default",
+			FallbackProviders: premium,
+		}
+		resolved, err := ResolveAgentConfig(&cfg,
+			&config.ChainConfig{FallbackList: "mid"},
+			config.StageConfig{},
+			config.StageAgentConfig{Name: "TestAgent"},
+		)
+		require.NoError(t, err)
+		assert.Equal(t, mid, resolved.FallbackProviders)
+	})
+
+	t.Run("compose inherits defaults.fallback_list", func(t *testing.T) {
+		cfg := *baseCfg
+		cfg.Defaults = &config.Defaults{
+			LLMProvider:  "google-default",
+			FallbackList: "premium",
+		}
+		resolved, err := ResolveComposeConfig(&cfg, &config.ChainConfig{})
+		require.NoError(t, err)
+		assert.Equal(t, premium, resolved.FallbackProviders)
+	})
+
+	t.Run("exec summary inherits defaults.fallback_list", func(t *testing.T) {
+		cfg := *baseCfg
+		cfg.Defaults = &config.Defaults{
+			LLMProvider:  "google-default",
+			FallbackList: "premium",
+		}
+		resolved, err := ResolveExecSummaryConfig(&cfg, &config.ChainConfig{})
+		require.NoError(t, err)
+		assert.Equal(t, premium, resolved.FallbackProviders)
+	})
+}
+
 func TestResolvedFallbackProviders(t *testing.T) {
 	primaryProvider := &config.LLMProviderConfig{
 		Type:      config.LLMProviderTypeGoogle,
@@ -1537,6 +1753,32 @@ func TestResolvedFallbackProviders(t *testing.T) {
 
 		assert.Equal(t, "fb-2", resolved.ResolvedFallbackProviders[1].ProviderName)
 		assert.Equal(t, config.LLMBackendLangChain, resolved.ResolvedFallbackProviders[1].Backend)
+		assert.Equal(t, "gpt-fallback-2", resolved.ResolvedFallbackProviders[1].Config.Model)
+	})
+
+	t.Run("named fallback_list populates ResolvedFallbackProviders", func(t *testing.T) {
+		cfgNamed := *cfg
+		cfgNamed.Defaults = &config.Defaults{
+			LLMProvider:  "primary",
+			FallbackList: "premium",
+		}
+		cfgNamed.FallbackLists = map[string][]config.FallbackProviderEntry{
+			"premium": {
+				{Provider: "fb-1", Backend: config.LLMBackendNativeGemini},
+				{Provider: "fb-2", Backend: config.LLMBackendLangChain},
+			},
+		}
+		resolved, err := ResolveAgentConfig(&cfgNamed,
+			&config.ChainConfig{},
+			config.StageConfig{},
+			config.StageAgentConfig{Name: "TestAgent"},
+		)
+		require.NoError(t, err)
+		require.Len(t, resolved.ResolvedFallbackProviders, 2)
+		assert.Equal(t, "fb-1", resolved.ResolvedFallbackProviders[0].ProviderName)
+		assert.Equal(t, config.LLMBackendNativeGemini, resolved.ResolvedFallbackProviders[0].Backend)
+		assert.Equal(t, "gemini-fallback-1", resolved.ResolvedFallbackProviders[0].Config.Model)
+		assert.Equal(t, "fb-2", resolved.ResolvedFallbackProviders[1].ProviderName)
 		assert.Equal(t, "gpt-fallback-2", resolved.ResolvedFallbackProviders[1].Config.Model)
 	})
 

--- a/pkg/config/chain.go
+++ b/pkg/config/chain.go
@@ -34,7 +34,13 @@ type ChainConfig struct {
 	// Chain-level LLM backend override
 	LLMBackend LLMBackend `yaml:"llm_backend,omitempty"`
 
-	// Chain-level fallback providers override
+	// Named catalog list for this chain. Expanded at resolve time. Empty /
+	// omitted inherits the next less-specific layer.
+	FallbackList string `yaml:"fallback_list,omitempty"`
+
+	// Chain-level fallback providers override.
+	// Deprecated: use fallback_lists + fallback_list. Still honored when
+	// fallback_list is unset. Mixing both on this node is a load-time error.
 	FallbackProviders []FallbackProviderEntry `yaml:"fallback_providers,omitempty"`
 
 	// Chain-level max iterations override
@@ -70,7 +76,13 @@ type StageConfig struct {
 	// Stage-level MCP servers override
 	MCPServers []string `yaml:"mcp_servers,omitempty"`
 
-	// Stage-level fallback providers override
+	// Named catalog list for this stage. Expanded at resolve time. Empty /
+	// omitted inherits the next less-specific layer.
+	FallbackList string `yaml:"fallback_list,omitempty"`
+
+	// Stage-level fallback providers override.
+	// Deprecated: use fallback_lists + fallback_list. Still honored when
+	// fallback_list is unset. Mixing both on this node is a load-time error.
 	FallbackProviders []FallbackProviderEntry `yaml:"fallback_providers,omitempty"`
 
 	// Sub-agents available to orchestrator agents in this stage

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -6,6 +6,10 @@ package config
 type Config struct {
 	configDir string // Configuration directory path (for reference)
 
+	// Named fallback lists (catalog). Resolver / validator / viewer read this,
+	// not the YAML struct. Omitted catalog is nil.
+	FallbackLists map[string][]FallbackProviderEntry
+
 	// System-wide defaults
 	Defaults *Defaults
 

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -15,7 +15,13 @@ type Defaults struct {
 	// LLM backend default
 	LLMBackend LLMBackend `yaml:"llm_backend,omitempty"`
 
-	// Ordered list of fallback providers to try when the primary provider fails
+	// Named catalog list to use as the default fallback walk. Expanded at
+	// resolve time. Empty / omitted inherits nothing (this is the root layer).
+	FallbackList string `yaml:"fallback_list,omitempty"`
+
+	// Ordered list of fallback providers to try when the primary provider fails.
+	// Deprecated: use fallback_lists + fallback_list. Still honored when
+	// fallback_list is unset. Mixing both on this node is a load-time error.
 	FallbackProviders []FallbackProviderEntry `yaml:"fallback_providers,omitempty"`
 
 	// Default scoring configuration for all chains.

--- a/pkg/config/fallback.go
+++ b/pkg/config/fallback.go
@@ -1,0 +1,68 @@
+package config
+
+import (
+	"fmt"
+	"slices"
+)
+
+// FallbackLayer is one YAML node's named-list selector plus its deprecated
+// inline fallback_providers slice.
+type FallbackLayer struct {
+	ListName string
+	Inline   []FallbackProviderEntry
+}
+
+// ExpandFallbackLayer expands one YAML node to a slice-or-nil.
+//
+// A non-empty ListName looks up the catalog and always returns a non-nil
+// slice (an empty catalog entry means "no fallback", not inherit). An empty
+// ListName returns Inline as-is (nil inherits; a non-nil empty slice clears).
+// Unknown names return an error.
+func ExpandFallbackLayer(lists map[string][]FallbackProviderEntry, layer FallbackLayer) ([]FallbackProviderEntry, error) {
+	if layer.ListName == "" {
+		return layer.Inline, nil
+	}
+	entries, ok := lists[layer.ListName]
+	if !ok {
+		return nil, fmt.Errorf("unknown fallback list %q", layer.ListName)
+	}
+	if entries == nil {
+		return []FallbackProviderEntry{}, nil
+	}
+	return slices.Clone(entries), nil
+}
+
+// LastNonNilFallback returns the last non-nil fallback list from layers listed
+// in lowest-to-highest precedence order. A non-nil empty slice is an explicit
+// override that clears inherited values. Returns nil when no layer provides a
+// value. The returned slice is a copy.
+func LastNonNilFallback(layers ...[]FallbackProviderEntry) []FallbackProviderEntry {
+	var result []FallbackProviderEntry
+	found := false
+	for _, layer := range layers {
+		if layer != nil {
+			result = layer
+			found = true
+		}
+	}
+	if !found {
+		return nil
+	}
+	if len(result) == 0 {
+		return []FallbackProviderEntry{}
+	}
+	return slices.Clone(result)
+}
+
+// ResolveFallbackLayers expands each layer then applies last-non-nil.
+func ResolveFallbackLayers(lists map[string][]FallbackProviderEntry, layers ...FallbackLayer) ([]FallbackProviderEntry, error) {
+	expanded := make([][]FallbackProviderEntry, len(layers))
+	for i, layer := range layers {
+		got, err := ExpandFallbackLayer(lists, layer)
+		if err != nil {
+			return nil, err
+		}
+		expanded[i] = got
+	}
+	return LastNonNilFallback(expanded...), nil
+}

--- a/pkg/config/fallback_test.go
+++ b/pkg/config/fallback_test.go
@@ -1,0 +1,186 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExpandFallbackLayer(t *testing.T) {
+	t.Parallel()
+
+	catalog := map[string][]FallbackProviderEntry{
+		"premium": {{Provider: "opus"}, {Provider: "sonnet"}},
+		"empty":   {},
+		"null":    nil,
+	}
+
+	tests := []struct {
+		name    string
+		layer   FallbackLayer
+		want    []FallbackProviderEntry
+		wantNil bool
+		wantErr string
+	}{
+		{
+			name:  "named list clones catalog slice",
+			layer: FallbackLayer{ListName: "premium"},
+			want:  []FallbackProviderEntry{{Provider: "opus"}, {Provider: "sonnet"}},
+		},
+		{
+			name:  "empty catalog entry returns non-nil empty",
+			layer: FallbackLayer{ListName: "empty"},
+			want:  []FallbackProviderEntry{},
+		},
+		{
+			name:  "nil catalog entry returns non-nil empty",
+			layer: FallbackLayer{ListName: "null"},
+			want:  []FallbackProviderEntry{},
+		},
+		{
+			name:    "omitted selector returns nil inline",
+			layer:   FallbackLayer{},
+			wantNil: true,
+		},
+		{
+			name:  "omitted selector returns inline as-is",
+			layer: FallbackLayer{Inline: []FallbackProviderEntry{{Provider: "inline"}}},
+			want:  []FallbackProviderEntry{{Provider: "inline"}},
+		},
+		{
+			name:  "empty-string selector inherits inline",
+			layer: FallbackLayer{ListName: "", Inline: []FallbackProviderEntry{{Provider: "inline"}}},
+			want:  []FallbackProviderEntry{{Provider: "inline"}},
+		},
+		{
+			name:    "unknown name",
+			layer:   FallbackLayer{ListName: "nope"},
+			wantErr: `unknown fallback list "nope"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := ExpandFallbackLayer(catalog, tt.layer)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Equal(t, tt.wantErr, err.Error())
+				return
+			}
+			require.NoError(t, err)
+			if tt.wantNil {
+				assert.Nil(t, got)
+				return
+			}
+			assert.Equal(t, tt.want, got)
+			assert.NotNil(t, got)
+		})
+	}
+
+	t.Run("clone is independent of catalog", func(t *testing.T) {
+		t.Parallel()
+		got, err := ExpandFallbackLayer(catalog, FallbackLayer{ListName: "premium"})
+		require.NoError(t, err)
+		require.NotEmpty(t, got)
+		got[0].Provider = "mutated"
+		assert.Equal(t, "opus", catalog["premium"][0].Provider)
+	})
+
+	t.Run("nil catalog with named selector", func(t *testing.T) {
+		t.Parallel()
+		_, err := ExpandFallbackLayer(nil, FallbackLayer{ListName: "premium"})
+		require.Error(t, err)
+		assert.Equal(t, `unknown fallback list "premium"`, err.Error())
+	})
+}
+
+func TestLastNonNilFallback(t *testing.T) {
+	t.Parallel()
+
+	lower := []FallbackProviderEntry{{Provider: "defaults"}}
+	higher := []FallbackProviderEntry{{Provider: "chain"}}
+	empty := []FallbackProviderEntry{}
+
+	assert.Nil(t, LastNonNilFallback(nil, nil))
+	assert.Equal(t, lower, LastNonNilFallback(lower, nil))
+	assert.Equal(t, higher, LastNonNilFallback(lower, higher))
+	assert.NotNil(t, LastNonNilFallback(lower, empty))
+	assert.Empty(t, LastNonNilFallback(lower, empty))
+
+	got := LastNonNilFallback(lower)
+	require.NotEmpty(t, got)
+	got[0].Provider = "mutated"
+	assert.Equal(t, "defaults", lower[0].Provider)
+}
+
+func TestResolveFallbackLayers(t *testing.T) {
+	t.Parallel()
+
+	catalog := map[string][]FallbackProviderEntry{
+		"premium": {{Provider: "opus"}},
+		"mid":     {{Provider: "sonnet"}},
+		"empty":   {},
+	}
+
+	t.Run("last expanded named list wins", func(t *testing.T) {
+		t.Parallel()
+		got, err := ResolveFallbackLayers(catalog,
+			FallbackLayer{ListName: "premium"},
+			FallbackLayer{ListName: "mid"},
+		)
+		require.NoError(t, err)
+		assert.Equal(t, []FallbackProviderEntry{{Provider: "sonnet"}}, got)
+	})
+
+	t.Run("named empty clears inherited", func(t *testing.T) {
+		t.Parallel()
+		got, err := ResolveFallbackLayers(catalog,
+			FallbackLayer{ListName: "premium"},
+			FallbackLayer{ListName: "empty"},
+		)
+		require.NoError(t, err)
+		assert.NotNil(t, got)
+		assert.Empty(t, got)
+	})
+
+	t.Run("inline still works when selector unset", func(t *testing.T) {
+		t.Parallel()
+		inline := []FallbackProviderEntry{{Provider: "inline"}}
+		got, err := ResolveFallbackLayers(catalog,
+			FallbackLayer{Inline: inline},
+			FallbackLayer{},
+		)
+		require.NoError(t, err)
+		assert.Equal(t, inline, got)
+	})
+
+	t.Run("unknown name errors", func(t *testing.T) {
+		t.Parallel()
+		_, err := ResolveFallbackLayers(catalog, FallbackLayer{ListName: "ghost"})
+		require.Error(t, err)
+		assert.Equal(t, `unknown fallback list "ghost"`, err.Error())
+	})
+
+	t.Run("inline at higher layer beats named lower layer", func(t *testing.T) {
+		t.Parallel()
+		inline := []FallbackProviderEntry{{Provider: "inline"}}
+		got, err := ResolveFallbackLayers(catalog,
+			FallbackLayer{ListName: "premium"},
+			FallbackLayer{Inline: inline},
+		)
+		require.NoError(t, err)
+		assert.Equal(t, inline, got)
+	})
+
+	t.Run("named at higher layer beats inline lower layer", func(t *testing.T) {
+		t.Parallel()
+		got, err := ResolveFallbackLayers(catalog,
+			FallbackLayer{Inline: []FallbackProviderEntry{{Provider: "inline"}}},
+			FallbackLayer{ListName: "mid"},
+		)
+		require.NoError(t, err)
+		assert.Equal(t, []FallbackProviderEntry{{Provider: "sonnet"}}, got)
+	})
+}

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
 	"os"
 	"path/filepath"
 	"time"
@@ -15,12 +16,13 @@ import (
 
 // TarsyYAMLConfig represents the complete tarsy.yaml file structure
 type TarsyYAMLConfig struct {
-	System      *SystemYAMLConfig          `yaml:"system"`
-	MCPServers  map[string]MCPServerConfig `yaml:"mcp_servers"`
-	Agents      map[string]AgentConfig     `yaml:"agents"`
-	AgentChains map[string]ChainConfig     `yaml:"agent_chains"`
-	Defaults    *Defaults                  `yaml:"defaults"`
-	Queue       *QueueConfig               `yaml:"queue"`
+	System        *SystemYAMLConfig                  `yaml:"system"`
+	MCPServers    map[string]MCPServerConfig         `yaml:"mcp_servers"`
+	Agents        map[string]AgentConfig             `yaml:"agents"`
+	AgentChains   map[string]ChainConfig             `yaml:"agent_chains"`
+	FallbackLists map[string][]FallbackProviderEntry `yaml:"fallback_lists"`
+	Defaults      *Defaults                          `yaml:"defaults"`
+	Queue         *QueueConfig                       `yaml:"queue"`
 }
 
 // SystemYAMLConfig groups system-wide infrastructure settings.
@@ -235,6 +237,7 @@ func load(_ context.Context, configDir string) (*Config, error) {
 
 	return &Config{
 		configDir:           configDir,
+		FallbackLists:       maps.Clone(tarsyConfig.FallbackLists),
 		Defaults:            defaults,
 		Queue:               queueConfig,
 		GitHub:              githubCfg,

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -1399,6 +1399,86 @@ agent_chains:
 	assert.Equal(t, "fb-agent-3", agentFB[2].Provider)
 }
 
+func TestLoadTarsyYAML_FallbackLists(t *testing.T) {
+	t.Run("catalog and selectors parse onto Config", func(t *testing.T) {
+		dir := t.TempDir()
+		tarsyYAML := `
+fallback_lists:
+  premium:
+    - provider: "fb-opus"
+      backend: "langchain"
+    - provider: "fb-omit"
+  mid:
+    - provider: "fb-sonnet"
+      backend: "google-native"
+  empty: []
+
+defaults:
+  llm_provider: "test-provider"
+  fallback_list: premium
+
+agents:
+  test-agent:
+    mcp_servers: []
+
+agent_chains:
+  test-chain:
+    alert_types: ["test"]
+    fallback_list: mid
+    stages:
+      - name: "stage1"
+        fallback_list: empty
+        agents:
+          - name: "test-agent"
+            fallback_list: premium
+`
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "tarsy.yaml"), []byte(tarsyYAML), 0644))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "llm-providers.yaml"), []byte("llm_providers: {}\n"), 0644))
+
+		cfg, err := load(context.Background(), dir)
+		require.NoError(t, err)
+
+		require.Len(t, cfg.FallbackLists, 3)
+		require.Len(t, cfg.FallbackLists["premium"], 2)
+		assert.Equal(t, "fb-opus", cfg.FallbackLists["premium"][0].Provider)
+		assert.Equal(t, LLMBackendLangChain, cfg.FallbackLists["premium"][0].Backend)
+		assert.Equal(t, "fb-omit", cfg.FallbackLists["premium"][1].Provider)
+		assert.Empty(t, cfg.FallbackLists["premium"][1].Backend)
+		require.Len(t, cfg.FallbackLists["mid"], 1)
+		assert.Equal(t, "fb-sonnet", cfg.FallbackLists["mid"][0].Provider)
+		assert.Equal(t, LLMBackendNativeGemini, cfg.FallbackLists["mid"][0].Backend)
+		require.NotNil(t, cfg.FallbackLists["empty"])
+		assert.Empty(t, cfg.FallbackLists["empty"])
+
+		require.NotNil(t, cfg.Defaults)
+		assert.Equal(t, "premium", cfg.Defaults.FallbackList)
+
+		chain, err := cfg.GetChain("test-chain")
+		require.NoError(t, err)
+		assert.Equal(t, "mid", chain.FallbackList)
+		assert.Equal(t, "empty", chain.Stages[0].FallbackList)
+		assert.Equal(t, "premium", chain.Stages[0].Agents[0].FallbackList)
+	})
+
+	t.Run("omitted catalog is fine", func(t *testing.T) {
+		dir := t.TempDir()
+		tarsyYAML := `
+defaults:
+  llm_provider: "test-provider"
+agents:
+  test-agent:
+    mcp_servers: []
+agent_chains: {}
+`
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "tarsy.yaml"), []byte(tarsyYAML), 0644))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "llm-providers.yaml"), []byte("llm_providers: {}\n"), 0644))
+
+		cfg, err := load(context.Background(), dir)
+		require.NoError(t, err)
+		assert.Empty(t, cfg.FallbackLists)
+	})
+}
+
 func TestLoadAppliesScoringEnabledDefault(t *testing.T) {
 	t.Run("defaults.scoring.enabled injects scoring config for chains without it", func(t *testing.T) {
 		dir := t.TempDir()

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -81,6 +81,7 @@ type StageAgentConfig struct {
 	// Named catalog list for this stage-agent. Expanded at resolve time.
 	// Empty / omitted inherits the next less-specific layer.
 	FallbackList string `yaml:"fallback_list,omitempty"`
+	// Stage-agent fallback providers override.
 	// Deprecated: use fallback_lists + fallback_list. Still honored when
 	// fallback_list is unset. Mixing both on this node is a load-time error.
 	FallbackProviders []FallbackProviderEntry `yaml:"fallback_providers,omitempty"`

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -71,13 +71,18 @@ func BoolPtr(b bool) *bool { return &b }
 // Used in stage.agents[] array (even for single-agent stages)
 // Parallel execution occurs when: len(agents) > 1 OR replicas > 1
 type StageAgentConfig struct {
-	Name              string                  `yaml:"name" validate:"required"`
-	Type              AgentType               `yaml:"type,omitempty"`
-	LLMProvider       string                  `yaml:"llm_provider,omitempty"`
-	LLMBackend        LLMBackend              `yaml:"llm_backend,omitempty"`
-	MaxIterations     *int                    `yaml:"max_iterations,omitempty" validate:"omitempty,min=1"`
-	MCPServers        []string                `yaml:"mcp_servers,omitempty"`
-	SubAgents         SubAgentRefs            `yaml:"sub_agents,omitempty"`
+	Name          string       `yaml:"name" validate:"required"`
+	Type          AgentType    `yaml:"type,omitempty"`
+	LLMProvider   string       `yaml:"llm_provider,omitempty"`
+	LLMBackend    LLMBackend   `yaml:"llm_backend,omitempty"`
+	MaxIterations *int         `yaml:"max_iterations,omitempty" validate:"omitempty,min=1"`
+	MCPServers    []string     `yaml:"mcp_servers,omitempty"`
+	SubAgents     SubAgentRefs `yaml:"sub_agents,omitempty"`
+	// Named catalog list for this stage-agent. Expanded at resolve time.
+	// Empty / omitted inherits the next less-specific layer.
+	FallbackList string `yaml:"fallback_list,omitempty"`
+	// Deprecated: use fallback_lists + fallback_list. Still honored when
+	// fallback_list is unset. Mixing both on this node is a load-time error.
 	FallbackProviders []FallbackProviderEntry `yaml:"fallback_providers,omitempty"`
 	// RequiredSkills and Skills are additive with the agent definition (merged at resolve time, deduplicated).
 	RequiredSkills []string `yaml:"required_skills,omitempty"`

--- a/pkg/config/validator.go
+++ b/pkg/config/validator.go
@@ -22,8 +22,8 @@ func NewValidator(cfg *Config) *Validator {
 
 // ValidateAll performs comprehensive validation (fail-fast - stops at first error)
 func (v *Validator) ValidateAll() error {
-	// Validate in order: queue → agents → MCP servers → LLM providers → chains
-	// This ensures dependencies are validated before dependents
+	// Validate in order: queue → agents → MCP servers → fallback lists →
+	// LLM providers → chains. Dependencies are validated before dependents.
 
 	if err := v.validateQueue(); err != nil {
 		return fmt.Errorf("queue validation failed: %w", err)
@@ -41,6 +41,10 @@ func (v *Validator) ValidateAll() error {
 		return fmt.Errorf("MCP server validation failed: %w", err)
 	}
 
+	if err := v.validateNamedFallbackLists(); err != nil {
+		return fmt.Errorf("fallback list validation failed: %w", err)
+	}
+
 	if err := v.validateLLMProviders(); err != nil {
 		return fmt.Errorf("LLM provider validation failed: %w", err)
 	}
@@ -50,6 +54,7 @@ func (v *Validator) ValidateAll() error {
 	}
 
 	v.warnNativeToolAgentsWithoutCompatibleFallback()
+	v.warnDeprecatedFallbackProviders()
 
 	if err := v.validateDefaults(); err != nil {
 		return fmt.Errorf("defaults validation failed: %w", err)
@@ -785,6 +790,8 @@ func (v *Validator) collectReferencedLLMProviders() map[string]bool {
 		}
 	}
 
+	v.addReferencedFallbackListProviders(referenced)
+
 	if v.cfg.MCPServerRegistry != nil {
 		for _, server := range v.cfg.MCPServerRegistry.GetAll() {
 			if server.Summarization != nil && server.Summarization.LLMProvider != "" {
@@ -951,31 +958,182 @@ func missingProviderEnvVar(provider *LLMProviderConfig) string {
 func (v *Validator) validateFallbackProviders(entries []FallbackProviderEntry, section, name, field string) error {
 	for i, entry := range entries {
 		entryRef := fmt.Sprintf("%s[%d]", field, i)
-
-		// Provider must exist in the registry
-		if !v.cfg.LLMProviderRegistry.Has(entry.Provider) {
-			return NewValidationError(section, name, entryRef,
-				fmt.Errorf("LLM provider '%s' not found", entry.Provider))
+		if err := v.validateFallbackEntryStructure(entry, section, name, entryRef); err != nil {
+			return err
 		}
-
-		// Backend must be valid (omitted defaults to langchain)
-		if !entry.ResolvedBackend().IsValid() {
-			return NewValidationError(section, name, entryRef,
-				fmt.Errorf("invalid LLM backend: %s", entry.Backend))
-		}
-		if err := v.googleNativeRequiresGoogleProvider(entry.Provider, entry.Backend); err != nil {
-			return NewValidationError(section, name, entryRef, err)
-		}
-
-		// Credentials must be set
-		provider, _ := v.cfg.LLMProviderRegistry.Get(entry.Provider)
-		if missing := missingProviderEnvVar(provider); missing != "" {
-			return NewValidationError(section, name, entryRef,
-				fmt.Errorf("environment variable %s is not set (required by fallback provider '%s')",
-					missing, entry.Provider))
+		if err := v.validateFallbackEntryCredentials(entry, section, name, entryRef); err != nil {
+			return err
 		}
 	}
 	return nil
+}
+
+func (v *Validator) validateFallbackEntryStructure(entry FallbackProviderEntry, section, name, field string) error {
+	if v.cfg.LLMProviderRegistry == nil || !v.cfg.LLMProviderRegistry.Has(entry.Provider) {
+		return NewValidationError(section, name, field,
+			fmt.Errorf("LLM provider '%s' not found", entry.Provider))
+	}
+	if !entry.ResolvedBackend().IsValid() {
+		return NewValidationError(section, name, field,
+			fmt.Errorf("invalid LLM backend: %s", entry.Backend))
+	}
+	if err := v.googleNativeRequiresGoogleProvider(entry.Provider, entry.Backend); err != nil {
+		return NewValidationError(section, name, field, err)
+	}
+	return nil
+}
+
+func (v *Validator) validateFallbackEntryCredentials(entry FallbackProviderEntry, section, name, field string) error {
+	if v.cfg.LLMProviderRegistry == nil {
+		return nil
+	}
+	provider, err := v.cfg.LLMProviderRegistry.Get(entry.Provider)
+	if err != nil {
+		return nil
+	}
+	if missing := missingProviderEnvVar(provider); missing != "" {
+		return NewValidationError(section, name, field,
+			fmt.Errorf("environment variable %s is not set (required by fallback provider '%s')",
+				missing, entry.Provider))
+	}
+	return nil
+}
+
+// validateNamedFallbackLists structure-validates every catalog entry, credential-
+// checks referenced lists, and rejects unknown names and mixed selector+inline
+// on the four existing layers (defaults, chain, stage, stage-agent).
+func (v *Validator) validateNamedFallbackLists() error {
+	referenced := v.referencedFallbackListNames()
+
+	for listName, entries := range v.cfg.FallbackLists {
+		if listName == "" {
+			return NewValidationError("fallback_lists", "", "",
+				fmt.Errorf("fallback list name must be non-empty"))
+		}
+		for i, entry := range entries {
+			entryRef := fmt.Sprintf("[%d]", i)
+			if err := v.validateFallbackEntryStructure(entry, "fallback_lists", listName, entryRef); err != nil {
+				return err
+			}
+			if referenced[listName] {
+				if err := v.validateFallbackEntryCredentials(entry, "fallback_lists", listName, entryRef); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	if v.cfg.Defaults != nil {
+		if err := v.validateFallbackSelector(v.cfg.Defaults.FallbackList, v.cfg.Defaults.FallbackProviders,
+			"defaults", "", "fallback_list"); err != nil {
+			return err
+		}
+	}
+
+	if v.cfg.ChainRegistry == nil {
+		return nil
+	}
+	for chainID, chain := range v.cfg.ChainRegistry.GetAll() {
+		if err := v.validateFallbackSelector(chain.FallbackList, chain.FallbackProviders,
+			"chain", chainID, "fallback_list"); err != nil {
+			return err
+		}
+		for i, stage := range chain.Stages {
+			stageRef := fmt.Sprintf("chain '%s' stage %d", chainID, i)
+			if err := v.validateFallbackSelector(stage.FallbackList, stage.FallbackProviders,
+				stageRef, "", "fallback_list"); err != nil {
+				return err
+			}
+			for _, agent := range stage.Agents {
+				if err := v.validateFallbackSelector(agent.FallbackList, agent.FallbackProviders,
+					stageRef, agent.Name, "fallback_list"); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (v *Validator) validateFallbackSelector(listName string, inline []FallbackProviderEntry, section, name, field string) error {
+	if listName != "" && inline != nil {
+		return NewValidationError(section, name, field,
+			fmt.Errorf("cannot set both fallback_list and fallback_providers"))
+	}
+	if listName == "" {
+		return nil
+	}
+	if _, ok := v.cfg.FallbackLists[listName]; !ok {
+		return NewValidationError(section, name, field,
+			fmt.Errorf("unknown fallback list %q", listName))
+	}
+	return nil
+}
+
+// referencedFallbackListNames returns every non-empty fallback_list selector on
+// the four existing layers. A default list named in YAML is referenced even if
+// every chain overrides it.
+func (v *Validator) referencedFallbackListNames() map[string]bool {
+	referenced := make(map[string]bool)
+	add := func(name string) {
+		if name != "" {
+			referenced[name] = true
+		}
+	}
+	if v.cfg.Defaults != nil {
+		add(v.cfg.Defaults.FallbackList)
+	}
+	if v.cfg.ChainRegistry == nil {
+		return referenced
+	}
+	for _, chain := range v.cfg.ChainRegistry.GetAll() {
+		add(chain.FallbackList)
+		for _, stage := range chain.Stages {
+			add(stage.FallbackList)
+			for _, agent := range stage.Agents {
+				add(agent.FallbackList)
+			}
+		}
+	}
+	return referenced
+}
+
+func (v *Validator) addReferencedFallbackListProviders(referenced map[string]bool) {
+	if v.cfg.FallbackLists == nil {
+		return
+	}
+	for listName := range v.referencedFallbackListNames() {
+		for _, entry := range v.cfg.FallbackLists[listName] {
+			if entry.Provider != "" {
+				referenced[entry.Provider] = true
+			}
+		}
+	}
+}
+
+func (v *Validator) warnDeprecatedFallbackProviders() {
+	const msg = "fallback_providers is deprecated; use fallback_lists and fallback_list"
+	if v.cfg.Defaults != nil && v.cfg.Defaults.FallbackProviders != nil {
+		slog.Warn(msg, "location", "defaults")
+	}
+	if v.cfg.ChainRegistry == nil {
+		return
+	}
+	for chainID, chain := range v.cfg.ChainRegistry.GetAll() {
+		if chain.FallbackProviders != nil {
+			slog.Warn(msg, "location", "chain", "chain", chainID)
+		}
+		for _, stage := range chain.Stages {
+			if stage.FallbackProviders != nil {
+				slog.Warn(msg, "location", "stage", "chain", chainID, "stage", stage.Name)
+			}
+			for _, agent := range stage.Agents {
+				if agent.FallbackProviders != nil {
+					slog.Warn(msg, "location", "stage-agent", "chain", chainID, "stage", stage.Name, "agent", agent.Name)
+				}
+			}
+		}
+	}
 }
 
 func (v *Validator) validateRunbooks() error {
@@ -1190,33 +1348,47 @@ func (v *Validator) validateSkills() error {
 // require native tools but have no google-native fallback entry in their
 // effective fallback list. Logs a warning for each such case. Non-blocking.
 func (v *Validator) warnNativeToolAgentsWithoutCompatibleFallback() {
-	var defaultsFallback []FallbackProviderEntry
+	if v.cfg.ChainRegistry == nil {
+		return
+	}
+
+	var defaultsLayer FallbackLayer
 	if v.cfg.Defaults != nil {
-		defaultsFallback = v.cfg.Defaults.FallbackProviders
+		defaultsLayer = FallbackLayer{
+			ListName: v.cfg.Defaults.FallbackList,
+			Inline:   v.cfg.Defaults.FallbackProviders,
+		}
 	}
 
 	for chainID, chain := range v.cfg.ChainRegistry.GetAll() {
-		// Check stage agents
+		chainLayer := FallbackLayer{ListName: chain.FallbackList, Inline: chain.FallbackProviders}
 		for _, stage := range chain.Stages {
+			stageLayer := FallbackLayer{ListName: stage.FallbackList, Inline: stage.FallbackProviders}
 			for _, agentCfg := range stage.Agents {
-				v.warnIfNativeAgentLacksFallback(chainID, agentCfg.Name,
-					defaultsFallback, chain.FallbackProviders,
-					stage.FallbackProviders, agentCfg.FallbackProviders)
+				effective, err := ResolveFallbackLayers(v.cfg.FallbackLists, defaultsLayer, chainLayer, stageLayer,
+					FallbackLayer{ListName: agentCfg.FallbackList, Inline: agentCfg.FallbackProviders})
+				if err != nil {
+					continue
+				}
+				v.warnIfNativeAgentLacksFallback(chainID, agentCfg.Name, effective)
 			}
 		}
 
-		// Check chain-level sub-agents (orchestrator dispatch targets)
+		// Chain-level sub-agents (orchestrator dispatch targets): defaults → chain only.
 		for _, ref := range chain.SubAgents {
-			v.warnIfNativeAgentLacksFallback(chainID, ref.Name,
-				defaultsFallback, chain.FallbackProviders, nil, nil)
+			effective, err := ResolveFallbackLayers(v.cfg.FallbackLists, defaultsLayer, chainLayer)
+			if err != nil {
+				continue
+			}
+			v.warnIfNativeAgentLacksFallback(chainID, ref.Name, effective)
 		}
 	}
 }
 
-func (v *Validator) warnIfNativeAgentLacksFallback(
-	chainID, agentName string,
-	defaultsFallback, chainFallback, stageFallback, agentFallback []FallbackProviderEntry,
-) {
+func (v *Validator) warnIfNativeAgentLacksFallback(chainID, agentName string, effective []FallbackProviderEntry) {
+	if v.cfg.AgentRegistry == nil {
+		return
+	}
 	agentDef, err := v.cfg.AgentRegistry.Get(agentName)
 	if err != nil {
 		return
@@ -1226,9 +1398,6 @@ func (v *Validator) warnIfNativeAgentLacksFallback(
 		return
 	}
 
-	// Resolve effective fallback list using the same precedence as runtime:
-	// last non-nil wins (defaults → chain → stage → agent)
-	effective := resolveEffectiveFallback(defaultsFallback, chainFallback, stageFallback, agentFallback)
 	if len(effective) == 0 {
 		return
 	}
@@ -1253,16 +1422,4 @@ func agentHasEnabledNativeTools(nativeTools map[GoogleNativeTool]bool) bool {
 		}
 	}
 	return false
-}
-
-// resolveEffectiveFallback returns the last non-nil fallback list, mirroring
-// the runtime resolution logic in pkg/agent/config_resolver.go.
-func resolveEffectiveFallback(layers ...[]FallbackProviderEntry) []FallbackProviderEntry {
-	var result []FallbackProviderEntry
-	for _, layer := range layers {
-		if layer != nil {
-			result = layer
-		}
-	}
-	return result
 }

--- a/pkg/config/validator_test.go
+++ b/pkg/config/validator_test.go
@@ -4266,6 +4266,46 @@ func TestCollectReferencedLLMProviders_IncludesFallbackAndSubAgents(t *testing.T
 	assert.True(t, referenced["agent-subagent"], "agent sub-agent provider should be referenced")
 }
 
+func TestCollectReferencedLLMProviders_NamedFallbackLists(t *testing.T) {
+	cfg := &Config{
+		Defaults: &Defaults{
+			FallbackList: "premium",
+		},
+		FallbackLists: map[string][]FallbackProviderEntry{
+			"premium": {{Provider: "catalog-referenced"}},
+			"spare":   {{Provider: "catalog-unused"}},
+		},
+		AgentRegistry:       NewAgentRegistry(map[string]*AgentConfig{"TestAgent": {}}),
+		LLMProviderRegistry: NewLLMProviderRegistry(map[string]*LLMProviderConfig{}),
+		MCPServerRegistry:   NewMCPServerRegistry(map[string]*MCPServerConfig{}),
+		ChainRegistry: NewChainRegistry(map[string]*ChainConfig{
+			"chain1": {
+				AlertTypes:   []string{"test"},
+				FallbackList: "mid",
+				Stages: []StageConfig{{
+					Name:         "s1",
+					FallbackList: "stage-list",
+					Agents: []StageAgentConfig{{
+						Name:         "TestAgent",
+						FallbackList: "agent-list",
+					}},
+				}},
+			},
+		}),
+	}
+	cfg.FallbackLists["mid"] = []FallbackProviderEntry{{Provider: "chain-catalog"}}
+	cfg.FallbackLists["stage-list"] = []FallbackProviderEntry{{Provider: "stage-catalog"}}
+	cfg.FallbackLists["agent-list"] = []FallbackProviderEntry{{Provider: "agent-catalog"}}
+
+	referenced := NewValidator(cfg).collectReferencedLLMProviders()
+
+	assert.True(t, referenced["catalog-referenced"])
+	assert.True(t, referenced["chain-catalog"])
+	assert.True(t, referenced["stage-catalog"])
+	assert.True(t, referenced["agent-catalog"])
+	assert.False(t, referenced["catalog-unused"])
+}
+
 func TestValidateLLMProviders_SummarizationOverlayMissingAPIKey(t *testing.T) {
 	cfg := &Config{
 		Queue:    DefaultQueueConfig(),
@@ -4901,5 +4941,413 @@ func TestWarnNativeToolAgentsWithoutCompatibleFallback(t *testing.T) {
 
 		assert.Contains(t, buf.String(), "native-tool agent with no compatible fallback")
 		assert.Contains(t, buf.String(), "CodeExecutor")
+	})
+
+	t.Run("warns when named list has only langchain entries", func(t *testing.T) {
+		buf, restore := captureLogs(t)
+		t.Cleanup(restore)
+
+		cfg := &Config{
+			Defaults: &Defaults{FallbackList: "langchain-only"},
+			FallbackLists: map[string][]FallbackProviderEntry{
+				"langchain-only": {{Provider: "openai-fb", Backend: LLMBackendLangChain}},
+			},
+			AgentRegistry: NewAgentRegistry(map[string]*AgentConfig{
+				"WebResearcher": {
+					NativeTools: map[GoogleNativeTool]bool{
+						GoogleNativeToolGoogleSearch: true,
+					},
+				},
+			}),
+			ChainRegistry: NewChainRegistry(map[string]*ChainConfig{
+				"test-chain": {
+					Stages: []StageConfig{
+						{Name: "s1", Agents: []StageAgentConfig{{Name: "WebResearcher"}}},
+					},
+				},
+			}),
+		}
+		v := NewValidator(cfg)
+		v.warnNativeToolAgentsWithoutCompatibleFallback()
+
+		assert.Contains(t, buf.String(), "native-tool agent with no compatible fallback")
+		assert.Contains(t, buf.String(), "WebResearcher")
+	})
+
+	t.Run("no warning when named list includes google-native entry", func(t *testing.T) {
+		buf, restore := captureLogs(t)
+		t.Cleanup(restore)
+
+		cfg := &Config{
+			Defaults: &Defaults{FallbackList: "google-native"},
+			FallbackLists: map[string][]FallbackProviderEntry{
+				"google-native": {{Provider: "google-fb", Backend: LLMBackendNativeGemini}},
+			},
+			AgentRegistry: NewAgentRegistry(map[string]*AgentConfig{
+				"WebResearcher": {
+					NativeTools: map[GoogleNativeTool]bool{
+						GoogleNativeToolGoogleSearch: true,
+					},
+				},
+			}),
+			ChainRegistry: NewChainRegistry(map[string]*ChainConfig{
+				"test-chain": {
+					Stages: []StageConfig{
+						{Name: "s1", Agents: []StageAgentConfig{{Name: "WebResearcher"}}},
+					},
+				},
+			}),
+		}
+		v := NewValidator(cfg)
+		v.warnNativeToolAgentsWithoutCompatibleFallback()
+
+		assert.NotContains(t, buf.String(), "native-tool agent with no compatible fallback")
+	})
+}
+
+func TestValidateNamedFallbackLists(t *testing.T) {
+	baseAgents := map[string]*AgentConfig{"TestAgent": {}}
+	baseChains := map[string]*ChainConfig{
+		"chain1": {
+			AlertTypes: []string{"test"},
+			Stages:     []StageConfig{{Name: "s1", Agents: []StageAgentConfig{{Name: "TestAgent"}}}},
+		},
+	}
+	providers := map[string]*LLMProviderConfig{
+		"fb-1": {Type: LLMProviderTypeGoogle, Model: "gemini", APIKeyEnv: "FB_KEY"},
+		"fb-2": {Type: LLMProviderTypeOpenAI, Model: "gpt-5", APIKeyEnv: "UNUSED_KEY"},
+	}
+
+	tests := []struct {
+		name    string
+		cfg     func() *Config
+		env     map[string]string
+		wantErr string
+		alsoLLM bool
+	}{
+		{
+			name: "unknown list name",
+			cfg: func() *Config {
+				return &Config{
+					Defaults:            &Defaults{FallbackList: "ghost"},
+					FallbackLists:       map[string][]FallbackProviderEntry{},
+					AgentRegistry:       NewAgentRegistry(baseAgents),
+					LLMProviderRegistry: NewLLMProviderRegistry(providers),
+					ChainRegistry:       NewChainRegistry(baseChains),
+				}
+			},
+			wantErr: `defaults '': field 'fallback_list': unknown fallback list "ghost"`,
+		},
+		{
+			name: "typo provider in unused list still fails",
+			cfg: func() *Config {
+				return &Config{
+					Defaults: &Defaults{},
+					FallbackLists: map[string][]FallbackProviderEntry{
+						"spare": {{Provider: "ghost"}},
+					},
+					AgentRegistry:       NewAgentRegistry(baseAgents),
+					LLMProviderRegistry: NewLLMProviderRegistry(providers),
+					ChainRegistry:       NewChainRegistry(baseChains),
+				}
+			},
+			wantErr: "fallback_lists 'spare': field '[0]': LLM provider 'ghost' not found",
+		},
+		{
+			name: "missing creds fail on referenced list",
+			cfg: func() *Config {
+				return &Config{
+					Defaults: &Defaults{FallbackList: "premium"},
+					FallbackLists: map[string][]FallbackProviderEntry{
+						"premium": {{Provider: "fb-1"}},
+					},
+					AgentRegistry:       NewAgentRegistry(baseAgents),
+					LLMProviderRegistry: NewLLMProviderRegistry(providers),
+					ChainRegistry:       NewChainRegistry(baseChains),
+				}
+			},
+			wantErr: "fallback_lists 'premium': field '[0]': environment variable FB_KEY is not set (required by fallback provider 'fb-1')",
+		},
+		{
+			name: "missing creds on unused list pass",
+			cfg: func() *Config {
+				return &Config{
+					Defaults: &Defaults{},
+					FallbackLists: map[string][]FallbackProviderEntry{
+						"spare": {{Provider: "fb-2"}},
+					},
+					AgentRegistry:       NewAgentRegistry(baseAgents),
+					LLMProviderRegistry: NewLLMProviderRegistry(providers),
+					MCPServerRegistry:   NewMCPServerRegistry(map[string]*MCPServerConfig{}),
+					ChainRegistry:       NewChainRegistry(baseChains),
+				}
+			},
+			alsoLLM: true,
+		},
+		{
+			name: "both fields on defaults including empty inline",
+			cfg: func() *Config {
+				return &Config{
+					Defaults: &Defaults{
+						FallbackList:      "premium",
+						FallbackProviders: []FallbackProviderEntry{},
+					},
+					FallbackLists: map[string][]FallbackProviderEntry{
+						"premium": {{Provider: "fb-1"}},
+					},
+					AgentRegistry:       NewAgentRegistry(baseAgents),
+					LLMProviderRegistry: NewLLMProviderRegistry(providers),
+					ChainRegistry:       NewChainRegistry(baseChains),
+				}
+			},
+			env:     map[string]string{"FB_KEY": "secret"},
+			wantErr: "defaults '': field 'fallback_list': cannot set both fallback_list and fallback_providers",
+		},
+		{
+			name: "both fields on chain",
+			cfg: func() *Config {
+				return &Config{
+					Defaults: &Defaults{},
+					FallbackLists: map[string][]FallbackProviderEntry{
+						"premium": {{Provider: "fb-1"}},
+					},
+					AgentRegistry:       NewAgentRegistry(baseAgents),
+					LLMProviderRegistry: NewLLMProviderRegistry(providers),
+					ChainRegistry: NewChainRegistry(map[string]*ChainConfig{
+						"chain1": {
+							AlertTypes:        []string{"test"},
+							FallbackList:      "premium",
+							FallbackProviders: []FallbackProviderEntry{{Provider: "fb-1"}},
+							Stages:            []StageConfig{{Name: "s1", Agents: []StageAgentConfig{{Name: "TestAgent"}}}},
+						},
+					}),
+				}
+			},
+			env:     map[string]string{"FB_KEY": "secret"},
+			wantErr: "chain 'chain1': field 'fallback_list': cannot set both fallback_list and fallback_providers",
+		},
+		{
+			name: "empty named list is valid",
+			cfg: func() *Config {
+				return &Config{
+					Defaults: &Defaults{FallbackList: "empty"},
+					FallbackLists: map[string][]FallbackProviderEntry{
+						"empty": {},
+					},
+					AgentRegistry:       NewAgentRegistry(baseAgents),
+					LLMProviderRegistry: NewLLMProviderRegistry(providers),
+					ChainRegistry:       NewChainRegistry(baseChains),
+				}
+			},
+		},
+		{
+			name: "empty catalog key is rejected",
+			cfg: func() *Config {
+				return &Config{
+					Defaults: &Defaults{},
+					FallbackLists: map[string][]FallbackProviderEntry{
+						"": {{Provider: "fb-1"}},
+					},
+					AgentRegistry:       NewAgentRegistry(baseAgents),
+					LLMProviderRegistry: NewLLMProviderRegistry(providers),
+					ChainRegistry:       NewChainRegistry(baseChains),
+				}
+			},
+			env:     map[string]string{"FB_KEY": "secret"},
+			wantErr: "fallback_lists '': fallback list name must be non-empty",
+		},
+		{
+			name: "valid named default list",
+			cfg: func() *Config {
+				return &Config{
+					Defaults: &Defaults{FallbackList: "premium"},
+					FallbackLists: map[string][]FallbackProviderEntry{
+						"premium": {{Provider: "fb-1", Backend: LLMBackendNativeGemini}},
+						"spare":   {{Provider: "fb-2"}},
+					},
+					AgentRegistry:       NewAgentRegistry(baseAgents),
+					LLMProviderRegistry: NewLLMProviderRegistry(providers),
+					MCPServerRegistry:   NewMCPServerRegistry(map[string]*MCPServerConfig{}),
+					ChainRegistry:       NewChainRegistry(baseChains),
+				}
+			},
+			env:     map[string]string{"FB_KEY": "secret"},
+			alsoLLM: true,
+		},
+		{
+			name: "defaults list still needs creds when every chain overrides",
+			cfg: func() *Config {
+				return &Config{
+					Defaults: &Defaults{FallbackList: "premium"},
+					FallbackLists: map[string][]FallbackProviderEntry{
+						"premium": {{Provider: "fb-1"}},
+						"mid":     {{Provider: "fb-2"}},
+					},
+					AgentRegistry:       NewAgentRegistry(baseAgents),
+					LLMProviderRegistry: NewLLMProviderRegistry(providers),
+					ChainRegistry: NewChainRegistry(map[string]*ChainConfig{
+						"chain1": {
+							AlertTypes:   []string{"test"},
+							FallbackList: "mid",
+							Stages:       []StageConfig{{Name: "s1", Agents: []StageAgentConfig{{Name: "TestAgent"}}}},
+						},
+					}),
+				}
+			},
+			env:     map[string]string{"UNUSED_KEY": "secret"},
+			wantErr: "fallback_lists 'premium': field '[0]': environment variable FB_KEY is not set (required by fallback provider 'fb-1')",
+		},
+		{
+			name: "google-native on unused non-google list fails structure",
+			cfg: func() *Config {
+				return &Config{
+					Defaults: &Defaults{},
+					FallbackLists: map[string][]FallbackProviderEntry{
+						"spare": {{Provider: "fb-2", Backend: LLMBackendNativeGemini}},
+					},
+					AgentRegistry:       NewAgentRegistry(baseAgents),
+					LLMProviderRegistry: NewLLMProviderRegistry(providers),
+					ChainRegistry:       NewChainRegistry(baseChains),
+				}
+			},
+			wantErr: `fallback_lists 'spare': field '[0]': llm_backend "google-native" requires a google provider, got type "openai" for "fb-2"`,
+		},
+		{
+			name: "invalid backend in unused list fails structure",
+			cfg: func() *Config {
+				return &Config{
+					Defaults: &Defaults{},
+					FallbackLists: map[string][]FallbackProviderEntry{
+						"spare": {{Provider: "fb-2", Backend: "bad"}},
+					},
+					AgentRegistry:       NewAgentRegistry(baseAgents),
+					LLMProviderRegistry: NewLLMProviderRegistry(providers),
+					ChainRegistry:       NewChainRegistry(baseChains),
+				}
+			},
+			wantErr: "fallback_lists 'spare': field '[0]': invalid LLM backend: bad",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for k, v := range tt.env {
+				t.Setenv(k, v)
+			}
+			v := NewValidator(tt.cfg())
+			err := v.validateNamedFallbackLists()
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Equal(t, tt.wantErr, err.Error())
+				return
+			}
+			require.NoError(t, err)
+			if tt.alsoLLM {
+				require.NoError(t, v.validateLLMProviders())
+			}
+		})
+	}
+}
+
+func TestWarnDeprecatedFallbackProviders(t *testing.T) {
+	captureLogs := func(t *testing.T) (*bytes.Buffer, func()) {
+		t.Helper()
+		var buf bytes.Buffer
+		old := slog.Default()
+		slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+		return &buf, func() { slog.SetDefault(old) }
+	}
+
+	t.Run("warns for defaults including empty slice", func(t *testing.T) {
+		buf, restore := captureLogs(t)
+		t.Cleanup(restore)
+
+		cfg := &Config{
+			Defaults: &Defaults{
+				FallbackProviders: []FallbackProviderEntry{},
+			},
+			ChainRegistry: NewChainRegistry(map[string]*ChainConfig{}),
+		}
+		NewValidator(cfg).warnDeprecatedFallbackProviders()
+
+		assert.Contains(t, buf.String(), "fallback_providers is deprecated")
+		assert.Contains(t, buf.String(), "defaults")
+	})
+
+	t.Run("warns for chain stage and stage-agent", func(t *testing.T) {
+		buf, restore := captureLogs(t)
+		t.Cleanup(restore)
+
+		cfg := &Config{
+			ChainRegistry: NewChainRegistry(map[string]*ChainConfig{
+				"c1": {
+					FallbackProviders: []FallbackProviderEntry{{Provider: "x"}},
+					Stages: []StageConfig{{
+						Name:              "s1",
+						FallbackProviders: []FallbackProviderEntry{{Provider: "y"}},
+						Agents: []StageAgentConfig{{
+							Name:              "A",
+							FallbackProviders: []FallbackProviderEntry{{Provider: "z"}},
+						}},
+					}},
+				},
+			}),
+		}
+		NewValidator(cfg).warnDeprecatedFallbackProviders()
+
+		logs := buf.String()
+		assert.Contains(t, logs, "fallback_providers is deprecated")
+		assert.Contains(t, logs, "chain=c1")
+		assert.Contains(t, logs, "stage=s1")
+		assert.Contains(t, logs, "agent=A")
+	})
+
+	t.Run("no warning when only fallback_list is set", func(t *testing.T) {
+		buf, restore := captureLogs(t)
+		t.Cleanup(restore)
+
+		cfg := &Config{
+			Defaults:      &Defaults{FallbackList: "premium"},
+			ChainRegistry: NewChainRegistry(map[string]*ChainConfig{}),
+		}
+		NewValidator(cfg).warnDeprecatedFallbackProviders()
+
+		assert.NotContains(t, buf.String(), "fallback_providers is deprecated")
+	})
+}
+
+func TestValidateAll_NamedFallbackLists(t *testing.T) {
+	minimal := func(fallbackList string, lists map[string][]FallbackProviderEntry) *Config {
+		return &Config{
+			Queue:         DefaultQueueConfig(),
+			Defaults:      &Defaults{FallbackList: fallbackList},
+			FallbackLists: lists,
+			AgentRegistry: NewAgentRegistry(map[string]*AgentConfig{"TestAgent": {}}),
+			LLMProviderRegistry: NewLLMProviderRegistry(map[string]*LLMProviderConfig{
+				"fb-1": {Type: LLMProviderTypeGoogle, Model: "gemini", APIKeyEnv: "FB_KEY"},
+			}),
+			MCPServerRegistry: NewMCPServerRegistry(map[string]*MCPServerConfig{}),
+			ChainRegistry: NewChainRegistry(map[string]*ChainConfig{
+				"chain1": {
+					AlertTypes: []string{"test"},
+					Stages:     []StageConfig{{Name: "s1", Agents: []StageAgentConfig{{Name: "TestAgent"}}}},
+				},
+			}),
+		}
+	}
+
+	t.Run("unknown list name fails ValidateAll", func(t *testing.T) {
+		err := NewValidator(minimal("ghost", map[string][]FallbackProviderEntry{})).ValidateAll()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "fallback list validation failed")
+		assert.Contains(t, err.Error(), `unknown fallback list "ghost"`)
+	})
+
+	t.Run("valid named list passes ValidateAll", func(t *testing.T) {
+		t.Setenv("FB_KEY", "secret")
+		err := NewValidator(minimal("premium", map[string][]FallbackProviderEntry{
+			"premium": {{Provider: "fb-1"}},
+		})).ValidateAll()
+		require.NoError(t, err)
 	})
 }

--- a/proto/llm_service.pb.go
+++ b/proto/llm_service.pb.go
@@ -7,11 +7,12 @@
 package llmv1
 
 import (
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (

--- a/proto/llm_service_grpc.pb.go
+++ b/proto/llm_service_grpc.pb.go
@@ -8,6 +8,7 @@ package llmv1
 
 import (
 	context "context"
+
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"


### PR DESCRIPTION
- Bind executions to a named catalog list via fallback_list on defaults, chain, stage, and stage-agent
- Keep deprecated fallback_providers with a startup warning; mixing both fields on one node is a load error
- Credential-check only referenced catalog lists; structure-validate every entry


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reusable, named fallback lists across defaults, agents, chains, stages, chats, scoring, summaries, and compositions.
  * Added inheritance, precedence, explicit clearing, and provider/backend resolution for fallback lists.
  * Added validation for list references, providers, credentials, backends, and native-tool requirements.
  * Added comprehensive design documentation and configuration-loading support.

* **Bug Fixes**
  * Improved fallback resolution consistency across configuration layers.
  * Added clear errors for unknown lists and conflicting fallback settings.

* **Deprecations**
  * Legacy inline fallback provider settings remain supported but now produce warnings and cannot be combined with named lists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->