### PR TITLE
feat(config): default omitted chat agent and enabled

### DIFF
--- a/deploy/config/README.md
+++ b/deploy/config/README.md
@@ -193,8 +193,25 @@ TARSy includes built-in configurations that work out-of-the-box:
 ### Built-in Agents
 
 - **KubernetesAgent** - Kubernetes troubleshooting
-- **ChatAgent** - Follow-up conversations
+- **ChatAgent** - Follow-up conversations (used when `chain.chat.agent` is omitted)
 - **SynthesisAgent** - Synthesizes parallel investigations
+
+### Follow-up chat
+
+Chat is on by default. Omit the `chat:` block entirely, or include it with only the overrides you need (`llm_provider`, `sub_agents`, `mcp_servers`, …).
+
+```yaml
+agent_chains:
+  my-chain:
+    chat:
+      llm_provider: google-default
+      sub_agents: [KubernetesAgent, WebResearcher]
+```
+
+- **`enabled`** — omit or `true` means on; `false` disables chat for that chain
+- **`agent`** — omit to use built-in `ChatAgent`; otherwise any registered agent
+- MCP tools — union of investigation-stage servers unless `chat.mcp_servers` is set
+- **`sub_agents`** — `chat.sub_agents` overrides `chain.sub_agents`. Stage-agent `sub_agents` lists do not apply to chat
 
 ### Built-in MCP Servers
 

--- a/deploy/config/tarsy.yaml.example
+++ b/deploy/config/tarsy.yaml.example
@@ -512,6 +512,8 @@ agents:
   # Follow-up chat can dispatch sub-agents too: set sub_agents under chat: or chain-level
   # sub_agents (see agent_chains). Precedence: chat.sub_agents > chain.sub_agents.
   # Stage-level sub_agents apply to investigation agents only, not to chat resolution.
+  # chain.chat.agent is optional (default: ChatAgent). chain.chat.enabled is optional
+  # (default: true); set enabled: false to disable chat for that chain.
   # ChatAgent:
   #   custom_instructions: |
   #     You are a follow-up chat agent for SRE investigations.
@@ -571,12 +573,12 @@ agent_chains:
     # chain.sub_agents when chat.sub_agents is set; otherwise chain.sub_agents applies.
     # sub_agents:
     #   - name: GeneralWorker
-    chat:
-      enabled: true
-      agent: "ChatAgent"
-      # Optional: override chain sub_agents for chat only
-      # sub_agents:
-      #   - name: GeneralWorker
+    # Follow-up chat is on by default (built-in ChatAgent). Uncomment to override or disable.
+    # chat:
+    #   enabled: false                    # Disable follow-up chat for this chain
+    #   # agent: "ChatAgent"              # Optional (default: built-in ChatAgent)
+    #   # sub_agents:
+    #   #   - name: GeneralWorker
     # Automatic scoring — evaluates session quality after investigation completes.
     # Omit this block entirely to disable scoring for the chain.
     scoring:
@@ -662,8 +664,8 @@ agent_chains:
             llm_backend: "langchain"
             max_iterations: 30
     chat:
