### PR TITLE
fix(llm): avoid tool_choice none on Claude forced conclusion

### DIFF
--- a/docs/adr/0026-prompt-caching.md
+++ b/docs/adr/0026-prompt-caching.md
@@ -119,6 +119,8 @@ flowchart TD
 
 Do **not** set the flag true for every iterating-controller Generate. Gate the loop and forced-conclusion calls on agent type ≠ action. Forced conclusion is eligible for **reads** of the looping prefix; calling is disabled via `disable_tool_calls`.
 
+`disable_tool_calls` maps to LangChain `tool_choice="none"` for OpenAI/xAI-style providers only. Anthropic's `tool_choice` schema has no `"none"`; `langchain_anthropic`/`langchain_google_vertexai` treat any non-`any`/`auto` string as a forced tool *name*, which the Anthropic API rejects once thinking is enabled ("Thinking may not be enabled when tool_choice forces tool use." — hard 400 on Vertex Claude, silently dropped with a warning on direct Anthropic). For Claude/Vertex Claude, leave `tool_choice` unset (default `auto`) on forced conclusion; the forced-conclusion prompt is what steers the model to answer in text instead of calling a tool.
+
 ### Claude / Vertex Claude
 
 When `prompt_cache` is set and the LangChain model is Anthropic or Vertex Claude:

--- a/llm-service/llm/providers/langchain_provider.py
+++ b/llm-service/llm/providers/langchain_provider.py
@@ -99,6 +99,7 @@ class LangChainProvider(LLMProvider):
                 model = self._bind_tools(
                     model, list(tools), cache_kind, strip_ttl,
                     disable_tool_calls=disable_tool_calls,
+                    is_anthropic=prompt_cache.is_anthropic_claude(config),
                 )
         if cache_kind in (
             prompt_cache.OPENAI_EXPLICIT,
@@ -368,6 +369,7 @@ class LangChainProvider(LLMProvider):
         cache_kind: str = prompt_cache.NONE,
         strip_ttl: bool = False,
         disable_tool_calls: bool = False,
+        is_anthropic: bool = False,
     ):
         """Bind MCP tools to the model via LangChain's bind_tools()."""
         langchain_tools = []
@@ -400,7 +402,14 @@ class LangChainProvider(LLMProvider):
                 langchain_tools.append(item)
         if langchain_tools:
             bind_kwargs = {}
-            if disable_tool_calls:
+            # "none" is an OpenAI-only tool_choice value. Anthropic's schema only
+            # knows "auto" / "any" / a forced tool name, so langchain_anthropic
+            # and langchain_google_vertexai treat "none" as a tool name to force —
+            # combined with Claude's always-on thinking, the API rejects that as
+            # "Thinking may not be enabled when tool_choice forces tool use."
+            # Leave tool_choice unset (default "auto") for Anthropic; the forced
+            # conclusion prompt is what actually steers the model away from tools.
+            if disable_tool_calls and not is_anthropic:
                 bind_kwargs["tool_choice"] = "none"
             return model.bind_tools(langchain_tools, **bind_kwargs)
         return model

--- a/llm-service/tests/test_langchain_provider.py
+++ b/llm-service/tests/test_langchain_provider.py
@@ -1510,6 +1510,63 @@ class TestLangChainPromptCacheBreakpoints:
         assert captured["bind_tools_kwargs"]["tool_choice"] == "none"
 
     @patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"})
+    def test_disable_tool_calls_leaves_anthropic_tool_choice_unset(self, provider):
+        """Anthropic has no 'none' tool_choice; langchain_anthropic/vertexai treat any
+        non-any/auto string as a forced tool name, which 400s once thinking is enabled
+        ("Thinking may not be enabled when tool_choice forces tool use."). Forced
+        conclusion must not set tool_choice at all for Claude models.
+        """
+        captured = {}
+
+        class FakeChatAnthropic:
+            def __init__(self, **kwargs):
+                captured["ctor"] = kwargs
+
+            def bind_tools(self, tools, **kwargs):
+                captured["bind_tools_kwargs"] = kwargs
+                return self
+
+        with patch("langchain_anthropic.ChatAnthropic", FakeChatAnthropic):
+            config = pb.LLMConfig(
+                provider="anthropic", model="claude-sonnet-4-5",
+                api_key_env="ANTHROPIC_API_KEY",
+            )
+            provider._get_or_create_model(
+                config, _sample_tools(), prompt_cache.ANTHROPIC, False, "exec-99",
+                disable_tool_calls=True,
+            )
+
+        assert "tool_choice" not in captured["bind_tools_kwargs"]
+
+    def test_disable_tool_calls_leaves_vertex_claude_tool_choice_unset(self, provider):
+        captured = {}
+
+        class FakeChatAnthropicVertex:
+            def __init__(self, **kwargs):
+                captured["ctor"] = kwargs
+
+            def bind_tools(self, tools, **kwargs):
+                captured["bind_tools_kwargs"] = kwargs
+                return self
+
+        with patch(
+            "langchain_google_vertexai.model_garden.ChatAnthropicVertex",
+            FakeChatAnthropicVertex,
+        ):
+            config = pb.LLMConfig(
+                provider="vertexai",
+                model="claude-sonnet-4-6",
+                project="p",
+                location="us-east5",
+            )
+            provider._get_or_create_model(
+                config, _sample_tools(), prompt_cache.ANTHROPIC, False, "exec-99",
+                disable_tool_calls=True,
+            )
+
+        assert "tool_choice" not in captured["bind_tools_kwargs"]
+
+    @patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"})
     def test_anthropic_max_retries_on_constructor_not_bind(self, provider):
         captured = {}
 


### PR DESCRIPTION
- Skip OpenAI-only tool_choice="none" for Anthropic and Vertex Claude
- Prevents 400 "Thinking may not be enabled when tool_choice forces tool use"
- Add regression tests for direct Anthropic and Vertex Claude bind_tools
- Document Claude forced-conclusion tool_choice behavior in ADR-0026


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with Anthropic and Vertex Claude models when tool calls are disabled.
  * Prevented invalid forced tool-selection settings that could cause errors while thinking is enabled.
  * Other supported providers continue to use their existing tool-call behavior.

* **Documentation**
  * Clarified provider-specific handling of tool selection and text responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->