-      enabled: true
-      agent: "ChatAgent"
+      # enabled: true                     # Optional (default: true). Set false to disable.
+      # agent: "ChatAgent"                # Optional (default: built-in ChatAgent)
       max_iterations: 20
 
   # ── Chains with sub-agents ───────────────────────────────────

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -378,6 +378,8 @@ See [ADR-0029: Sub-Agent Execution Limits](adr/0029-sub-agent-execution-limits.m
 
 After a session reaches a terminal state (completed, failed, or timed out), engineers can start a chat conversation to ask follow-up questions. The chat agent receives the full investigation timeline as context and has access to the same MCP tools. Responses stream in real-time and appear inline in the conversation timeline.
 
+Chat is on by default: omit the `chat:` block, or omit `enabled` / `agent` on it, to use built-in `ChatAgent`. Set `chat.enabled: false` to disable follow-up chat for that chain.
+
 Chat is a **prompt concern, not a controller concern** -- the same IteratingController and SingleShotController handle both investigation and chat. The `ChatContext` on the execution context triggers chat-specific prompting.
 
 ## Authentication & Access Control
@@ -485,7 +487,8 @@ agent_chains:
         max_iterations: 15
         synthesis_llm_provider: "openai-default"
     chat:
-      enabled: true
+      # enabled/agent optional (defaults: on, ChatAgent)
+      llm_provider: "google-default"
 ```
 
 ## Next Steps

--- a/docs/functional-areas-design.md
+++ b/docs/functional-areas-design.md
@@ -1107,7 +1107,7 @@ graph TB
 - **One Chat per session**: enforced by schema uniqueness on `session_id`
 - **Terminal sessions only**: available for completed/failed/timed_out sessions
 - **One-at-a-time per chat**: new message while processing returns 409 Conflict
-- **Chat enabled check**: `chain.Chat.Enabled` must be true
+- **Chat enabled check**: chat is on unless `chain.chat.enabled` is explicitly `false`. Omitting the `chat:` block, or omitting `enabled` on a `chat:` block, both leave chat on. Omitting `agent` uses built-in `ChatAgent`.
 
 #### Configuration
 
@@ -1115,8 +1115,7 @@ graph TB
 agent_chains:
   kubernetes:
     chat:
-      enabled: true
-      agent: "ChatAgent"
+      # enabled and agent are optional (defaults: on, ChatAgent)
       llm_backend: "google-native"
       llm_provider: "google-default"
       mcp_servers: ["kubernetes-server"]

--- a/pkg/agent/config_resolver_test.go
+++ b/pkg/agent/config_resolver_test.go
@@ -607,6 +607,16 @@ func TestResolveChatAgentConfig(t *testing.T) {
 		assert.Equal(t, "You are a chat agent", resolved.CustomInstructions)
 	})
 
+	t.Run("defaults to ChatAgent when chatCfg.Agent is empty", func(t *testing.T) {
+		chain := &config.ChainConfig{}
+		chatCfg := &config.ChatConfig{LLMProvider: "openai-default"}
+
+		resolved, err := ResolveChatAgentConfig(cfg, chain, chatCfg)
+		require.NoError(t, err)
+		assert.Equal(t, config.AgentNameChat, resolved.AgentName)
+		assert.Equal(t, openaiProvider, resolved.LLMProvider)
+	})
+
 	t.Run("chatCfg agent overrides default", func(t *testing.T) {
 		chain := &config.ChainConfig{}
 		chatCfg := &config.ChatConfig{

--- a/pkg/api/handler_chat.go
+++ b/pkg/api/handler_chat.go
@@ -148,7 +148,7 @@ func isChatAvailable(sessionStatus alertsession.Status, chain *config.ChainConfi
 	}
 
 	// Chat is enabled by default; only disabled if explicitly set to false.
-	if chain.Chat != nil && !chain.Chat.Enabled {
+	if !chain.Chat.IsEnabled() {
 		return "chat is not enabled for this chain"
 	}
 

--- a/pkg/api/handler_chat_test.go
+++ b/pkg/api/handler_chat_test.go
@@ -15,12 +15,15 @@ import (
 
 func TestIsChatAvailable(t *testing.T) {
 	enabledChain := &config.ChainConfig{
-		Chat: &config.ChatConfig{Enabled: true},
+		Chat: &config.ChatConfig{Enabled: config.BoolPtr(true)},
 	}
 	disabledChain := &config.ChainConfig{
-		Chat: &config.ChatConfig{Enabled: false},
+		Chat: &config.ChatConfig{Enabled: config.BoolPtr(false)},
 	}
 	noChatChain := &config.ChainConfig{}
+	omittedEnabledChain := &config.ChainConfig{
+		Chat: &config.ChatConfig{},
+	}
 
 	tests := []struct {
 		name          string
@@ -81,6 +84,12 @@ func TestIsChatAvailable(t *testing.T) {
 			name:          "no chat config in chain (enabled by default)",
 			sessionStatus: alertsession.StatusCompleted,
 			chain:         noChatChain,
+			wantEmpty:     true,
+		},
+		{
+			name:          "chat block with omitted enabled (enabled by default)",
+			sessionStatus: alertsession.StatusCompleted,
+			chain:         omittedEnabledChain,
 			wantEmpty:     true,
 		},
 	}

--- a/pkg/api/system_config.go
+++ b/pkg/api/system_config.go
@@ -752,7 +752,7 @@ func buildChatView(c *config.ChatConfig) *ChatView {
 		return nil
 	}
 	return &ChatView{
-		Enabled:       c.Enabled,
+		Enabled:       c.IsEnabled(),
 		Agent:         c.Agent,
 		LLMBackend:    string(c.LLMBackend),
 		LLMProvider:   c.LLMProvider,

--- a/pkg/api/system_config_test.go
+++ b/pkg/api/system_config_test.go
@@ -497,7 +497,7 @@ func TestSystemConfigHandler(t *testing.T) {
 								},
 							},
 						},
-						Chat: &config.ChatConfig{Enabled: true, Agent: "Worker"},
+						Chat: &config.ChatConfig{Agent: "Worker"},
 					},
 				}),
 				LLMProviderRegistry: config.NewLLMProviderRegistry(map[string]*config.LLMProviderConfig{
@@ -694,7 +694,6 @@ func TestBuildSystemConfigResponse_NamedFallbackLists(t *testing.T) {
 						{Name: "WebResearcher", FallbackList: "empty"},
 					},
 					Chat: &config.ChatConfig{
-						Enabled:      true,
 						FallbackList: "mid",
 						SubAgents: config.SubAgentRefs{
 							{Name: "WebResearcher", LLMProvider: "google-default"},
@@ -923,6 +922,31 @@ func TestBuildOrchestratorView(t *testing.T) {
 	t.Run("nil config yields nil view", func(t *testing.T) {
 		t.Parallel()
 		assert.Nil(t, buildOrchestratorView(nil))
+	})
+}
+
+func TestBuildChatView(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil config yields nil view", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, buildChatView(nil))
+	})
+
+	t.Run("omitted enabled is true and omitted agent stays empty", func(t *testing.T) {
+		t.Parallel()
+		view := buildChatView(&config.ChatConfig{LLMProvider: "google-default"})
+		require.NotNil(t, view)
+		assert.True(t, view.Enabled)
+		assert.Empty(t, view.Agent)
+		assert.Equal(t, "google-default", view.LLMProvider)
+	})
+
+	t.Run("explicit false stays disabled", func(t *testing.T) {
+		t.Parallel()
+		view := buildChatView(&config.ChatConfig{Enabled: config.BoolPtr(false)})
+		require.NotNil(t, view)
+		assert.False(t, view.Enabled)
 	})
 }
 

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -116,6 +116,57 @@ agent_chains:
 	assert.Contains(t, err.Error(), "NonexistentAgent")
 }
 
+func TestInitialize_ChatOmitsEnabledAndAgent(t *testing.T) {
+	configDir := t.TempDir()
+	tarsyYAML := `
+agents:
+  test-agent:
+    mcp_servers: []
+
+agent_chains:
+  omitted-chat:
+    alert_types: ["omitted-chat"]
+    stages:
+      - name: "s1"
+        agents:
+          - name: "test-agent"
+    chat:
+      llm_provider: google-default
+  disabled-chat:
+    alert_types: ["disabled-chat"]
+    stages:
+      - name: "s1"
+        agents:
+          - name: "test-agent"
+    chat:
+      enabled: false
+`
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, "tarsy.yaml"), []byte(tarsyYAML), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, "llm-providers.yaml"), []byte("llm_providers: {}\n"), 0644))
+
+	t.Setenv("GOOGLE_API_KEY", "test-key")
+	t.Setenv("OPENAI_API_KEY", "test-key")
+	t.Setenv("ANTHROPIC_API_KEY", "test-key")
+	t.Setenv("XAI_API_KEY", "test-key")
+	t.Setenv("GOOGLE_CLOUD_PROJECT", "test-project")
+	t.Setenv("GOOGLE_CLOUD_LOCATION", "us-central1")
+
+	cfg, err := Initialize(context.Background(), configDir)
+	require.NoError(t, err)
+
+	omitted, err := cfg.GetChain("omitted-chat")
+	require.NoError(t, err)
+	require.NotNil(t, omitted.Chat)
+	assert.True(t, omitted.Chat.IsEnabled())
+	assert.Empty(t, omitted.Chat.Agent)
+	assert.Equal(t, "google-default", omitted.Chat.LLMProvider)
+
+	disabled, err := cfg.GetChain("disabled-chat")
+	require.NoError(t, err)
+	require.NotNil(t, disabled.Chat)
+	assert.False(t, disabled.Chat.IsEnabled())
+}
+
 func TestLoadTarsyYAML(t *testing.T) {
 	configDir := t.TempDir()
 

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -287,9 +287,11 @@ type SynthesisConfig struct {
 	FallbackList string     `yaml:"fallback_list,omitempty"`
 }
 
-// ChatConfig defines chat agent configuration
+// ChatConfig defines chat agent configuration.
+// Enabled is a *bool: nil means enabled (same as omitting the chat block).
+// Explicit false disables chat. Agent omitted defaults to ChatAgent at resolve/validate time.
 type ChatConfig struct {
-	Enabled       bool         `yaml:"enabled"`
+	Enabled       *bool        `yaml:"enabled,omitempty"`
 	Agent         string       `yaml:"agent,omitempty"`
 	LLMBackend    LLMBackend   `yaml:"llm_backend,omitempty"`
 	LLMProvider   string       `yaml:"llm_provider,omitempty"`
@@ -297,6 +299,14 @@ type ChatConfig struct {
 	MaxIterations *int         `yaml:"max_iterations,omitempty" validate:"omitempty,min=1"`
 	SubAgents     SubAgentRefs `yaml:"sub_agents,omitempty"`
 	FallbackList  string       `yaml:"fallback_list,omitempty"`
+}
+
+// IsEnabled reports whether chat is on. Nil ChatConfig or nil Enabled means enabled.
+func (c *ChatConfig) IsEnabled() bool {
+	if c == nil {
+		return true
+	}
+	return c.Enabled == nil || *c.Enabled
 }
 
 // ScoringConfig defines scoring agent configuration for session quality evaluation

--- a/pkg/config/types_test.go
+++ b/pkg/config/types_test.go
@@ -303,6 +303,37 @@ func TestFallbackProviderEntry_UnmarshalYAML_UnknownKeys(t *testing.T) {
 	}
 }
 
+func TestChatConfig_IsEnabled(t *testing.T) {
+	var nilCfg *ChatConfig
+	assert.True(t, nilCfg.IsEnabled())
+	assert.True(t, (&ChatConfig{}).IsEnabled())
+	assert.True(t, (&ChatConfig{Enabled: BoolPtr(true)}).IsEnabled())
+	assert.False(t, (&ChatConfig{Enabled: BoolPtr(false)}).IsEnabled())
+}
+
+func TestChatConfig_EnabledYAML(t *testing.T) {
+	tests := []struct {
+		name        string
+		yaml        string
+		wantEnabled bool
+		wantAgent   string
+	}{
+		{name: "enabled omitted with agent", yaml: "agent: ChatAgent\n", wantEnabled: true, wantAgent: "ChatAgent"},
+		{name: "empty mapping", yaml: "{}\n", wantEnabled: true},
+		{name: "explicit true", yaml: "enabled: true\n", wantEnabled: true},
+		{name: "explicit false", yaml: "enabled: false\n", wantEnabled: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var c ChatConfig
+			err := yaml.Unmarshal([]byte(tt.yaml), &c)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantEnabled, c.IsEnabled())
+			assert.Equal(t, tt.wantAgent, c.Agent)
+		})
+	}
+}
+
 func TestEmbeddingProviderType_IsValid(t *testing.T) {
 	tests := []struct {
 		provider EmbeddingProviderType

--- a/pkg/config/validator.go
+++ b/pkg/config/validator.go
@@ -442,15 +442,17 @@ func (v *Validator) validateChains() error {
 			}
 		}
 
-		// Validate chat agent if enabled
-		if chain.Chat != nil && chain.Chat.Enabled {
-			// Chat agent is required when chat is enabled
-			if chain.Chat.Agent == "" {
-				return NewValidationError("chain", chainID, "chat.agent", fmt.Errorf("chat.agent required when chat is enabled"))
+		// Validate chat agent if enabled (omitted enabled defaults to on)
+		if chain.Chat != nil && chain.Chat.IsEnabled() {
+			chatAgent := chain.Chat.Agent
+			if chatAgent == "" {
+				chatAgent = AgentNameChat
 			}
 
-			if !v.cfg.AgentRegistry.Has(chain.Chat.Agent) {
-				return NewValidationError("chain", chainID, "chat.agent", fmt.Errorf("agent '%s' not found", chain.Chat.Agent))
+			if !v.cfg.AgentRegistry.Has(chatAgent) {
+				if _, isBuiltin := GetBuiltinConfig().Agents[chatAgent]; !isBuiltin {
+					return NewValidationError("chain", chainID, "chat.agent", fmt.Errorf("agent '%s' not found", chatAgent))
+				}
 			}
 
 			// Validate chat LLM backend if specified

--- a/pkg/config/validator_test.go
+++ b/pkg/config/validator_test.go
@@ -964,7 +964,6 @@ func TestValidateLLMProvidersOnlyReferencedProviders(t *testing.T) {
 						},
 					},
 					Chat: &ChatConfig{
-						Enabled:     true,
 						Agent:       "test-agent",
 						LLMProvider: "chat-provider",
 					},
@@ -1053,8 +1052,7 @@ func TestValidateLLMProvidersOnlyReferencedProviders(t *testing.T) {
 				"test-chain": {
 					AlertTypes: []string{"test"},
 					Chat: &ChatConfig{
-						Enabled: true,
-						Agent:   "ChatAgent",
+						Agent: "ChatAgent",
 						SubAgents: SubAgentRefs{
 							{Name: "Worker", LLMProvider: "chat-sub-provider"},
 						},
@@ -1965,13 +1963,12 @@ func TestValidateChainsEdgeCases(t *testing.T) {
 			errMsg:  "MCP server 'nonexistent-server' not found",
 		},
 		{
-			name: "chain with chat enabled but no chat agent",
+			name: "chain with chat enabled and omitted agent defaults to ChatAgent",
 			chains: map[string]*ChainConfig{
 				"test-chain": {
 					AlertTypes: []string{"test"},
 					Chat: &ChatConfig{
-						Enabled: true,
-						// Agent not specified
+						Enabled: BoolPtr(true),
 					},
 					Stages: []StageConfig{
 						{
@@ -1988,8 +1985,34 @@ func TestValidateChainsEdgeCases(t *testing.T) {
 			servers: map[string]*MCPServerConfig{
 				"test-server": {Transport: TransportConfig{Type: TransportTypeStdio, Command: "test"}},
 			},
-			wantErr: true,
-			errMsg:  "chat.agent required when chat is enabled",
+			wantErr: false,
+		},
+		{
+			name: "chain with chat overrides omitted enabled and agent",
+			chains: map[string]*ChainConfig{
+				"test-chain": {
+					AlertTypes: []string{"test"},
+					Chat: &ChatConfig{
+						LLMProvider: "test-provider",
+					},
+					Stages: []StageConfig{
+						{
+							Name:   "stage1",
+							Agents: []StageAgentConfig{{Name: "test-agent"}},
+						},
+					},
+				},
+			},
+			agents: map[string]*AgentConfig{
+				"test-agent": {MCPServers: []string{"test-server"}},
+			},
+			providers: map[string]*LLMProviderConfig{
+				"test-provider": {Type: LLMProviderTypeOpenAI, Model: "gpt-5"},
+			},
+			servers: map[string]*MCPServerConfig{
+				"test-server": {Transport: TransportConfig{Type: TransportTypeStdio, Command: "test"}},
+			},
+			wantErr: false,
 		},
 		{
 			name: "chain with chat agent not found",
@@ -1997,8 +2020,7 @@ func TestValidateChainsEdgeCases(t *testing.T) {
 				"test-chain": {
 					AlertTypes: []string{"test"},
 					Chat: &ChatConfig{
-						Enabled: true,
-						Agent:   "nonexistent-chat-agent",
+						Agent: "nonexistent-chat-agent",
 					},
 					Stages: []StageConfig{
 						{
@@ -2019,6 +2041,32 @@ func TestValidateChainsEdgeCases(t *testing.T) {
 			errMsg:  "agent 'nonexistent-chat-agent' not found",
 		},
 		{
+			name: "chat disabled skips agent validation",
+			chains: map[string]*ChainConfig{
+				"test-chain": {
+					AlertTypes: []string{"test"},
+					Chat: &ChatConfig{
+						Enabled: BoolPtr(false),
+						Agent:   "nonexistent-chat-agent",
+					},
+					Stages: []StageConfig{
+						{
+							Name:   "stage1",
+							Agents: []StageAgentConfig{{Name: "test-agent"}},
+						},
+					},
+				},
+			},
+			agents: map[string]*AgentConfig{
+				"test-agent": {MCPServers: []string{"test-server"}},
+			},
+			providers: map[string]*LLMProviderConfig{},
+			servers: map[string]*MCPServerConfig{
+				"test-server": {Transport: TransportConfig{Type: TransportTypeStdio, Command: "test"}},
+			},
+			wantErr: false,
+		},
+		{
 			name: "valid chain with all optional fields",
 			chains: map[string]*ChainConfig{
 				"test-chain": {
@@ -2027,8 +2075,7 @@ func TestValidateChainsEdgeCases(t *testing.T) {
 					MaxIterations: &maxIter15,
 					MCPServers:    []string{"test-server"},
 					Chat: &ChatConfig{
-						Enabled: true,
-						Agent:   "chat-agent",
+						Agent: "chat-agent",
 					},
 					Stages: []StageConfig{
 						{
@@ -2086,7 +2133,6 @@ func TestValidateChainsEdgeCases(t *testing.T) {
 				"test-chain": {
 					AlertTypes: []string{"test"},
 					Chat: &ChatConfig{
-						Enabled:     true,
 						Agent:       "test-agent",
 						LLMProvider: "openai-default",
 						LLMBackend:  LLMBackendNativeGemini,
@@ -3897,7 +3943,6 @@ func TestValidateSubAgents(t *testing.T) {
 				"chain1": {
 					AlertTypes: []string{"test"},
 					Chat: &ChatConfig{
-						Enabled:   true,
 						Agent:     "ChatAgent",
 						SubAgents: SubAgentRefs{{Name: "LogAnalyzer"}},
 					},
@@ -3925,7 +3970,6 @@ func TestValidateSubAgents(t *testing.T) {
 				"chain1": {
 					AlertTypes: []string{"test"},
 					Chat: &ChatConfig{
-						Enabled:   true,
 						Agent:     "ChatAgent",
 						SubAgents: SubAgentRefs{{Name: "MissingSub"}},
 					},
@@ -4380,8 +4424,7 @@ func TestCollectReferencedLLMProviders_IncludesFallbackAndSubAgents(t *testing.T
 					{Name: "Worker", LLMProvider: "chain-subagent"},
 				},
 				Chat: &ChatConfig{
-					Enabled: true,
-					Agent:   "TestAgent",
+					Agent: "TestAgent",
 					SubAgents: SubAgentRefs{
 						{Name: "Worker", LLMProvider: "chat-subagent"},
 					},

--- a/pkg/queue/chat_executor_integration_test.go
+++ b/pkg/queue/chat_executor_integration_test.go
@@ -82,7 +82,7 @@ func TestChatExecutor_FirstMessage_ExecutesThroughAgentFramework(t *testing.T) {
 				},
 			},
 		},
-		Chat: &config.ChatConfig{Enabled: true},
+		Chat: &config.ChatConfig{},
 	}
 
 	// Chat LLM response — agent produces a final answer in 1 call
@@ -251,7 +251,7 @@ func TestChatExecutor_MemoryEnabled_RecallToolPresent_NoAutoInjection(t *testing
 				Agents: []config.StageAgentConfig{{Name: "TestAgent"}},
 			},
 		},
-		Chat: &config.ChatConfig{Enabled: true},
+		Chat: &config.ChatConfig{},
 	}
 
 	// Seed a memory so the recall tool would have results.
@@ -378,7 +378,7 @@ func TestChatExecutor_ContextAccumulation(t *testing.T) {
 				},
 			},
 		},
-		Chat: &config.ChatConfig{Enabled: true},
+		Chat: &config.ChatConfig{},
 	}
 
 	// Two chat executions: first builds context, second should see it
@@ -571,7 +571,7 @@ func TestChatExecutor_OneAtATimeEnforcement(t *testing.T) {
 				},
 			},
 		},
-		Chat: &config.ChatConfig{Enabled: true},
+		Chat: &config.ChatConfig{},
 	}
 
 	// LLM that blocks until channel is fed (simulates slow execution)
@@ -685,7 +685,7 @@ func TestChatExecutor_CancellationEndToEnd(t *testing.T) {
 				},
 			},
 		},
-		Chat: &config.ChatConfig{Enabled: true},
+		Chat: &config.ChatConfig{},
 	}
 
 	// LLM that blocks until cancelled
@@ -798,7 +798,7 @@ func TestChatExecutor_AcceptsInProgressSession(t *testing.T) {
 				},
 			},
 		},
-		Chat: &config.ChatConfig{Enabled: true},
+		Chat: &config.ChatConfig{},
 	}
 
 	llm := &mockLLMClient{
@@ -879,7 +879,7 @@ func TestChatExecutor_CancelBySessionID(t *testing.T) {
 				},
 			},
 		},
-		Chat: &config.ChatConfig{Enabled: true},
+		Chat: &config.ChatConfig{},
 	}
 
 	// LLM that blocks
@@ -980,7 +980,6 @@ func TestChatExecutor_ChatSubAgents_DispatchesSubAgent(t *testing.T) {
 			},
 		},
 		Chat: &config.ChatConfig{
-			Enabled:   true,
 			SubAgents: config.SubAgentRefs{{Name: "SubWorker"}},
 		},
 	}

--- a/pkg/services/session_service.go
+++ b/pkg/services/session_service.go
@@ -565,9 +565,7 @@ func (s *SessionService) GetSessionDetail(ctx context.Context, sessionID string)
 	// Compute chat info — enabled by default unless explicitly disabled in chain config.
 	chatEnabled := true
 	if chain, chainErr := s.chainRegistry.Get(session.ChainID); chainErr == nil {
-		if chain.Chat != nil && !chain.Chat.Enabled {
-			chatEnabled = false
-		}
+		chatEnabled = chain.Chat.IsEnabled()
 	}
 	var chatID *string
 	chatMessageCount := 0

--- a/pkg/services/session_service_test.go
+++ b/pkg/services/session_service_test.go
@@ -1096,6 +1096,16 @@ func TestSessionService_GetSessionDetail(t *testing.T) {
 		assert.Equal(t, false, detail.ChatEnabled, "chat should be disabled when chain sets Chat.Enabled=false")
 	})
 
+	t.Run("chat_enabled true when chat block omits enabled", func(t *testing.T) {
+		sessionID := seedDashboardSession(t, client.Client,
+			"chat omitted enabled test", "test-omitted-chat", "chat-omitted-enabled-chain",
+			10, 5, 15, 0)
+
+		detail, err := service.GetSessionDetail(ctx, sessionID)
+		require.NoError(t, err)
+		assert.True(t, detail.ChatEnabled)
+	})
+
 	t.Run("populates fallback metadata in execution overview from timeline events", func(t *testing.T) {
 		now := time.Now()
 		started := now.Add(-10 * time.Second)

--- a/pkg/services/test_helpers_test.go
+++ b/pkg/services/test_helpers_test.go
@@ -46,7 +46,19 @@ func setupTestSessionService(_ *testing.T, client *ent.Client) *SessionService {
 		},
 		"chat-disabled-chain": {
 			AlertTypes: []string{"test-no-chat"},
-			Chat:       &config.ChatConfig{Enabled: false},
+			Chat:       &config.ChatConfig{Enabled: config.BoolPtr(false)},
+			Stages: []config.StageConfig{
+				{
+					Name: "stage1",
+					Agents: []config.StageAgentConfig{
+						{Name: "test-agent"},
+					},
+				},
+			},
+		},
+		"chat-omitted-enabled-chain": {
+			AlertTypes: []string{"test-omitted-chat"},
+			Chat:       &config.ChatConfig{},
 			Stages: []config.StageConfig{
 				{
 					Name: "stage1",


### PR DESCRIPTION
- Treat missing chat.enabled as true so a chat: block with only overrides stays on
- Default missing chat.agent to ChatAgent at validation time, matching scoring
- Keep enabled: false as the only way to disable chat on a chain


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat is enabled by default when the `enabled` setting is omitted.
  * Chat can still be explicitly disabled with `enabled: false`.
  * The built-in ChatAgent is used by default when no chat agent is specified.
  * Configured LLM provider settings continue to apply to the default chat agent.
* **Bug Fixes**
  * Chat availability and session details now consistently reflect default and explicit enablement settings.
  * Disabled chat configurations no longer require agent validation.
* **Documentation**
  * Configuration and architecture guides now describe chat defaults, agent selection, and optional settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->